### PR TITLE
Record mission worktree side effects

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -218,10 +218,11 @@ rg "Phase 1" atris.md                       # Agent generation spec
 - **Entry point:** `bin/atris.js` dispatch for `mission`
 - **Handler:** `commands/mission.js`
 - **Core flows:** `start` creates `.atris/state/missions.jsonl`; `status` renders `atris/status/now.md`; `tick --verify` runs the verifier command and writes a receipt; `run` executes bounded Claude ticks behind a mission lock; `complete`/`stop` close the mission.
+- **Worktree evidence:** receipts include capped git dirty counts/samples and flag unverified dirty work when no verifier exists.
 - **Verifier guard:** `lintMissionVerifier()` catches common shell-substitution mistakes before storing a verifier.
 - **Value:** Turns a broad goal into append-only state plus proof, so `atris` can surface the next concrete mission action.
 
-**Search:** `rg "missionCommand|lintMissionVerifier|runMission|tickMission" commands/mission.js test/mission-verifier.test.js`
+**Search:** `rg "missionCommand|lintMissionVerifier|gitWorktreeSnapshot|worktreeReceipt|runMission|tickMission" commands/mission.js test/mission-verifier.test.js test/mission-worktree-receipt.test.js`
 
 ### Feature: Live Brain Sync (`atris live`)
 

--- a/commands/mission.js
+++ b/commands/mission.js
@@ -510,6 +510,69 @@ function runVerifier(command, root = process.cwd()) {
   };
 }
 
+function gitWorktreeSnapshot(root = process.cwd()) {
+  const inside = spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  if (inside.status !== 0 || String(inside.stdout || '').trim() !== 'true') {
+    return { available: false, reason: 'not-git-worktree' };
+  }
+  const status = spawnSync('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  if (status.status !== 0) {
+    return {
+      available: false,
+      reason: 'git-status-failed',
+      stderr: String(status.stderr || '').slice(-1000),
+    };
+  }
+  const entries = String(status.stdout || '').split(/\r?\n/).filter(Boolean).sort();
+  const digest = crypto.createHash('sha1').update(entries.join('\n')).digest('hex');
+  return {
+    available: true,
+    dirty_count: entries.length,
+    dirty_hash: digest,
+    dirty_sample: entries.slice(0, 25),
+    entries,
+  };
+}
+
+function worktreeReceipt(before, after, { verifier = '' } = {}) {
+  if (!before?.available || !after?.available) {
+    return {
+      available: false,
+      before_reason: before?.reason || null,
+      after_reason: after?.reason || null,
+    };
+  }
+  const beforeSet = new Set(before.entries || []);
+  const afterSet = new Set(after.entries || []);
+  const newDirty = (after.entries || []).filter((entry) => !beforeSet.has(entry));
+  const clearedDirty = (before.entries || []).filter((entry) => !afterSet.has(entry));
+  const changed = before.dirty_hash !== after.dirty_hash;
+  const hasVerifier = !!String(verifier || '').trim();
+  return {
+    available: true,
+    before_dirty_count: before.dirty_count,
+    after_dirty_count: after.dirty_count,
+    changed,
+    unverified_dirty: !hasVerifier && after.dirty_count > 0,
+    unverified_change: !hasVerifier && changed,
+    new_dirty_count: newDirty.length,
+    cleared_dirty_count: clearedDirty.length,
+    dirty_sample_after: after.dirty_sample,
+    new_dirty_sample: newDirty.slice(0, 25),
+    cleared_dirty_sample: clearedDirty.slice(0, 25),
+    before_dirty_hash: before.dirty_hash,
+    after_dirty_hash: after.dirty_hash,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // `atris mission run <id>` — bounded local headless loop. v0.1.
 // Spawns `claude -p --resume <session>` per tick. Honors cadence, active-hours,
@@ -846,6 +909,7 @@ async function runMission(args) {
       lane: mission.lane || 'workspace',
       started_at: stampIso(),
     };
+    const runWorktreeBefore = gitWorktreeSnapshot(cwd);
     const cadence = cadenceOverride || mission.cadence || 'manual';
     let cadenceSeconds = parseCadenceSeconds(cadence);
     // cadence=manual|once: exactly 1 tick unless user explicitly raised --max-ticks
@@ -878,6 +942,7 @@ async function runMission(args) {
 
       const tickIdx = ticks.length + 1;
       const tickStart = stampIso();
+      const tickWorktreeBefore = gitWorktreeSnapshot(cwd);
       let result = { status: 'skipped', reason: 'unknown', tick_index: tickIdx, ran: false, started_at: tickStart };
 
       // Active-hours gate
@@ -960,10 +1025,11 @@ async function runMission(args) {
         verifierResult = runVerifier(frozen.verifier);
         result.verifier_passed = verifierResult.passed;
       }
+      const tickWorktree = worktreeReceipt(tickWorktreeBefore, gitWorktreeSnapshot(cwd), { verifier: frozen.verifier });
 
       // Persist tick to mission state + write structured receipt
       const finishedAt = stampIso();
-      const tickRecord = { ...result, started_at: tickStart, finished_at: finishedAt };
+      const tickRecord = { ...result, started_at: tickStart, finished_at: finishedAt, worktree: tickWorktree };
       ticks.push(tickRecord);
       receiptPath = writeReceipt(mission, {
         kind: 'mission_run_tick',
@@ -971,6 +1037,7 @@ async function runMission(args) {
         frozen,
         verifier_result: verifierResult,
         rate_limit_info: lastRateLimit,
+        worktree: tickWorktree,
       });
 
       const newStatus = (verifierResult?.passed && completeOnPass && !mission.always_on) ? 'complete' :
@@ -1049,6 +1116,7 @@ async function runMission(args) {
       }, cwd, 'mission_run_paused', { reason: pauseReason }).mission;
     }
 
+    const summaryWorktree = worktreeReceipt(runWorktreeBefore, gitWorktreeSnapshot(cwd), { verifier: frozen.verifier });
     const finalReceipt = writeReceipt(mission, {
       kind: 'mission_run_summary',
       frozen,
@@ -1059,10 +1127,11 @@ async function runMission(args) {
       session_id: sessionId,
       pending_session_id: mission.pending_session_id || null,
       elapsed_seconds: (Date.now() - startedAt) / 1000,
+      worktree: summaryWorktree,
     });
 
     printJsonOrText(
-      { ok: true, action: 'mission_run', mission, ran_ticks: ranTicks, tick_count: ticks.length, ticks, pause_reason: pauseReason, session_id: sessionId, summary_receipt: finalReceipt },
+      { ok: true, action: 'mission_run', mission, ran_ticks: ranTicks, tick_count: ticks.length, ticks, pause_reason: pauseReason, session_id: sessionId, summary_receipt: finalReceipt, worktree: summaryWorktree },
       [
         `Ran mission ${mission.id}`,
         `  objective: ${mission.objective}`,
@@ -1118,14 +1187,17 @@ function tickMission(args) {
     // This CLI subcommand records the tick: writes a structured receipt (matching the
     // `mission_run_tick` envelope) and runs the verifier when asked. Always emit a
     // receipt so every tick has its own audit row, not just verifier ticks.
+    const cwd = process.cwd();
     const tickStart = stampIso();
     const lastTickIndex = Number(mission.last_tick_index || 0);
     const tickIdx = lastTickIndex + 1;
+    const tickWorktreeBefore = gitWorktreeSnapshot(cwd);
 
     let verifierResult = null;
     if (verify && mission.verifier) {
       verifierResult = runVerifier(mission.verifier);
     }
+    const tickWorktree = worktreeReceipt(tickWorktreeBefore, gitWorktreeSnapshot(cwd), { verifier: mission.verifier });
 
     const tickRecord = {
       status: 'ran',
@@ -1137,6 +1209,7 @@ function tickMission(args) {
       summary: summary || null,
       verifier_passed: verifierResult ? !!verifierResult.passed : null,
       finished_at: stampIso(),
+      worktree: tickWorktree,
     };
     const receiptPath = writeReceipt(mission, {
       kind: 'mission_tick',
@@ -1148,6 +1221,7 @@ function tickMission(args) {
       },
       verifier_result: verifierResult,
       rate_limit_info: null,
+      worktree: tickWorktree,
     });
 
     let status = 'running';
@@ -1171,7 +1245,7 @@ function tickMission(args) {
       verifier_result: verifierResult || mission.verifier_result || null,
       next_action: nextAction,
     };
-    const { mission: saved } = saveMission(nextMission, process.cwd(), 'mission_tick', {
+    const { mission: saved } = saveMission(nextMission, cwd, 'mission_tick', {
       tick_index: tickIdx, verify, verifier_result: verifierResult, receipt_path: receiptPath,
     });
     const logPath = appendMemberLog(saved.owner, 'Mission tick', {

--- a/test/mission-worktree-receipt.test.js
+++ b/test/mission-worktree-receipt.test.js
@@ -1,0 +1,108 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-mission-worktree-test-'));
+}
+
+function cleanupTempDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function runCli(args, { cwd } = {}) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+    },
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function runGit(args, cwd) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', timeout: 15000 });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result;
+}
+
+function initGitRepo(dir) {
+  runGit(['init'], dir);
+  runGit(['config', 'user.email', 'test@example.com'], dir);
+  runGit(['config', 'user.name', 'Test User'], dir);
+}
+
+function commitAll(dir, message) {
+  runGit(['add', '.'], dir);
+  runGit(['commit', '-m', message], dir);
+}
+
+function startMission(dir, title, extraArgs = []) {
+  const res = runCli(['mission', 'start', title, '--owner', 'mission-lead', '--json', ...extraArgs], { cwd: dir });
+  assert.equal(res.status, 0, res.stderr || res.stdout);
+  return JSON.parse(res.stdout).mission;
+}
+
+function readReceipt(dir, relPath) {
+  return JSON.parse(fs.readFileSync(path.join(dir, relPath), 'utf8'));
+}
+
+test('mission tick receipt surfaces dirty worktree when no verifier exists', () => {
+  const dir = makeTempDir();
+  try {
+    initGitRepo(dir);
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const mission = startMission(dir, 'dirty no verifier mission');
+    commitAll(dir, 'baseline');
+
+    fs.writeFileSync(path.join(dir, 'outside.txt'), 'dirty\n');
+    const tick = runCli(['mission', 'tick', mission.id, '--json'], { cwd: dir });
+    assert.equal(tick.status, 0, tick.stderr || tick.stdout);
+    const payload = JSON.parse(tick.stdout);
+    const receipt = readReceipt(dir, payload.receipt_path);
+
+    assert.equal(payload.tick.worktree.available, true);
+    assert.equal(payload.tick.worktree.unverified_dirty, true);
+    assert(payload.tick.worktree.after_dirty_count > 0);
+    assert(payload.tick.worktree.dirty_sample_after.some((entry) => entry.includes('outside.txt')));
+    assert.equal(receipt.result.worktree.unverified_dirty, true);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run receipt records verifier worktree deltas', () => {
+  const dir = makeTempDir();
+  try {
+    initGitRepo(dir);
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const verifier = `${process.execPath} -e "require('fs').writeFileSync('verifier-output.txt','ok\\\\n')"`;
+    const mission = startMission(dir, 'verifier writes proof file', ['--verify', verifier]);
+    commitAll(dir, 'baseline');
+
+    const run = runCli(['mission', 'run', mission.id, '--no-claude', '--max-ticks', '1', '--json'], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const payload = JSON.parse(run.stdout);
+    const tickWorktree = payload.ticks[0].worktree;
+    const receipt = readReceipt(dir, payload.mission.receipt_path);
+
+    assert.equal(payload.mission.status, 'ready');
+    assert.equal(tickWorktree.available, true);
+    assert.equal(tickWorktree.changed, true);
+    assert.equal(tickWorktree.unverified_change, false);
+    assert(tickWorktree.new_dirty_sample.some((entry) => entry.includes('verifier-output.txt')));
+    assert.equal(receipt.result.worktree.changed, true);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});


### PR DESCRIPTION
## Summary
- add git worktree before/after snapshots to mission tick/run receipts
- flag unverified dirty work when a mission has no verifier
- document the receipt behavior in MAP

## Verification
- node --test test/mission-worktree-receipt.test.js test/mission-verifier.test.js test/mission-status.test.js
- npm test (382/382 passing)