### PR TITLE
Warn upgrade on dirty install checkout

### DIFF
--- a/bin/atris.js
+++ b/bin/atris.js
@@ -26,7 +26,13 @@ try {
 }
 
 // Update check utility
-const { checkForUpdates, showUpdateNotification, autoUpdate } = require('../utils/update-check');
+const {
+  checkForUpdates,
+  showUpdateNotification,
+  autoUpdate,
+  inspectInstallGitState,
+  formatInstallGitWarning,
+} = require('../utils/update-check');
 
 // State detection for smart default
 const { detectWorkspaceState, loadContext } = require('../lib/state-detection');
@@ -1386,6 +1392,11 @@ async function upgradeAtris() {
   console.log('');
   console.log(`Current version: ${CLI_VERSION}`);
   console.log('');
+  const installWarning = formatInstallGitWarning(inspectInstallGitState(path.join(__dirname, '..')));
+  if (installWarning) {
+    console.log(installWarning);
+    console.log('');
+  }
   console.log('Checking for updates...');
 
   // Force check npm for latest version

--- a/test/update-check-install-state.test.js
+++ b/test/update-check-install-state.test.js
@@ -1,0 +1,77 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  inspectInstallGitState,
+  formatInstallGitWarning,
+} = require('../utils/update-check');
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-update-check-'));
+}
+
+function cleanupTempDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function git(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result;
+}
+
+test('install git state is quiet outside git repos', () => {
+  const dir = makeTempDir();
+  try {
+    const state = inspectInstallGitState(dir);
+    assert.equal(state.isGitRepo, false);
+    assert.equal(formatInstallGitWarning(state), null);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('install git state warns on dirty install checkout', () => {
+  const dir = makeTempDir();
+  try {
+    git(dir, ['init']);
+    fs.writeFileSync(path.join(dir, 'local-overlay.txt'), 'dirty\n');
+
+    const state = inspectInstallGitState(dir);
+    assert.equal(state.isGitRepo, true);
+    assert.equal(state.dirty, true);
+    assert.equal(state.dirtyCount, 1);
+
+    const warning = formatInstallGitWarning(state);
+    assert.match(warning, /dirty worktree \(1 file\)/);
+    assert.match(warning, /npm update may not change the code currently on PATH/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('install git state warns on detached install checkout', () => {
+  const dir = makeTempDir();
+  try {
+    git(dir, ['init']);
+    git(dir, ['config', 'user.email', 'test@example.com']);
+    git(dir, ['config', 'user.name', 'Atris Test']);
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"atris"}\n');
+    git(dir, ['add', 'package.json']);
+    git(dir, ['commit', '-m', 'seed']);
+    git(dir, ['checkout', '--detach', 'HEAD']);
+
+    const state = inspectInstallGitState(dir);
+    assert.equal(state.isGitRepo, true);
+    assert.equal(state.detached, true);
+
+    const warning = formatInstallGitWarning(state);
+    assert.match(warning, /detached HEAD/);
+    assert.match(warning, /npm update may not change the code currently on PATH/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});

--- a/utils/update-check.js
+++ b/utils/update-check.js
@@ -2,6 +2,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { spawnSync } = require('child_process');
 
 const PACKAGE_NAME = 'atris';
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
@@ -191,6 +192,54 @@ function showUpdateNotification(updateInfo) {
   console.log(`${yellow}Update available: ${updateInfo.installed} → ${updateInfo.latest}. Run: npm install -g atris${reset}`);
 }
 
+function inspectInstallGitState(packageRoot = path.join(__dirname, '..')) {
+  const root = path.resolve(packageRoot);
+  const inRepo = spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (inRepo.status !== 0 || inRepo.stdout.trim() !== 'true') {
+    return { isGitRepo: false, root };
+  }
+
+  const branchResult = spawnSync('git', ['branch', '--show-current'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  const statusResult = spawnSync('git', ['status', '--porcelain'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  const headResult = spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  const branch = branchResult.status === 0 ? branchResult.stdout.trim() : '';
+  const dirtyEntries = statusResult.status === 0
+    ? statusResult.stdout.split('\n').filter((line) => line.trim())
+    : [];
+
+  return {
+    isGitRepo: true,
+    root,
+    branch,
+    detached: branch === '',
+    dirty: dirtyEntries.length > 0,
+    dirtyCount: dirtyEntries.length,
+    dirtySample: dirtyEntries.slice(0, 5),
+    head: headResult.status === 0 ? headResult.stdout.trim() : '',
+  };
+}
+
+function formatInstallGitWarning(state) {
+  if (!state || !state.isGitRepo || (!state.detached && !state.dirty)) return null;
+  const flags = [];
+  if (state.detached) flags.push(`detached HEAD${state.head ? ` ${state.head}` : ''}`);
+  if (state.dirty) flags.push(`dirty worktree (${state.dirtyCount} file${state.dirtyCount === 1 ? '' : 's'})`);
+  return `WARNING: Atris is running from a ${flags.join(' + ')} at ${state.root}.\n` +
+    'npm update may not change the code currently on PATH; resolve that checkout before trusting upgrade status.';
+}
+
 function autoUpdate(updateInfo) {
   if (!updateInfo || !updateInfo.needsUpdate) return false;
 
@@ -227,5 +276,6 @@ module.exports = {
   checkForUpdates,
   showUpdateNotification,
   autoUpdate,
+  inspectInstallGitState,
+  formatInstallGitWarning,
 };
-


### PR DESCRIPTION
## Summary
- detect when the running Atris CLI package root is a git checkout
- warn during `atris upgrade` if that checkout is detached or dirty
- add focused tests for non-git, dirty, and detached install states

## Verification
- node --test test/update-check-install-state.test.js
- node --test test/update-check-install-state.test.js test/mission-worktree-receipt.test.js test/mission-verifier.test.js test/mission-status.test.js