### PR TITLE
Warn when missions start without verifier

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -401,9 +401,18 @@ function missionFromArgs(args) {
   return mission;
 }
 
+function missingVerifierWarning(mission) {
+  if (String(mission.verifier || '').trim()) return null;
+  return {
+    code: 'missing_verifier',
+    message: 'Mission has no verifier; it cannot complete automatically and future runs will report unverified worktree side effects.',
+  };
+}
+
 function startMission(args) {
   const asJson = wantsJson(args);
   const mission = missionFromArgs(args);
+  const warnings = [missingVerifierWarning(mission)].filter(Boolean);
   ensureMemberMissionFile(mission.owner, process.cwd(), mission.objective);
   const { mission: saved } = saveMission(mission, process.cwd(), 'mission_started', { objective: mission.objective });
   const memberState = renderMemberMissionState(saved.owner);
@@ -415,11 +424,12 @@ function startMission(args) {
     verifier: saved.verifier,
   });
   printJsonOrText(
-    { ok: true, action: 'mission_started', mission: saved, state_path: statePaths().missionsJsonl, member_state: memberState, log_path: logPath },
+    { ok: true, action: 'mission_started', mission: saved, warnings, state_path: statePaths().missionsJsonl, member_state: memberState, log_path: logPath },
     [
       `Started mission: ${saved.objective}`,
       `Owner: ${saved.owner}`,
       `State: ${saved.status}`,
+      ...warnings.map((warning) => `Warning: ${warning.message}`),
       `Next: atris mission tick ${saved.id}`,
     ],
     asJson,

--- a/test/mission-verifier.test.js
+++ b/test/mission-verifier.test.js
@@ -77,3 +77,27 @@ test('mission start preserves dynamic verifier when quoted by caller', () => {
     cleanupTempDir(dir);
   }
 });
+
+test('mission start warns when no verifier is attached', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const res = runCli([
+      'mission',
+      'start',
+      'unverified mission',
+      '--owner',
+      'mission-lead',
+      '--json',
+    ], { cwd: dir });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.mission.verifier, '');
+    assert.equal(payload.warnings.length, 1);
+    assert.equal(payload.warnings[0].code, 'missing_verifier');
+    assert.match(payload.warnings[0].message, /cannot complete automatically/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});


### PR DESCRIPTION
## Summary
- add a non-blocking `missing_verifier` warning to `atris mission start` JSON output
- show the same warning in text output
- cover no-verifier start behavior in mission verifier tests

## Verification
- node --test test/mission-verifier.test.js test/mission-worktree-receipt.test.js test/mission-status.test.js test/update-check-install-state.test.js