### PR TITLE
[codex] Add member worktree command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,17 @@ BUILD → atris do     (execute tasks)
 CHECK → atris review (verify + cleanup)
 ```
 
+## Parallel Member Worktrees
+
+When multiple members or agents may touch a repo, start in an isolated checkout:
+
+```bash
+atris worktree start --member <member> --task "<short task>" --claim
+cd <printed path>
+```
+
+This ties member identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
+
 ## Rules
 
 - [ ] 3-4 sentences max per response

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,15 @@ CHECK → atris review (verify + cleanup)
 
 ## Parallel Member Worktrees
 
-When multiple members or agents may touch a repo, start in an isolated checkout:
+When multiple members, Codex/Claude subagents, or other agents may touch a repo, start in an isolated checkout:
 
 ```bash
 atris worktree start --member <member> --task "<short task>" --claim
+atris worktree start --agent <subagent> --task "<short task>"
 cd <printed path>
 ```
 
-This ties member identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
+This ties member/agent identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,17 @@ These are anti-patterns. Don't do them:
 
 **Next step:** Read `atris/PERSONA.md` and adopt that mindset. Then run `atris activate` to load context. You're ready to work.
 
+## Parallel Member Worktrees
+
+When multiple members or agents may touch a repo, start in an isolated checkout:
+
+```bash
+atris worktree start --member <member> --task "<short task>" --claim
+cd <printed path>
+```
+
+This ties member identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
+
 <!-- ATRIS_BRAIN_COMPILE:START -->
 ## Atris Brain Compile
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,14 +426,15 @@ These are anti-patterns. Don't do them:
 
 ## Parallel Member Worktrees
 
-When multiple members or agents may touch a repo, start in an isolated checkout:
+When multiple members, Codex/Claude subagents, or other agents may touch a repo, start in an isolated checkout:
 
 ```bash
 atris worktree start --member <member> --task "<short task>" --claim
+atris worktree start --agent <subagent> --task "<short task>"
 cd <printed path>
 ```
 
-This ties member identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
+This ties member/agent identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
 
 <!-- ATRIS_BRAIN_COMPILE:START -->
 ## Atris Brain Compile

--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -57,6 +57,7 @@ rg "alignAtris" commands/align.js           # Business workspace alignment
 rg "businessCommand|createCanonicalBusinessWorkspace" commands/business.js  # Business workspace flows
 rg "computerLocal|buildComputerCard|computerCard|resolveBusinessContext|ensureBusinessAwake" commands/computer.js  # AI computer local/cloud/card
 rg "cmdAdd|cmdImport|cmdClaim|cmdDone|getTaskDb" commands/task.js  # Local agent task plane
+rg "worktreeCommand|startWorktree|parseWorktrees|swarloClaim" commands/worktree.js  # Member-scoped isolated Git worktrees plus optional Swarlo claim
 rg "missionCommand|lintMissionVerifier|runMission|tickMission" commands/mission.js test/mission-verifier.test.js  # Durable mission start/status/tick/run plus verifier lint
 rg "addTask|claimTask|doneTask|listTasks|workspaceRoot" lib/task-db.js  # SQLite task store
 rg "gmailCommand" commands/integrations.js  # Integration commands
@@ -224,6 +225,17 @@ rg "Phase 1" atris.md                       # Agent generation spec
 - **Value:** Turns a broad goal into append-only state plus proof, so `atris` can surface the next concrete mission action.
 
 **Search:** `rg "missionCommand|lintMissionVerifier|gitWorktreeSnapshot|worktreeReceipt|runMission|tickMission" commands/mission.js test/mission-verifier.test.js test/mission-worktree-receipt.test.js`
+
+### Feature: Member Worktrees (`atris worktree`)
+
+**Purpose:** Keep parallel members/agents out of one dirty checkout by creating member-scoped Git worktrees and branches, with optional Swarlo claim wiring.
+
+- **Entry point:** `bin/atris.js` dispatch for `worktree`
+- **Handler:** `commands/worktree.js`
+- **Core flows:** `start --member <slug> --task "<task>" --claim` creates a sibling `.agent-worktrees/<repo>/...` checkout; `status` lists dirty counts for each worktree; `guard` blocks primary/dirty checkout use unless explicitly allowed; `prune --apply` removes stale missing worktree registrations.
+- **Value:** Ties member identity, branch, isolated filesystem state, staging area, and live Swarlo claim together for multi-agent work.
+
+**Search:** `rg "worktreeCommand|startWorktree|parseWorktrees|swarloClaim" commands/worktree.js test/commands.test.js`
 
 ### Feature: Live Brain Sync (`atris live`)
 

--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -228,12 +228,12 @@ rg "Phase 1" atris.md                       # Agent generation spec
 
 ### Feature: Member Worktrees (`atris worktree`)
 
-**Purpose:** Keep parallel members/agents out of one dirty checkout by creating member-scoped Git worktrees and branches, with optional Swarlo claim wiring.
+**Purpose:** Keep parallel members, subagents, and agents out of one dirty checkout by creating identity-scoped Git worktrees and branches, with optional Swarlo claim wiring.
 
 - **Entry point:** `bin/atris.js` dispatch for `worktree`
 - **Handler:** `commands/worktree.js`
-- **Core flows:** `start --member <slug> --task "<task>" --claim` creates a sibling `.agent-worktrees/<repo>/...` checkout; `status` lists dirty counts for each worktree; `guard` blocks primary/dirty checkout use unless explicitly allowed; `prune --apply` removes stale missing worktree registrations.
-- **Value:** Ties member identity, branch, isolated filesystem state, staging area, and live Swarlo claim together for multi-agent work.
+- **Core flows:** `start --member <slug> --task "<task>" --claim` and `start --agent <slug> --task "<task>"` create sibling `.agent-worktrees/<repo>/...` checkouts; `status` lists dirty counts for each worktree; `guard` blocks primary/dirty checkout use unless explicitly allowed; `prune --apply` removes stale missing worktree registrations.
+- **Value:** Ties member/agent identity, branch, isolated filesystem state, staging area, and live Swarlo claim together for multi-agent work.
 
 **Search:** `rg "worktreeCommand|startWorktree|parseWorktrees|swarloClaim" commands/worktree.js test/commands.test.js`
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -330,6 +330,7 @@ function showHelp() {
   console.log('Optional helpers:');
   console.log('  brainstorm - Explore ideas conversationally before planning');
   console.log('  autopilot  - Guided loop that can clarify TODOs and run plan → do → review');
+  console.log('  worktree   - Member-scoped isolated Git worktrees for parallel agents');
   console.log('  visualize  - Generate a Slack/deck-ready visual from a prompt');
   console.log('');
   console.log('Experiments:');
@@ -522,7 +523,7 @@ const { planAtris: planCmd, doAtris: doCmd, reviewAtris: reviewCmd } = require('
 const knownCommands = ['init', 'log', 'now', 'status', 'analytics', 'visualize', 'brain', 'brainstorm', 'autopilot', 'run', 'plan', 'do', 'review', 'release',
                        'activate', '_activate', 'agent', 'chat', 'console', 'login', 'logout', 'whoami', 'switch', 'use', 'accounts', '_resolve', '_profile-email', '_switch-session', 'shell-init', 'update', 'upgrade', 'version', 'help', 'next', 'atris',
                        'clean', 'verify', 'search', 'skill', 'member', 'app', 'apps', 'learn', 'lesson', 'plugin', 'experiments', 'receipt', 'proof', 'openclaw', 'pull', 'push', 'live', 'align', 'terminal', 'computer', 'diff', 'business', 'sync',
-                       'ingest', 'query', 'lint', 'loop', 'task', 'mission', 'aeo',
+                       'ingest', 'query', 'lint', 'loop', 'task', 'mission', 'worktree', 'aeo',
                        'gmail', 'calendar', 'twitter', 'slack', 'imessage', 'integrations', 'setup', 'clean-workspace', 'cw',
                        'fork', 'browse', 'publish', 'sleep', 'wake', 'feedback', 'errors', 'wiki', 'code-review', 'cr', 'soul', 'fleet'];
 
@@ -919,6 +920,10 @@ if (command === 'init') {
 } else if (command === 'mission') {
   Promise.resolve(require('../commands/mission').missionCommand(process.argv.slice(3)))
     .then(() => process.exit(0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'worktree') {
+  Promise.resolve(require('../commands/worktree').worktreeCommand(process.argv.slice(3)))
+    .then((code) => process.exit(code || 0))
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'aeo') {
   // AEO: AI Engine Optimization — credit-metered citation drafting against the customer workspace.

--- a/commands/worktree.js
+++ b/commands/worktree.js
@@ -130,23 +130,25 @@ function printStatus() {
 
 function startWorktree(args) {
   const root = repoRoot();
-  const member = readFlag(args, '--member') || readFlag(args, '--agent');
+  const member = readFlag(args, '--member');
+  const agent = readFlag(args, '--agent');
+  const owner = member || agent;
   const task = readFlag(args, '--task');
-  if (!member || !task) {
-    console.error('Usage: atris worktree start --member <member> --task "<short task>" [--claim]');
+  if (!owner || !task) {
+    console.error('Usage: atris worktree start --member <member>|--agent <name> --task "<short task>" [--claim]');
     return 2;
   }
   const now = new Date();
-  const branch = readFlag(args, '--branch') || branchName(member, task, now);
-  const target = path.resolve(readFlag(args, '--path') || defaultWorktreePath(root, member, task, now));
+  const branch = readFlag(args, '--branch') || branchName(owner, task, now);
+  const target = path.resolve(readFlag(args, '--path') || defaultWorktreePath(root, owner, task, now));
   const base = readFlag(args, '--base') || 'HEAD';
-  const memberFile = path.join(root, 'atris', 'team', member, 'MEMBER.md');
+  const memberFile = member ? path.join(root, 'atris', 'team', member, 'MEMBER.md') : '';
 
   if (fs.existsSync(target)) {
     console.error(`refusing: worktree path already exists: ${target}`);
     return 2;
   }
-  if (!fs.existsSync(memberFile)) {
+  if (memberFile && !fs.existsSync(memberFile)) {
     console.error(`warning: no member persona at ${path.relative(root, memberFile)}`);
   }
   fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -158,11 +160,11 @@ function startWorktree(args) {
   }
   console.log(`path: ${target}`);
   console.log(`branch: ${branch}`);
-  console.log(`member: ${member}`);
+  console.log(`${member ? 'member' : 'agent'}: ${owner}`);
   if (hasFlag(args, '--claim')) {
     const channel = readFlag(args, '--swarlo-channel', 'general');
-    const taskKey = readFlag(args, '--swarlo-task-key') || `${slugify(member, 'member', 24)}-${slugify(task, 'task', 36)}`;
-    const content = readFlag(args, '--swarlo-content') || `${member} owns ${task} in ${target}`;
+    const taskKey = readFlag(args, '--swarlo-task-key') || `${slugify(owner, 'agent', 24)}-${slugify(task, 'task', 36)}`;
+    const content = readFlag(args, '--swarlo-content') || `${owner} owns ${task} in ${target}`;
     console.log(`swarlo_channel: ${channel}`);
     console.log(`swarlo_claim: ${swarloClaim(target, { channel, taskKey, content })}`);
   }
@@ -177,7 +179,7 @@ function guard(args) {
   const primary = worktrees[0]?.path;
   if (path.resolve(root) === path.resolve(primary) && !hasFlag(args, '--allow-primary')) {
     console.error('blocked: this is the primary checkout; create an agent worktree first');
-    console.error('run: atris worktree start --member <member> --task "<short task>" --claim');
+    console.error('run: atris worktree start --member <member>|--agent <name> --task "<short task>" --claim');
     return 2;
   }
   const counts = statusCounts(root);
@@ -201,7 +203,7 @@ function prune(args) {
 function help() {
   console.log('Usage: atris worktree <start|status|guard|prune>');
   console.log('');
-  console.log('  atris worktree start --member <member> --task "<task>" [--claim]');
+  console.log('  atris worktree start --member <member>|--agent <name> --task "<task>" [--claim]');
   console.log('  atris worktree status');
   console.log('  atris worktree guard [--allow-primary] [--allow-dirty]');
   console.log('  atris worktree prune [--apply]');

--- a/commands/worktree.js
+++ b/commands/worktree.js
@@ -1,0 +1,236 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function runGit(args, { cwd = process.cwd(), check = true } = {}) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (check && result.status !== 0) {
+    const msg = (result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim();
+    throw new Error(msg);
+  }
+  return result;
+}
+
+function repoRoot(cwd = process.cwd()) {
+  return runGit(['rev-parse', '--show-toplevel'], { cwd }).stdout.trim();
+}
+
+function slugify(value, fallback = 'task', limit = 48) {
+  const slug = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, limit)
+    .replace(/-+$/g, '');
+  return slug || fallback;
+}
+
+function stamp(now = new Date()) {
+  return now.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, '').replace('T', '-');
+}
+
+function branchName(member, task, now = new Date()) {
+  return `codex/${slugify(member, 'member', 24)}-${slugify(task, 'task', 36)}-${stamp(now)}`;
+}
+
+function defaultWorktreePath(root, member, task, now = new Date()) {
+  const name = `${slugify(member, 'member', 24)}-${slugify(task, 'task', 36)}-${stamp(now)}`;
+  return path.join(path.dirname(root), '.agent-worktrees', path.basename(root), name);
+}
+
+function parseWorktrees(text) {
+  const out = [];
+  let current = {};
+  for (const raw of `${text}\n`.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) {
+      if (current.worktree) {
+        let branch = current.branch || 'detached';
+        branch = branch.replace(/^refs\/heads\//, '');
+        out.push({ path: current.worktree, branch, head: current.HEAD || '' });
+      }
+      current = {};
+      continue;
+    }
+    const idx = line.indexOf(' ');
+    if (idx === -1) {
+      current[line] = true;
+    } else {
+      current[line.slice(0, idx)] = line.slice(idx + 1);
+    }
+  }
+  return out;
+}
+
+function listWorktrees(root = repoRoot()) {
+  return parseWorktrees(runGit(['worktree', 'list', '--porcelain'], { cwd: root }).stdout);
+}
+
+function statusCounts(root) {
+  if (!fs.existsSync(root)) return null;
+  const result = runGit(['status', '--porcelain'], { cwd: root, check: false });
+  if (result.status !== 0) return null;
+  let staged = 0;
+  let unstaged = 0;
+  let untracked = 0;
+  for (const line of result.stdout.split(/\r?\n/).filter(Boolean)) {
+    if (line.startsWith('??')) {
+      untracked += 1;
+      continue;
+    }
+    if (line[0] !== ' ') staged += 1;
+    if (line[1] !== ' ') unstaged += 1;
+  }
+  return { staged, unstaged, untracked };
+}
+
+function readFlag(args, name, fallback = '') {
+  const prefix = `${name}=`;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = String(args[i]);
+    if (arg === name && args[i + 1] && !String(args[i + 1]).startsWith('--')) return String(args[i + 1]);
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return fallback;
+}
+
+function hasFlag(args, name) {
+  return args.includes(name);
+}
+
+function swarloClaim(root, { channel, taskKey, content }) {
+  const script = path.join(root, 'scripts', 'swarlo.py');
+  if (!fs.existsSync(script)) return 'skip: scripts/swarlo.py not found';
+  const result = spawnSync('python3', [script, 'claim', channel, taskKey, content], { cwd: root, encoding: 'utf8' });
+  const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+  if (result.status === 0) return output || `claimed ${taskKey}`;
+  return `skip: swarlo claim failed: ${output || result.status}`;
+}
+
+function printStatus() {
+  const root = repoRoot();
+  const worktrees = listWorktrees(root);
+  const primary = worktrees[0]?.path;
+  for (const wt of worktrees) {
+    const counts = statusCounts(wt.path);
+    const tags = [];
+    if (wt.path === primary) tags.push('primary');
+    if (path.resolve(wt.path) === path.resolve(root)) tags.push('current');
+    const tagText = tags.length ? ` [${tags.join(' ')}]` : '';
+    if (!counts) {
+      console.log(`${wt.path}${tagText} branch=${wt.branch} missing=true`);
+      continue;
+    }
+    console.log(`${wt.path}${tagText} branch=${wt.branch} staged=${counts.staged} unstaged=${counts.unstaged} untracked=${counts.untracked}`);
+  }
+}
+
+function startWorktree(args) {
+  const root = repoRoot();
+  const member = readFlag(args, '--member') || readFlag(args, '--agent');
+  const task = readFlag(args, '--task');
+  if (!member || !task) {
+    console.error('Usage: atris worktree start --member <member> --task "<short task>" [--claim]');
+    return 2;
+  }
+  const now = new Date();
+  const branch = readFlag(args, '--branch') || branchName(member, task, now);
+  const target = path.resolve(readFlag(args, '--path') || defaultWorktreePath(root, member, task, now));
+  const base = readFlag(args, '--base') || 'HEAD';
+  const memberFile = path.join(root, 'atris', 'team', member, 'MEMBER.md');
+
+  if (fs.existsSync(target)) {
+    console.error(`refusing: worktree path already exists: ${target}`);
+    return 2;
+  }
+  if (!fs.existsSync(memberFile)) {
+    console.error(`warning: no member persona at ${path.relative(root, memberFile)}`);
+  }
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  runGit(['worktree', 'add', '-b', branch, target, base], { cwd: root });
+
+  const counts = statusCounts(root);
+  if (counts && (counts.staged || counts.unstaged || counts.untracked)) {
+    console.log(`note: primary checkout is dirty staged=${counts.staged} unstaged=${counts.unstaged} untracked=${counts.untracked}`);
+  }
+  console.log(`path: ${target}`);
+  console.log(`branch: ${branch}`);
+  console.log(`member: ${member}`);
+  if (hasFlag(args, '--claim')) {
+    const channel = readFlag(args, '--swarlo-channel', 'general');
+    const taskKey = readFlag(args, '--swarlo-task-key') || `${slugify(member, 'member', 24)}-${slugify(task, 'task', 36)}`;
+    const content = readFlag(args, '--swarlo-content') || `${member} owns ${task} in ${target}`;
+    console.log(`swarlo_channel: ${channel}`);
+    console.log(`swarlo_claim: ${swarloClaim(target, { channel, taskKey, content })}`);
+  }
+  console.log(`base: ${base}`);
+  console.log(`next: cd ${target}`);
+  return 0;
+}
+
+function guard(args) {
+  const root = repoRoot();
+  const worktrees = listWorktrees(root);
+  const primary = worktrees[0]?.path;
+  if (path.resolve(root) === path.resolve(primary) && !hasFlag(args, '--allow-primary')) {
+    console.error('blocked: this is the primary checkout; create an agent worktree first');
+    console.error('run: atris worktree start --member <member> --task "<short task>" --claim');
+    return 2;
+  }
+  const counts = statusCounts(root);
+  if (counts && (counts.staged || counts.unstaged || counts.untracked) && !hasFlag(args, '--allow-dirty')) {
+    console.error(`blocked: checkout is dirty staged=${counts.staged} unstaged=${counts.unstaged} untracked=${counts.untracked}`);
+    return 3;
+  }
+  console.log('atris worktree guard: ok');
+  return 0;
+}
+
+function prune(args) {
+  const cmd = ['worktree', 'prune', '--verbose'];
+  if (!hasFlag(args, '--apply')) cmd.push('--dry-run');
+  const result = runGit(cmd, { cwd: repoRoot(), check: false });
+  const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+  console.log(output || (hasFlag(args, '--apply') ? 'no stale worktree registrations removed' : 'no stale worktree registrations found'));
+  return result.status || 0;
+}
+
+function help() {
+  console.log('Usage: atris worktree <start|status|guard|prune>');
+  console.log('');
+  console.log('  atris worktree start --member <member> --task "<task>" [--claim]');
+  console.log('  atris worktree status');
+  console.log('  atris worktree guard [--allow-primary] [--allow-dirty]');
+  console.log('  atris worktree prune [--apply]');
+}
+
+function worktreeCommand(args = []) {
+  const sub = args[0] || 'status';
+  const rest = args.slice(1);
+  if (sub === '--help' || sub === '-h' || sub === 'help') {
+    help();
+    return 0;
+  }
+  if (sub === 'start') return startWorktree(rest);
+  if (sub === 'status') {
+    printStatus();
+    return 0;
+  }
+  if (sub === 'guard') return guard(rest);
+  if (sub === 'prune') return prune(rest);
+  help();
+  return 2;
+}
+
+module.exports = {
+  branchName,
+  defaultWorktreePath,
+  parseWorktrees,
+  slugify,
+  statusCounts,
+  swarloClaim,
+  worktreeCommand,
+};

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -181,6 +181,45 @@ test('worktree start creates a member-scoped isolated checkout', () => {
   }
 });
 
+test('worktree start supports generic subagent checkout without a member persona', () => {
+  const dir = makeTempDir();
+  let worktreePath;
+  try {
+    const runGit = (args, cwd = dir) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      return result.stdout.trim();
+    };
+    runGit(['init', '-q']);
+    runGit(['config', 'user.email', 'test@example.com']);
+    runGit(['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(dir, 'README.md'), '# Smoke\n');
+    runGit(['add', '.']);
+    runGit(['commit', '-qm', 'init']);
+
+    worktreePath = path.join(dir, '..', `${path.basename(dir)}-subagent-worktree`);
+    const res = runCli([
+      'worktree',
+      'start',
+      '--agent',
+      'codex-reviewer',
+      '--task',
+      'Smoke Task',
+      '--path',
+      worktreePath,
+    ], { cwd: dir });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /agent: codex-reviewer/);
+    assert.doesNotMatch(res.stderr, /no member persona/);
+    assert.equal(fs.existsSync(path.join(worktreePath, 'README.md')), true);
+    assert.match(runGit(['branch', '--show-current'], worktreePath), /^codex\/codex-reviewer-smoke-task-/);
+  } finally {
+    if (worktreePath) cleanupTempDir(worktreePath);
+    cleanupTempDir(dir);
+  }
+});
+
 test('member create --help prints usage without creating a --help member', () => {
   const dir = makeTempDir();
   try {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 const { buildManifest } = require('../lib/manifest');
+const { branchName, parseWorktrees, slugify, swarloClaim } = require('../commands/worktree');
 const { ensureWikiScaffold, normalizeWikiOnlyPrefix, validateAgentReadableWikiPages } = require('../lib/wiki');
 const {
   analyzeBusinessDoctor,
@@ -102,6 +103,40 @@ test('member create initializes MEMBER.md and dated logs', () => {
     assert.match(log, /Member initialized/);
     assert.match(log, /Trains teammates before autonomy/);
     assert.match(res.stdout, /logs\/\d{4}-\d{2}-\d{2}\.md/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('worktree helpers keep member identity in branch and parse git worktrees', () => {
+  assert.equal(slugify('Security Agent!!'), 'security-agent');
+  assert.equal(
+    branchName('security', 'OAuth timeout hardening', new Date('2026-05-11T08:09:10Z')),
+    'codex/security-oauth-timeout-hardening-20260511-080910'
+  );
+
+  const parsed = parseWorktrees(`
+worktree /repo/main
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo/.agent-worktrees/security
+HEAD def456
+branch refs/heads/codex/security-task
+`);
+  assert.deepEqual(parsed, [
+    { path: '/repo/main', branch: 'main', head: 'abc123' },
+    { path: '/repo/.agent-worktrees/security', branch: 'codex/security-task', head: 'def456' },
+  ]);
+});
+
+test('worktree swarlo claim is best-effort when local bridge is absent', () => {
+  const dir = makeTempDir();
+  try {
+    assert.equal(
+      swarloClaim(dir, { channel: 'general', taskKey: 'security-task', content: 'security owns task' }),
+      'skip: scripts/swarlo.py not found'
+    );
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -142,6 +142,45 @@ test('worktree swarlo claim is best-effort when local bridge is absent', () => {
   }
 });
 
+test('worktree start creates a member-scoped isolated checkout', () => {
+  const dir = makeTempDir();
+  let worktreePath;
+  try {
+    const runGit = (args, cwd = dir) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      return result.stdout.trim();
+    };
+    runGit(['init', '-q']);
+    runGit(['config', 'user.email', 'test@example.com']);
+    runGit(['config', 'user.name', 'Test User']);
+    fs.mkdirSync(path.join(dir, 'atris', 'team', 'security'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'atris', 'team', 'security', 'MEMBER.md'), '# Security\n');
+    runGit(['add', '.']);
+    runGit(['commit', '-qm', 'init']);
+
+    worktreePath = path.join(dir, '..', `${path.basename(dir)}-security-worktree`);
+    const res = runCli([
+      'worktree',
+      'start',
+      '--member',
+      'security',
+      '--task',
+      'Smoke Task',
+      '--path',
+      worktreePath,
+    ], { cwd: dir });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, new RegExp(`path: ${worktreePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+    assert.equal(fs.existsSync(path.join(worktreePath, 'atris', 'team', 'security', 'MEMBER.md')), true);
+    assert.match(runGit(['branch', '--show-current'], worktreePath), /^codex\/security-smoke-task-/);
+  } finally {
+    if (worktreePath) cleanupTempDir(worktreePath);
+    cleanupTempDir(dir);
+  }
+});
+
 test('member create --help prints usage without creating a --help member', () => {
   const dir = makeTempDir();
   try {


### PR DESCRIPTION
## What changed

- Adds `atris worktree` with `start`, `status`, `guard`, and `prune`.
- `start --member <member> --task "<task>" --claim` creates a member-scoped Git worktree/branch and optionally claims the matching Swarlo task.
- Documents the member worktree protocol in `AGENTS.md`, `CLAUDE.md`, and `atris/MAP.md`.

## Why

Parallel Atris members/agents need identity, Swarlo ownership, and Git filesystem isolation to be the same object. This prevents mixed dirty checkouts and accidental staged commits when multiple agents are active.

## Validation

- `node --check commands/worktree.js`
- `node --check bin/atris.js`
- `node --test --test-name-pattern 'worktree' test/commands.test.js`
- `ATRIS_SKIP_UPDATE_CHECK=1 node bin/atris.js worktree --help`
- `ATRIS_SKIP_UPDATE_CHECK=1 node bin/atris.js worktree status`
- `node --test test/cli-smoke.test.js --test-name-pattern 'help|worktree'`
- `git diff --check`
