### PR TITLE
[codex] Add guarded worktree ship flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,10 @@ When multiple members, Codex/Claude subagents, or other agents may touch a repo,
 atris worktree start --member <member> --task "<short task>" --claim
 atris worktree start --agent <subagent> --task "<short task>"
 cd <printed path>
+atris worktree ship --message "<commit summary>" --verify "<test command>" --merge
 ```
 
-This ties member/agent identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
+This ties member/agent identity, branch name, isolated checkout, optional Swarlo claim, verification, push, PR, and merge together. Use `atris worktree status` before broad staging or cleanup.
 
 ## Mission Autonomy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,9 +432,10 @@ When multiple members, Codex/Claude subagents, or other agents may touch a repo,
 atris worktree start --member <member> --task "<short task>" --claim
 atris worktree start --agent <subagent> --task "<short task>"
 cd <printed path>
+atris worktree ship --message "<commit summary>" --verify "<test command>" --merge
 ```
 
-This ties member/agent identity, branch name, isolated checkout, and optional Swarlo claim together. Use `atris worktree status` before broad staging or cleanup.
+This ties member/agent identity, branch name, isolated checkout, optional Swarlo claim, verification, push, PR, and merge together. Use `atris worktree status` before broad staging or cleanup.
 
 ## Mission Autonomy
 

--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -63,7 +63,7 @@ rg "alignAtris" commands/align.js           # Business workspace alignment
 rg "businessCommand|createCanonicalBusinessWorkspace" commands/business.js  # Business workspace flows
 rg "computerLocal|buildComputerCard|computerCard|resolveBusinessContext|ensureBusinessAwake" commands/computer.js  # AI computer local/cloud/card
 rg "cmdAdd|cmdImport|cmdClaim|cmdDone|getTaskDb" commands/task.js  # Local agent task plane
-rg "worktreeCommand|startWorktree|parseWorktrees|swarloClaim" commands/worktree.js  # Member-scoped isolated Git worktrees plus optional Swarlo claim
+rg "worktreeCommand|startWorktree|shipWorktree|parseWorktrees|swarloClaim" commands/worktree.js  # Member-scoped isolated Git worktrees, optional Swarlo claim, and guarded ship flow
 rg "missionCommand|lintMissionVerifier|normalizeMissionState|selectCodexGoalMission|codex_goal.json|runMission|tickMission" commands/mission.js test/mission-verifier.test.js test/mission-status.test.js  # Durable mission start/status/Codex-goal/tick/run plus verifier lint/status filters and terminal next-action normalization
 rg "Codex Goal Replacement|replace_goal|set_goal|codex_goal.json" atris/features/codex-goal-replacement commands/mission.js test/mission-status.test.js  # Contract for Atris mission -> visible Codex /goal replacement
 rg "addTask|claimTask|doneTask|listTasks|workspaceRoot" lib/task-db.js  # SQLite task store
@@ -259,10 +259,10 @@ rg "Phase 1" atris.md                       # Agent generation spec
 
 - **Entry point:** `bin/atris.js` dispatch for `worktree`
 - **Handler:** `commands/worktree.js`
-- **Core flows:** `start --member <slug> --task "<task>" --claim` and `start --agent <slug> --task "<task>"` create sibling `.agent-worktrees/<repo>/...` checkouts; `status` lists dirty counts for each worktree; `guard` blocks primary/dirty checkout use unless explicitly allowed; `prune --apply` removes stale missing worktree registrations.
-- **Value:** Ties member/agent identity, branch, isolated filesystem state, staging area, and live Swarlo claim together for multi-agent work.
+- **Core flows:** `start --member <slug> --task "<task>" --claim` and `start --agent <slug> --task "<task>"` create sibling `.agent-worktrees/<repo>/...` checkouts from the current upstream/default remote base; `ship --message "<commit>" --verify "<cmd>" [--merge]` commits, verifies, merge-checks, pushes, opens a PR, and optionally merges; `status` lists dirty counts for each worktree; `guard` blocks primary/dirty checkout use unless explicitly allowed; `prune --apply` removes stale missing worktree registrations.
+- **Value:** Ties member/agent identity, branch, isolated filesystem state, staging area, live Swarlo claim, verification, push, PR, and merge together for multi-agent work.
 
-**Search:** `rg "worktreeCommand|startWorktree|parseWorktrees|swarloClaim" commands/worktree.js test/commands.test.js`
+**Search:** `rg "worktreeCommand|startWorktree|shipWorktree|parseWorktrees|swarloClaim" commands/worktree.js test/commands.test.js`
 
 ### Feature: Live Brain Sync (`atris live`)
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -352,7 +352,7 @@ function showHelp() {
   console.log('Optional helpers:');
   console.log('  brainstorm - Explore ideas conversationally before planning');
   console.log('  autopilot  - Guided loop that can clarify TODOs and run plan → do → review');
-  console.log('  worktree   - Member-scoped isolated Git worktrees for parallel agents');
+  console.log('  worktree   - Isolated Git worktrees plus guarded ship/merge for parallel agents');
   console.log('  visualize  - Generate a Slack/deck-ready visual from a prompt');
   console.log('');
   console.log('Experiments:');

--- a/commands/worktree.js
+++ b/commands/worktree.js
@@ -13,6 +13,15 @@ function runGit(args, { cwd = process.cwd(), check = true } = {}) {
   return result;
 }
 
+function runCommand(command, { cwd = process.cwd(), check = true } = {}) {
+  const result = spawnSync(command, { cwd, encoding: 'utf8', shell: true, stdio: 'pipe' });
+  if (check && result.status !== 0) {
+    const msg = (result.stderr || result.stdout || `${command} failed`).trim();
+    throw new Error(msg);
+  }
+  return result;
+}
+
 function repoRoot(cwd = process.cwd()) {
   return runGit(['rev-parse', '--show-toplevel'], { cwd }).stdout.trim();
 }
@@ -67,6 +76,78 @@ function parseWorktrees(text) {
 
 function listWorktrees(root = repoRoot()) {
   return parseWorktrees(runGit(['worktree', 'list', '--porcelain'], { cwd: root }).stdout);
+}
+
+function refExists(root, ref) {
+  return runGit(['rev-parse', '--verify', `${ref}^{commit}`], { cwd: root, check: false }).status === 0;
+}
+
+function currentBranch(root = repoRoot()) {
+  return runGit(['branch', '--show-current'], { cwd: root, check: false }).stdout.trim();
+}
+
+function currentUpstream(root) {
+  const result = runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], { cwd: root, check: false });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function remoteHead(root) {
+  const result = runGit(['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'], { cwd: root, check: false });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function normalizeTargetRef(root, target) {
+  const value = String(target || '').trim();
+  if (!value) return '';
+  const remotes = runGit(['remote'], { cwd: root, check: false }).stdout.split(/\r?\n/);
+  const preferRemote =
+    !value.startsWith('origin/') &&
+    !value.startsWith('refs/') &&
+    value !== 'HEAD' &&
+    !/^[0-9a-f]{7,40}$/i.test(value) &&
+    remotes.includes('origin');
+  const remoteRef = value.startsWith('origin/') ? value : `origin/${value}`;
+  if (preferRemote && refExists(root, remoteRef)) return remoteRef;
+  if (preferRemote) return remoteRef;
+  if (refExists(root, value)) return value;
+  if (refExists(root, remoteRef)) return remoteRef;
+  if (value.startsWith('origin/') || remotes.includes('origin')) return remoteRef;
+  return value;
+}
+
+function defaultStartBase(root) {
+  const upstream = currentUpstream(root);
+  if (upstream && refExists(root, upstream)) return upstream;
+  const head = remoteHead(root);
+  if (head && refExists(root, head)) return head;
+  for (const candidate of ['origin/master', 'origin/main']) {
+    if (refExists(root, candidate)) return candidate;
+  }
+  return 'HEAD';
+}
+
+function defaultShipTarget(root) {
+  const branch = currentBranch(root);
+  if (branch) {
+    const configured = runGit(['config', '--get', `branch.${branch}.atris-base`], { cwd: root, check: false }).stdout.trim();
+    if (configured && refExists(root, configured)) return configured;
+  }
+  const head = remoteHead(root);
+  if (head && refExists(root, head)) return head;
+  for (const candidate of ['origin/master', 'origin/main']) {
+    if (refExists(root, candidate)) return candidate;
+  }
+  return 'HEAD';
+}
+
+function refreshRemoteRef(root, ref) {
+  if (!ref.startsWith('origin/')) return;
+  const remoteBranch = ref.slice('origin/'.length);
+  runGit(['fetch', 'origin', remoteBranch], { cwd: root, check: false });
+}
+
+function baseBranchName(ref) {
+  return String(ref || '').replace(/^refs\/heads\//, '').replace(/^origin\//, '');
 }
 
 function statusCounts(root) {
@@ -141,7 +222,7 @@ function startWorktree(args) {
   const now = new Date();
   const branch = readFlag(args, '--branch') || branchName(owner, task, now);
   const target = path.resolve(readFlag(args, '--path') || defaultWorktreePath(root, owner, task, now));
-  const base = readFlag(args, '--base') || 'HEAD';
+  const base = normalizeTargetRef(root, readFlag(args, '--base') || readFlag(args, '--target') || defaultStartBase(root));
   const memberFile = member ? path.join(root, 'atris', 'team', member, 'MEMBER.md') : '';
 
   if (fs.existsSync(target)) {
@@ -152,7 +233,11 @@ function startWorktree(args) {
     console.error(`warning: no member persona at ${path.relative(root, memberFile)}`);
   }
   fs.mkdirSync(path.dirname(target), { recursive: true });
+  refreshRemoteRef(root, base);
   runGit(['worktree', 'add', '-b', branch, target, base], { cwd: root });
+  runGit(['config', `branch.${branch}.atris-base`, base], { cwd: target, check: false });
+  runGit(['config', `branch.${branch}.atris-owner`, owner], { cwd: target, check: false });
+  runGit(['config', `branch.${branch}.atris-task`, task], { cwd: target, check: false });
 
   const counts = statusCounts(root);
   if (counts && (counts.staged || counts.unstaged || counts.untracked)) {
@@ -170,6 +255,119 @@ function startWorktree(args) {
   }
   console.log(`base: ${base}`);
   console.log(`next: cd ${target}`);
+  return 0;
+}
+
+function createOrFindPr(root, branch, targetRef, title, dryRun) {
+  const targetBranch = baseBranchName(targetRef);
+  const existing = spawnSync('gh', ['pr', 'view', '--json', 'number,url', '--jq', '"\\(.number) \\(.url)"'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (existing.status === 0 && existing.stdout.trim()) {
+    return existing.stdout.trim();
+  }
+  const body = [
+    'Automated Atris worktree ship.',
+    '',
+    `Branch: ${branch}`,
+    `Target: ${targetBranch}`,
+  ].join('\n');
+  if (dryRun) return `dry-run: gh pr create --base ${targetBranch} --head ${branch}`;
+  const created = spawnSync(
+    'gh',
+    ['pr', 'create', '--base', targetBranch, '--head', branch, '--title', title, '--body', body],
+    { cwd: root, encoding: 'utf8' }
+  );
+  if (created.status !== 0) {
+    throw new Error((created.stderr || created.stdout || 'gh pr create failed').trim());
+  }
+  return created.stdout.trim();
+}
+
+function shipWorktree(args) {
+  const root = repoRoot();
+  const dryRun = hasFlag(args, '--dry-run');
+  const noPr = hasFlag(args, '--no-pr');
+  const merge = hasFlag(args, '--merge');
+  const message = readFlag(args, '--message') || readFlag(args, '-m');
+  const verify = readFlag(args, '--verify');
+  const branch = currentBranch(root);
+  const worktrees = listWorktrees(root);
+  const primary = worktrees[0]?.path;
+  const targetRef = normalizeTargetRef(root, readFlag(args, '--target') || defaultShipTarget(root));
+
+  if (!branch || branch === 'master' || branch === 'main') {
+    console.error('blocked: ship from a feature worktree branch, not master/main');
+    return 2;
+  }
+  if (path.resolve(root) === path.resolve(primary) && !hasFlag(args, '--allow-primary')) {
+    console.error('blocked: ship from an isolated worktree, not the primary checkout');
+    return 2;
+  }
+
+  refreshRemoteRef(root, targetRef);
+  const counts = statusCounts(root) || { staged: 0, unstaged: 0, untracked: 0 };
+  const dirty = counts.staged || counts.unstaged || counts.untracked;
+  if (dirty && !message) {
+    console.error('blocked: --message is required when there are local changes to commit');
+    return 2;
+  }
+
+  if (dirty) {
+    console.log(`commit: ${message}`);
+    if (!dryRun) {
+      runGit(['add', '-A'], { cwd: root });
+      runGit(['commit', '-m', message], { cwd: root });
+    }
+  } else {
+    console.log('commit: skipped (no local changes)');
+  }
+
+  if (verify) {
+    console.log(`verify: ${verify}`);
+    if (!dryRun) runCommand(verify, { cwd: root });
+    const afterVerify = dryRun ? { staged: 0, unstaged: 0, untracked: 0 } : statusCounts(root) || { staged: 0, unstaged: 0, untracked: 0 };
+    if (!dryRun && (afterVerify.staged || afterVerify.unstaged || afterVerify.untracked)) {
+      console.error(
+        `blocked: verifier left checkout dirty staged=${afterVerify.staged} ` +
+          `unstaged=${afterVerify.unstaged} untracked=${afterVerify.untracked}`
+      );
+      return 3;
+    }
+  } else {
+    console.log('verify: skipped (no --verify)');
+  }
+
+  const mergeCheck = dryRun
+    ? { status: 0, stdout: 'dry-run' }
+    : runGit(['merge-tree', '--write-tree', targetRef, 'HEAD'], { cwd: root, check: false });
+  if (mergeCheck.status !== 0) {
+    console.error(`blocked: branch does not merge cleanly into ${targetRef}`);
+    console.error((mergeCheck.stderr || mergeCheck.stdout || '').trim());
+    return 3;
+  }
+  console.log(`merge_check: ${targetRef} clean`);
+
+  console.log(`push: origin ${branch}`);
+  if (!dryRun) runGit(['push', '-u', 'origin', branch], { cwd: root });
+
+  if (!noPr || merge) {
+    const title = message || branch;
+    const pr = createOrFindPr(root, branch, targetRef, title, dryRun);
+    console.log(`pr: ${pr}`);
+    if (merge) {
+      console.log('merge: requested');
+      if (!dryRun) {
+        const merged = spawnSync('gh', ['pr', 'merge', '--merge', '--delete-branch'], { cwd: root, encoding: 'utf8' });
+        if (merged.status !== 0) throw new Error((merged.stderr || merged.stdout || 'gh pr merge failed').trim());
+      }
+    }
+  } else {
+    console.log('pr: skipped (--no-pr)');
+  }
+
+  console.log('done: worktree shipped');
   return 0;
 }
 
@@ -201,9 +399,10 @@ function prune(args) {
 }
 
 function help() {
-  console.log('Usage: atris worktree <start|status|guard|prune>');
+  console.log('Usage: atris worktree <start|ship|status|guard|prune>');
   console.log('');
   console.log('  atris worktree start --member <member>|--agent <name> --task "<task>" [--claim]');
+  console.log('  atris worktree ship --message "<commit>" --verify "<cmd>" [--merge]');
   console.log('  atris worktree status');
   console.log('  atris worktree guard [--allow-primary] [--allow-dirty]');
   console.log('  atris worktree prune [--apply]');
@@ -217,6 +416,7 @@ function worktreeCommand(args = []) {
     return 0;
   }
   if (sub === 'start') return startWorktree(rest);
+  if (sub === 'ship') return shipWorktree(rest);
   if (sub === 'status') {
     printStatus();
     return 0;
@@ -229,8 +429,11 @@ function worktreeCommand(args = []) {
 
 module.exports = {
   branchName,
+  defaultShipTarget,
+  defaultStartBase,
   defaultWorktreePath,
   parseWorktrees,
+  normalizeTargetRef,
   slugify,
   statusCounts,
   swarloClaim,

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -5,7 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 const { buildManifest } = require('../lib/manifest');
-const { branchName, parseWorktrees, slugify, swarloClaim } = require('../commands/worktree');
+const { branchName, defaultStartBase, normalizeTargetRef, parseWorktrees, slugify, swarloClaim } = require('../commands/worktree');
 const { ensureWikiScaffold, normalizeWikiOnlyPrefix, validateAgentReadableWikiPages } = require('../lib/wiki');
 const { formatLocalDate } = require('../commands/now');
 const {
@@ -215,6 +215,118 @@ test('worktree start supports generic subagent checkout without a member persona
     assert.doesNotMatch(res.stderr, /no member persona/);
     assert.equal(fs.existsSync(path.join(worktreePath, 'README.md')), true);
     assert.match(runGit(['branch', '--show-current'], worktreePath), /^codex\/codex-reviewer-smoke-task-/);
+  } finally {
+    if (worktreePath) cleanupTempDir(worktreePath);
+    cleanupTempDir(dir);
+  }
+});
+
+test('worktree start defaults to upstream remote base and records ship metadata', () => {
+  const dir = makeTempDir();
+  let worktreePath;
+  try {
+    const remote = path.join(dir, 'remote.git');
+    const repo = path.join(dir, 'repo');
+    const runGit = (args, cwd = repo) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      return result.stdout.trim();
+    };
+    fs.mkdirSync(repo);
+    spawnSync('git', ['init', '--bare', '-q', remote], { encoding: 'utf8' });
+    runGit(['init', '-q']);
+    runGit(['config', 'user.email', 'test@example.com']);
+    runGit(['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Smoke\n');
+    runGit(['add', '.']);
+    runGit(['commit', '-qm', 'init']);
+    runGit(['branch', '-M', 'master']);
+    runGit(['remote', 'add', 'origin', remote]);
+    runGit(['push', '-u', 'origin', 'master']);
+    runGit(['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/master']);
+
+    assert.equal(defaultStartBase(repo), 'origin/master');
+    assert.equal(normalizeTargetRef(repo, 'master'), 'origin/master');
+    worktreePath = path.join(dir, 'agent-worktree');
+    const res = runCli([
+      'worktree',
+      'start',
+      '--agent',
+      'codex-shipper',
+      '--task',
+      'Ship Smoke',
+      '--path',
+      worktreePath,
+    ], { cwd: repo });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /base: origin\/master/);
+    const branch = runGit(['branch', '--show-current'], worktreePath);
+    assert.match(branch, /^codex\/codex-shipper-ship-smoke-/);
+    assert.equal(runGit(['config', '--get', `branch.${branch}.atris-base`], worktreePath), 'origin/master');
+  } finally {
+    if (worktreePath) cleanupTempDir(worktreePath);
+    cleanupTempDir(dir);
+  }
+});
+
+test('worktree ship commits verifies and pushes an isolated branch', () => {
+  const dir = makeTempDir();
+  let worktreePath;
+  try {
+    const remote = path.join(dir, 'remote.git');
+    const repo = path.join(dir, 'repo');
+    const runGit = (args, cwd = repo) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      return result.stdout.trim();
+    };
+    fs.mkdirSync(repo);
+    spawnSync('git', ['init', '--bare', '-q', remote], { encoding: 'utf8' });
+    runGit(['init', '-q']);
+    runGit(['config', 'user.email', 'test@example.com']);
+    runGit(['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Smoke\n');
+    runGit(['add', '.']);
+    runGit(['commit', '-qm', 'init']);
+    runGit(['branch', '-M', 'master']);
+    runGit(['remote', 'add', 'origin', remote]);
+    runGit(['push', '-u', 'origin', 'master']);
+    runGit(['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/master']);
+
+    worktreePath = path.join(dir, 'ship-worktree');
+    const start = runCli([
+      'worktree',
+      'start',
+      '--agent',
+      'codex-shipper',
+      '--task',
+      'Ship Smoke',
+      '--path',
+      worktreePath,
+    ], { cwd: repo });
+    assert.equal(start.status, 0, start.stderr || start.stdout);
+    fs.appendFileSync(path.join(worktreePath, 'README.md'), 'changed\n');
+
+    const shipped = runCli([
+      'worktree',
+      'ship',
+      '--message',
+      'ship smoke',
+      '--verify',
+      'git status --short',
+      '--no-pr',
+    ], { cwd: worktreePath });
+
+    assert.equal(shipped.status, 0, shipped.stderr || shipped.stdout);
+    assert.match(shipped.stdout, /merge_check: origin\/master clean/);
+    assert.match(shipped.stdout, /pr: skipped \(\-\-no-pr\)/);
+    assert.match(shipped.stdout, /done: worktree shipped/);
+    const branch = runGit(['branch', '--show-current'], worktreePath);
+    assert.match(
+      runGit(['--git-dir', remote, 'show-ref', '--verify', `refs/heads/${branch}`], dir),
+      new RegExp(`refs/heads/${branch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`)
+    );
   } finally {
     if (worktreePath) cleanupTempDir(worktreePath);
     cleanupTempDir(dir);


### PR DESCRIPTION
## What changed
- Makes atris worktree start choose the current upstream/default remote base instead of dirty local HEAD.
- Records branch metadata for the target base.
- Adds atris worktree ship to commit, verify, merge-check, push, open PRs, and optionally merge.
- Adds local git smoke coverage for start and ship.

## Validation
- node --check commands/worktree.js
- node --check bin/atris.js
- node --check test/commands.test.js
- node --test --test-name-pattern 'worktree' test/commands.test.js
- git diff --check