### PR TITLE
[codex] Add worktree agent guide and guard tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,14 @@ CHECK → atris review (verify + cleanup)
 When multiple members, Codex/Claude subagents, or other agents may touch a repo, start in an isolated checkout:
 
 ```bash
+atris worktree guide
 atris worktree start --member <member> --task "<short task>" --claim
 atris worktree start --agent <subagent> --task "<short task>"
 cd <printed path>
 atris worktree ship --message "<commit summary>" --verify "<test command>" --merge
 ```
 
-This ties member/agent identity, branch name, isolated checkout, optional Swarlo claim, verification, push, PR, and merge together. Use `atris worktree status` before broad staging or cleanup.
+This ties member/agent identity, mission/member state, branch name, isolated checkout, optional Swarlo claim, verification, push, PR, and merge together. Use `atris worktree status` before broad staging or cleanup.
 
 ## Mission Autonomy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,13 +429,14 @@ These are anti-patterns. Don't do them:
 When multiple members, Codex/Claude subagents, or other agents may touch a repo, start in an isolated checkout:
 
 ```bash
+atris worktree guide
 atris worktree start --member <member> --task "<short task>" --claim
 atris worktree start --agent <subagent> --task "<short task>"
 cd <printed path>
 atris worktree ship --message "<commit summary>" --verify "<test command>" --merge
 ```
 
-This ties member/agent identity, branch name, isolated checkout, optional Swarlo claim, verification, push, PR, and merge together. Use `atris worktree status` before broad staging or cleanup.
+This ties member/agent identity, mission/member state, branch name, isolated checkout, optional Swarlo claim, verification, push, PR, and merge together. Use `atris worktree status` before broad staging or cleanup.
 
 ## Mission Autonomy
 

--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -259,7 +259,7 @@ rg "Phase 1" atris.md                       # Agent generation spec
 
 - **Entry point:** `bin/atris.js` dispatch for `worktree`
 - **Handler:** `commands/worktree.js`
-- **Core flows:** `start --member <slug> --task "<task>" --claim` and `start --agent <slug> --task "<task>"` create sibling `.agent-worktrees/<repo>/...` checkouts from the current upstream/default remote base; `ship --message "<commit>" --verify "<cmd>" [--merge]` commits, verifies, merge-checks, pushes, opens a PR, and optionally merges; `status` lists dirty counts for each worktree; `guard` blocks primary/dirty checkout use unless explicitly allowed; `prune --apply` removes stale missing worktree registrations.
+- **Core flows:** `guide` prints the agent recipe; `start --member <slug> --task "<task>" --claim` and `start --agent <slug> --task "<task>"` create sibling `.agent-worktrees/<repo>/...` checkouts from the current upstream/default remote base; `ship --message "<commit>" --verify "<cmd>" [--merge]` commits, verifies, merge-checks, pushes, opens a PR, and optionally merges; `status` lists dirty counts for each worktree; `guard` blocks primary/dirty checkout use unless explicitly allowed; `prune --apply` removes stale missing worktree registrations.
 - **Value:** Ties member/agent identity, branch, isolated filesystem state, staging area, live Swarlo claim, verification, push, PR, and merge together for multi-agent work.
 
 **Search:** `rg "worktreeCommand|startWorktree|shipWorktree|parseWorktrees|swarloClaim" commands/worktree.js test/commands.test.js`

--- a/commands/worktree.js
+++ b/commands/worktree.js
@@ -398,9 +398,35 @@ function prune(args) {
   return result.status || 0;
 }
 
-function help() {
-  console.log('Usage: atris worktree <start|ship|status|guard|prune>');
+function guide() {
+  console.log('Atris worktree agent recipe');
   console.log('');
+  console.log('1. Start isolated work:');
+  console.log('   atris worktree start --member <member> --task "<task>" --claim');
+  console.log('   atris worktree start --agent <agent> --task "<task>"');
+  console.log('');
+  console.log('2. Move into the printed path:');
+  console.log('   cd <printed path>');
+  console.log('   atris worktree guard');
+  console.log('');
+  console.log('3. Tie work to mission/member state when relevant:');
+  console.log('   atris mission start "<objective>" --owner <member> --verify "<cmd>"');
+  console.log('   atris member goal-from-mission <member>');
+  console.log('   atris member tick <member>');
+  console.log('   atris mission tick <id> --verify --complete-on-pass');
+  console.log('');
+  console.log('4. Ship only from the isolated worktree:');
+  console.log('   atris worktree ship --message "<commit>" --verify "<cmd>" --merge');
+  console.log('');
+  console.log('Notes: start uses the current upstream/default remote base, not dirty local HEAD.');
+  console.log('Use `atris worktree status` to see all worktrees and dirty counts.');
+  return 0;
+}
+
+function help() {
+  console.log('Usage: atris worktree <guide|start|ship|status|guard|prune>');
+  console.log('');
+  console.log('  atris worktree guide');
   console.log('  atris worktree start --member <member>|--agent <name> --task "<task>" [--claim]');
   console.log('  atris worktree ship --message "<commit>" --verify "<cmd>" [--merge]');
   console.log('  atris worktree status');
@@ -415,6 +441,7 @@ function worktreeCommand(args = []) {
     help();
     return 0;
   }
+  if (sub === 'guide' || sub === 'recipe') return guide();
   if (sub === 'start') return startWorktree(rest);
   if (sub === 'ship') return shipWorktree(rest);
   if (sub === 'status') {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -143,6 +143,20 @@ test('worktree swarlo claim is best-effort when local bridge is absent', () => {
   }
 });
 
+test('worktree guide prints the agent mission ship recipe', () => {
+  const dir = makeTempDir();
+  try {
+    const res = runCli(['worktree', 'guide'], { cwd: dir });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /Atris worktree agent recipe/);
+    assert.match(res.stdout, /atris mission start/);
+    assert.match(res.stdout, /atris member goal-from-mission/);
+    assert.match(res.stdout, /atris worktree ship --message/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('worktree start creates a member-scoped isolated checkout', () => {
   const dir = makeTempDir();
   let worktreePath;
@@ -327,6 +341,78 @@ test('worktree ship commits verifies and pushes an isolated branch', () => {
       runGit(['--git-dir', remote, 'show-ref', '--verify', `refs/heads/${branch}`], dir),
       new RegExp(`refs/heads/${branch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`)
     );
+  } finally {
+    if (worktreePath) cleanupTempDir(worktreePath);
+    cleanupTempDir(dir);
+  }
+});
+
+test('worktree ship blocks from primary checkout', () => {
+  const dir = makeTempDir();
+  try {
+    const runGit = (args, cwd = dir) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      return result.stdout.trim();
+    };
+    runGit(['init', '-q']);
+    runGit(['config', 'user.email', 'test@example.com']);
+    runGit(['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(dir, 'README.md'), '# Smoke\n');
+    runGit(['add', '.']);
+    runGit(['commit', '-qm', 'init']);
+    runGit(['checkout', '-b', 'codex/primary-ship']);
+
+    const res = runCli(['worktree', 'ship', '--message', 'should block', '--dry-run', '--no-pr'], { cwd: dir });
+
+    assert.equal(res.status, 2);
+    assert.match(res.stderr, /blocked: ship from an isolated worktree/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('worktree ship requires a message for dirty isolated checkout', () => {
+  const dir = makeTempDir();
+  let worktreePath;
+  try {
+    const remote = path.join(dir, 'remote.git');
+    const repo = path.join(dir, 'repo');
+    const runGit = (args, cwd = repo) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      return result.stdout.trim();
+    };
+    fs.mkdirSync(repo);
+    spawnSync('git', ['init', '--bare', '-q', remote], { encoding: 'utf8' });
+    runGit(['init', '-q']);
+    runGit(['config', 'user.email', 'test@example.com']);
+    runGit(['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Smoke\n');
+    runGit(['add', '.']);
+    runGit(['commit', '-qm', 'init']);
+    runGit(['branch', '-M', 'master']);
+    runGit(['remote', 'add', 'origin', remote]);
+    runGit(['push', '-u', 'origin', 'master']);
+    runGit(['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/master']);
+
+    worktreePath = path.join(dir, 'message-worktree');
+    assert.equal(runCli([
+      'worktree',
+      'start',
+      '--agent',
+      'codex',
+      '--task',
+      'Message Gate',
+      '--path',
+      worktreePath,
+    ], { cwd: repo }).status, 0);
+    fs.appendFileSync(path.join(worktreePath, 'README.md'), 'changed\n');
+
+    const res = runCli(['worktree', 'ship', '--verify', 'git status --short', '--dry-run', '--no-pr'], { cwd: worktreePath });
+
+    assert.equal(res.status, 2);
+    assert.match(res.stderr, /--message is required/);
   } finally {
     if (worktreePath) cleanupTempDir(worktreePath);
     cleanupTempDir(dir);


### PR DESCRIPTION
## What changed
- Adds Atris worktree agent recipe

1. Start isolated work:
   atris worktree start --member <member> --task "<task>" --claim
   atris worktree start --agent <agent> --task "<task>"

2. Move into the printed path:
   cd <printed path>
   atris worktree guard

3. Tie work to mission/member state when relevant:
   atris mission start "<objective>" --owner <member> --verify "<cmd>"
   atris member goal-from-mission <member>
   atris member tick <member>
   atris mission tick <id> --verify --complete-on-pass

4. Ship only from the isolated worktree:
   atris worktree ship --message "<commit>" --verify "<cmd>" --merge

Notes: start uses the current upstream/default remote base, not dirty local HEAD.
Use `atris worktree status` to see all worktrees and dirty counts. with the worktree -> mission -> member -> ship recipe.
- Updates agent docs/MAP to point agents at the guide.
- Adds focused tests for guide output, primary-checkout ship blocking, and dirty ship message requirements.

## Validation
- node --check commands/worktree.js
- node --check test/commands.test.js
- node --check bin/atris.js
- node --test --test-name-pattern 'worktree' test/commands.test.js
- git diff --check