### PR TITLE
Clarify ax Pro reasoning profile

### DIFF
--- a/ax
+++ b/ax
@@ -62,8 +62,8 @@ function buildRunProfile(options = {}) {
     streaming: true,
     runtime: 'local workspace',
     reasoning: mode === 'pro'
-      ? 'backend resolved; Pro workspace default is medium unless env overrides'
-      : 'backend resolved; Fast workspace default is low unless env overrides'
+      ? 'backend reports run row; Pro workspace tool loop uses API default medium'
+      : 'backend reports run row; Fast workspace tool loop uses provider default'
   };
 }
 

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -240,9 +240,9 @@ test('ax keeps chat context and file-operation proof readable', () => {
     max_turns: 8,
     streaming: true,
     runtime: 'local workspace',
-    reasoning: 'backend resolved; Pro workspace default is medium unless env overrides'
+    reasoning: 'backend reports run row; Pro workspace tool loop uses API default medium'
   });
-  assert.match(ax.formatRunProfile(ax.buildRunProfile({ mode: 'pro', cwd: '/workspace/demo' })), /thinking\s+backend resolved/);
+  assert.match(ax.formatRunProfile(ax.buildRunProfile({ mode: 'pro', cwd: '/workspace/demo' })), /thinking\s+backend reports run row/);
   assert.equal(
     ax.formatSystemInit({
       type: 'system_init',


### PR DESCRIPTION
## Summary
- Update `ax --doctor` reasoning text after live backend smoke showed the Chat Completions tool loop uses the API default rather than a request-level override
- Keep the runtime run row wording intact so real backend metadata remains visible during turns

## Proof
- node --check ax
- node --test test/cli-smoke.test.js -> 28 passed
- ./ax --doctor -> Pro profile says backend run row + API default medium
- git diff --check

Task: CLI-79 follow-up
