### PR TITLE
Keep ax help local

### DIFF
--- a/ax
+++ b/ax
@@ -45,6 +45,26 @@ function formatHeader({ mode = 'pro', cwd = process.cwd(), chat = false } = {}) 
   ].filter(Boolean).join('\n');
 }
 
+function formatUsage() {
+  return [
+    'ax - Atris 2 local coding agent',
+    '',
+    'Usage:',
+    '  ax [--pro|--fast] <message>',
+    '  ax [--pro|--fast] --chat',
+    '  ax [--pro|--fast] --doctor',
+    '',
+    'Modes:',
+    '  --pro   local workspace agent, deeper tool loop',
+    '  --fast  local workspace agent, faster low-latency turns',
+    '',
+    'Examples:',
+    '  ax --pro find the config file and explain it',
+    '  ax --fast what files are here',
+    '  ax --pro --chat',
+  ].join('\n');
+}
+
 function backendUrl() {
   return `http://${BACKEND.host}:${BACKEND.port}${BACKEND.path}`;
 }
@@ -539,10 +559,15 @@ function printBackendHint() {
 
 async function main() {
   const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(formatUsage());
+    return;
+  }
+
   const mode = args.includes('--fast') ? 'fast' : 'pro';
   const doctor = args.includes('--doctor');
   const prompt = args
-    .filter(arg => !['--fast', '--pro', '--chat', '--doctor'].includes(arg))
+    .filter(arg => !['--fast', '--pro', '--chat', '--doctor', '--help', '-h'].includes(arg))
     .join(' ')
     .trim();
 
@@ -589,6 +614,7 @@ module.exports = {
   formatRunProfile,
   formatStatusMessage,
   formatSystemInit,
+  formatUsage,
   formatWorkingLine,
   handleEvent,
   modelForMode,

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -206,6 +206,23 @@ test('ax is a self-contained Atris2 Pro workspace agent script', () => {
   assert.ok(pkg.files.includes('ax'), 'published package must include the ax entrypoint');
 });
 
+test('ax help stays local and does not start an agent turn', () => {
+  const res = spawnSync(process.execPath, [path.join(repoRoot, 'ax'), '--help'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+    },
+  });
+
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /ax - Atris 2 local coding agent/);
+  assert.match(res.stdout, /ax \[--pro\|--fast\] <message>/);
+  assert.doesNotMatch(res.stdout, /run\s+local workspace/);
+  assert.doesNotMatch(res.stdout, /Worked for/);
+});
+
 test('ax keeps chat context and file-operation proof readable', () => {
   const ax = require('../ax');
   const payload = ax.buildPayload('edit config', {


### PR DESCRIPTION
## Summary
- add local ax usage output for --help/-h
- intercept help before prompt construction so it never starts an agent turn
- add CLI smoke coverage proving help stays local

## Tests
- node --check ax
- node --test test/cli-smoke.test.js
- git diff --check