### PR TITLE
Give ax fast enough turns to verify small edits

### DIFF
--- a/ax
+++ b/ax
@@ -346,7 +346,7 @@ function buildPayload(message, options = {}) {
     message: buildMessage(message, options.history || []),
     workspace_path: options.cwd || process.cwd(),
     model: modelForMode(mode),
-    max_turns: mode === 'pro' ? 8 : 4,
+    max_turns: mode === 'pro' ? 8 : 6,
     verify_command: 'true'
   };
 }

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -197,7 +197,7 @@ test('ax is a self-contained Atris2 Pro workspace agent script', () => {
   assert.match(ax, /function modelForMode/);
   assert.match(ax, /function buildRunProfile/);
   assert.match(ax, /function formatSystemInit/);
-  assert.match(ax, /max_turns:\s*mode === 'pro' \? 8 : 4/);
+  assert.match(ax, /max_turns:\s*mode === 'pro' \? 8 : 6/);
   assert.match(ax, /Accept:\s*'text\/event-stream'/);
   assert.match(ax, /async function chat/);
   assert.doesNotMatch(ax, /\/api\/agent-sdk\/fast/);
@@ -237,6 +237,7 @@ test('ax keeps chat context and file-operation proof readable', () => {
   assert.equal(payload.workspace_path, '/workspace/demo');
   assert.equal(payload.model, 'atris:pro');
   assert.equal(payload.max_turns, 8);
+  assert.equal(ax.buildPayload('quick edit', { cwd: '/workspace/demo', mode: 'fast' }).max_turns, 6);
   assert.match(payload.message, /Recent conversation/);
   assert.equal(ax.modelForMode('pro'), 'atris:pro');
   assert.equal(ax.modelForMode('fast'), 'atris:fast');


### PR DESCRIPTION
## Summary
- raise ax Fast max_turns from 4 to 6 so tiny edit/test loops can rerun verification
- keep Pro at 8 turns and simple Fast behavior unchanged
- add smoke coverage for the Fast turn budget

## Proof
- node --check ax
- node --test test/cli-smoke.test.js
- git diff --check
- live ax --fast disposable edit/test smoke: fixed label.js and reran node test.js -> fast-agentic-smoke-ok