### PR TITLE
Add ax to Atris map

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -29,6 +29,7 @@ For details, read `atris/wiki/concepts/owner-computer-model.md` before changing 
 ```bash
 # Core CLI logic
 rg "async function interactiveEntry|async function atrisDevEntry" bin/atris.js    # Main entry points: cold-start dispatcher + legacy natural-language mode
+rg "modelForMode|buildPayload|formatUsage|async function chat|postTurn" ax test/cli-smoke.test.js  # ax Atris2 local coding-agent CLI: Fast/Pro modes, SSE streaming, workspace_path, chat history, doctor/help
 rg "brainstormAtris|Usage: atris brainstorm|brainstorm help" commands/brainstorm.js test/commands.test.js  # Brainstorm command + workspace-free help
 rg "function planAtris" commands/workflow.js   # Plan command (line 66)
 rg "function doAtris" commands/workflow.js     # Do command (line 394)


### PR DESCRIPTION
## Summary
- add ax to atris/MAP.md quick-reference search patterns
- point future agents to Fast/Pro mode parsing, SSE/chat history, doctor/help, and smoke coverage

## Proof
- git diff --check
- rg confirmed the MAP pointer