### PR TITLE
Give ax pro room for deeper inspections

### DIFF
--- a/ax
+++ b/ax
@@ -346,7 +346,7 @@ function buildPayload(message, options = {}) {
     message: buildMessage(message, options.history || []),
     workspace_path: options.cwd || process.cwd(),
     model: modelForMode(mode),
-    max_turns: mode === 'pro' ? 8 : 6,
+    max_turns: mode === 'pro' ? 14 : 6,
     verify_command: 'true'
   };
 }

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -197,7 +197,7 @@ test('ax is a self-contained Atris2 Pro workspace agent script', () => {
   assert.match(ax, /function modelForMode/);
   assert.match(ax, /function buildRunProfile/);
   assert.match(ax, /function formatSystemInit/);
-  assert.match(ax, /max_turns:\s*mode === 'pro' \? 8 : 6/);
+  assert.match(ax, /max_turns:\s*mode === 'pro' \? 14 : 6/);
   assert.match(ax, /Accept:\s*'text\/event-stream'/);
   assert.match(ax, /async function chat/);
   assert.doesNotMatch(ax, /\/api\/agent-sdk\/fast/);
@@ -236,7 +236,7 @@ test('ax keeps chat context and file-operation proof readable', () => {
 
   assert.equal(payload.workspace_path, '/workspace/demo');
   assert.equal(payload.model, 'atris:pro');
-  assert.equal(payload.max_turns, 8);
+  assert.equal(payload.max_turns, 14);
   assert.equal(ax.buildPayload('quick edit', { cwd: '/workspace/demo', mode: 'fast' }).max_turns, 6);
   assert.match(payload.message, /Recent conversation/);
   assert.equal(ax.modelForMode('pro'), 'atris:pro');
@@ -255,7 +255,7 @@ test('ax keeps chat context and file-operation proof readable', () => {
     mode: 'pro',
     model: 'atris:pro',
     workspace_path: '/workspace/demo',
-    max_turns: 8,
+    max_turns: 14,
     streaming: true,
     runtime: 'local workspace',
     reasoning: 'backend reports run row; Pro workspace tool loop uses API default medium'


### PR DESCRIPTION
## Summary
- raise ax Pro max_turns from 8 to 14 for deeper inspection/review loops
- keep Fast at 6 turns for quick mode and small edit/test loops
- update CLI smoke expectations

## Proof
- node --check ax
- node --test test/cli-smoke.test.js
- git diff --check
- bounded ax --pro self-critique reached deeper inspection; rejected the suggested path-spacing change to preserve the Atris-style file display