### PR TITLE
Fix business wake lifecycle routing

### DIFF
--- a/commands/lifecycle.js
+++ b/commands/lifecycle.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { loadCredentials } = require('../utils/auth');
 const { apiRequestJson } = require('../utils/api');
+const { loadBusinesses, saveBusinesses, businessMatchesSlug } = require('./business');
 
 /**
  * Resolve business slug from CLI arg or local .atris/business.json.
@@ -22,6 +23,69 @@ function resolveSlug() {
   return slug;
 }
 
+async function resolveBusiness(token, slug) {
+  const businesses = loadBusinesses();
+
+  const listResult = await apiRequestJson('/business/', { method: 'GET', token });
+  if (listResult.ok && Array.isArray(listResult.data)) {
+    const match = listResult.data.find((business) =>
+      businessMatchesSlug(business, slug, { includeName: true })
+    );
+    if (match && match.id) {
+      businesses[slug] = {
+        business_id: match.id,
+        workspace_id: match.workspace_id,
+        name: match.name || slug,
+        slug: match.slug || slug,
+        canonical_slug: match.slug || slug,
+        added_at: businesses[slug]?.added_at || new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      saveBusinesses(businesses);
+      return businesses[slug];
+    }
+  }
+
+  const wanted = String(slug || '').toLowerCase();
+  return businesses[slug] || Object.values(businesses).find((entry) =>
+    entry
+      && (
+        String(entry.slug || '').toLowerCase() === wanted
+        || String(entry.canonical_slug || '').toLowerCase() === wanted
+        || String(entry.name || '').toLowerCase() === wanted
+      )
+  ) || null;
+}
+
+async function activateBusinessWorkspace(token, business) {
+  if (!business?.business_id || !business?.workspace_id) return;
+  const result = await apiRequestJson(`/business/${business.business_id}/workspaces/${business.workspace_id}/activate`, {
+    method: 'POST',
+    token,
+    body: {},
+  });
+  if (!result.ok && result.status !== 409) {
+    throw new Error(`Failed to activate business workspace: ${result.errorMessage || result.error || result.status}`);
+  }
+}
+
+async function waitForBusinessComputer(token, business, maxWait = 90000) {
+  const start = Date.now();
+  while (Date.now() - start < maxWait) {
+    await new Promise((r) => setTimeout(r, 3000));
+
+    const status = await apiRequestJson(`/business/${business.business_id}/ai-computer/status`, {
+      method: 'GET',
+      token,
+    });
+
+    if (status.ok && status.data && status.data.status === 'running' && status.data.endpoint) {
+      return status.data;
+    }
+  }
+  return null;
+}
+
 /**
  * Pause a workspace to save compute (storage only mode).
  * @returns {Promise<void>}
@@ -38,6 +102,23 @@ async function sleepAtris() {
 
   const creds = loadCredentials();
   if (!creds || !creds.token) { console.error('Not logged in. Run: atris login'); process.exit(1); }
+
+  const business = await resolveBusiness(creds.token, slug);
+  if (business?.business_id) {
+    const result = await apiRequestJson(`/business/${business.business_id}/ai-computer/sleep`, {
+      method: 'POST',
+      token: creds.token,
+      body: {},
+    });
+
+    if (!result.ok) {
+      console.error(`Failed to sleep business computer: ${result.error || result.errorMessage || result.status}`);
+      process.exit(1);
+    }
+
+    console.log(`Business computer '${business.name || slug}' is now sleeping. Files persist. Wake it with: atris wake ${slug}`);
+    return;
+  }
 
   const result = await apiRequestJson(`/workspace/${slug}/sleep`, {
     method: 'POST',
@@ -69,6 +150,40 @@ async function wakeAtris() {
 
   const creds = loadCredentials();
   if (!creds || !creds.token) { console.error('Not logged in. Run: atris login'); process.exit(1); }
+
+  const business = await resolveBusiness(creds.token, slug);
+  if (business?.business_id) {
+    if (business.workspace_id) {
+      await activateBusinessWorkspace(creds.token, business);
+    }
+
+    const result = await apiRequestJson(`/business/${business.business_id}/ai-computer/wake`, {
+      method: 'POST',
+      token: creds.token,
+      body: {},
+    });
+
+    if (!result.ok) {
+      console.error(`Failed to wake business computer: ${result.error || result.errorMessage || result.status}`);
+      process.exit(1);
+    }
+
+    console.log(`Waking business computer '${business.name || slug}'...`);
+
+    if (result.data && result.data.status === 'running' && result.data.endpoint) {
+      console.log(`Business computer '${business.name || slug}' is alive. Agents resuming.`);
+      return;
+    }
+
+    const running = await waitForBusinessComputer(creds.token, business);
+    if (running) {
+      console.log(`Business computer '${business.name || slug}' is alive. Agents resuming.`);
+      return;
+    }
+
+    console.log('Still starting up. Check with: atris computer status --business ' + slug);
+    return;
+  }
 
   const result = await apiRequestJson(`/workspace/${slug}/wake`, {
     method: 'POST',

--- a/test/computer-create.test.js
+++ b/test/computer-create.test.js
@@ -84,9 +84,18 @@ function startApiServer(requests) {
         });
         return;
       }
+      if (req.method === 'POST' && req.url === '/api/business/biz-1/workspaces/ws-old/activate') {
+        send(200, {
+          status: 'ok',
+          business_id: 'biz-1',
+          workspace_id: 'ws-old',
+          endpoint: 'https://runner.example',
+        });
+        return;
+      }
       if (req.method === 'POST' && req.url === '/api/business/biz-1/ai-computer/wake') {
         send(200, {
-          status: 'awake',
+          status: 'running',
           business_id: 'biz-1',
           endpoint: 'https://runner.example',
         });
@@ -179,6 +188,48 @@ test('computer proof can retry against attached workspace context', () => {
     workspaceId: '51803cee-f153-4ac1-9cd4-eab97fd4aa3a',
   });
   assert.equal(contextForAttachedWorkspaceMismatch(ctx, { fallback: { error: 'other' } }), null);
+});
+
+test('top-level wake and sleep use business computer lifecycle for business slugs', async () => {
+  const home = makeTempDir();
+  const cwd = makeTempDir();
+  const requests = [];
+  const server = await startApiServer(requests);
+  try {
+    writeCredentials(home);
+    const { port } = server.address();
+    const env = {
+      ...process.env,
+      HOME: home,
+      ATRIS_API_URL: `http://127.0.0.1:${port}/api`,
+      ATRIS_NO_INTERACTIVE: '1',
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+    };
+
+    const wake = await runCliAsync(['wake', 'atris-labs'], { cwd, env });
+    assert.equal(wake.status, 0, wake.stderr || wake.stdout);
+    assert.match(wake.stdout, /Business computer 'Atris Labs' is alive/);
+
+    const sleep = await runCliAsync(['sleep', 'atris-labs'], { cwd, env });
+    assert.equal(sleep.status, 0, sleep.stderr || sleep.stdout);
+    assert.match(sleep.stdout, /Business computer 'Atris Labs' is now sleeping/);
+
+    assert.deepEqual(
+      requests.map((request) => [request.method, request.url]),
+      [
+        ['GET', '/api/business/'],
+        ['POST', '/api/business/biz-1/workspaces/ws-old/activate'],
+        ['POST', '/api/business/biz-1/ai-computer/wake'],
+        ['GET', '/api/business/'],
+        ['POST', '/api/business/biz-1/ai-computer/sleep'],
+      ]
+    );
+    assert.ok(!requests.some((request) => request.url.includes('/api/workspace/')));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    cleanupTempDir(home);
+    cleanupTempDir(cwd);
+  }
 });
 
 test('computer create creates workspace, activates it, wakes it, and prints next steps', async () => {


### PR DESCRIPTION
## Summary
- Route top-level `atris wake <business>` and `atris sleep <business>` through the business AI computer lifecycle endpoints when the slug resolves to a business
- Activate the bound workspace before waking the business computer so wake/status/pull use the same workspace contract
- Keep the legacy `/workspace/{slug}` lifecycle route as fallback for non-business workspaces

## Verification
- `node --test test/computer-create.test.js`
- `npm test` (579 tests, 0 failures)
- Local installed CLI: `atris --version` => `atris v3.15.36`
- Runtime smoke: `atris wake atris-labs` => business computer alive
