### PR TITLE
Fix mission goal selection for current Codex missions

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -747,9 +747,17 @@ function secondsUntilMissionDue(mission, now = new Date()) {
   return Math.max(0, Math.ceil((dueAt - now.getTime()) / 1000));
 }
 
+function missionIsRunnable(mission) {
+  return mission && !TERMINAL_STATUSES.has(mission.status) && mission.status !== 'paused';
+}
+
+function missionSortTime(mission) {
+  return Date.parse(mission?.updated_at || mission?.created_at || '') || 0;
+}
+
 function selectDueMission(root = process.cwd(), now = new Date()) {
   const candidates = listMissions(root)
-    .filter((mission) => !TERMINAL_STATUSES.has(mission.status))
+    .filter(missionIsRunnable)
     .filter((mission) => mission.verifier)
     .filter((mission) => mission.always_on || !missionVerifierPassed(mission))
     .filter((mission) => missionDueAt(mission, now));
@@ -763,11 +771,8 @@ function selectDueMission(root = process.cwd(), now = new Date()) {
 }
 
 function selectCodexGoalMission(root = process.cwd(), now = new Date()) {
-  const due = selectDueMission(root, now);
-  if (due) return { mission: due, reason: 'due' };
-
   const candidates = listMissions(root)
-    .filter((mission) => !TERMINAL_STATUSES.has(mission.status));
+    .filter(missionIsRunnable);
 
   candidates.sort((a, b) => {
     const aCaller = runnerUsesCallerSession(a.runner) ? 1 : 0;
@@ -778,14 +783,15 @@ function selectCodexGoalMission(root = process.cwd(), now = new Date()) {
     const bVerifier = b.verifier ? 1 : 0;
     if (aVerifier !== bVerifier) return bVerifier - aVerifier;
 
-    const aTime = Date.parse(a.updated_at || a.created_at || '') || 0;
-    const bTime = Date.parse(b.updated_at || b.created_at || '') || 0;
+    const aTime = missionSortTime(a);
+    const bTime = missionSortTime(b);
     return bTime - aTime;
   });
 
   const mission = candidates[0] || null;
   if (!mission) return null;
-  return { mission, reason: 'active' };
+  const due = mission.verifier && missionDueAt(mission, now);
+  return { mission, reason: due ? 'due' : 'active' };
 }
 
 function codexGoalObjective(mission) {

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -37,6 +37,21 @@ function startMission(dir, title) {
   return JSON.parse(res.stdout).mission;
 }
 
+function appendMissionState(dir, mission) {
+  const stateDir = path.join(dir, '.atris', 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.appendFileSync(path.join(stateDir, 'missions.jsonl'), JSON.stringify({
+    schema: 'atris.mission.v1',
+    owner: 'mission-lead',
+    cadence: 'manual',
+    lane: 'workspace',
+    task_ids: [],
+    human_asks: [],
+    next_action: 'next move',
+    ...mission,
+  }) + '\n', 'utf8');
+}
+
 test('mission status filters by status and limits list output', () => {
   const dir = makeTempDir();
   try {
@@ -276,6 +291,36 @@ test('mission run --due selects an active verifier mission for loop heartbeats',
   }
 });
 
+test('mission run --due skips paused missions', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    appendMissionState(dir, {
+      id: 'paused-due',
+      slug: 'paused-due',
+      objective: 'paused due mission',
+      status: 'paused',
+      verifier: 'true',
+      created_at: '2026-05-01T00:00:00.000Z',
+      updated_at: '2026-05-01T00:00:00.000Z',
+    });
+    appendMissionState(dir, {
+      id: 'runnable-due',
+      slug: 'runnable-due',
+      objective: 'runnable due mission',
+      status: 'running',
+      verifier: 'true',
+      created_at: '2026-05-02T00:00:00.000Z',
+      updated_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const due = selectDueMission(dir);
+    assert.equal(due.id, 'runnable-due');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('mission goal emits the Codex goal candidate from mission state', () => {
   const dir = makeTempDir();
   try {
@@ -326,6 +371,39 @@ test('mission goal emits the Codex goal candidate from mission state', () => {
     assert.equal(state.action, 'codex_goal_candidate');
     assert.equal(state.goal.mission_id, mission.id);
     assert.match(fs.readFileSync(payload.status_path, 'utf8'), /Codex Goal Controller/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission goal prefers the latest caller-session mission over stale due history', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    appendMissionState(dir, {
+      id: 'old-codex-due',
+      slug: 'old-codex-due',
+      objective: 'old codex goal mission',
+      status: 'running',
+      runner: 'codex_goal',
+      verifier: 'true',
+      created_at: '2026-05-01T00:00:00.000Z',
+      updated_at: '2026-05-01T00:00:00.000Z',
+    });
+    appendMissionState(dir, {
+      id: 'current-codex-due',
+      slug: 'current-codex-due',
+      objective: 'current codex goal mission',
+      status: 'blocked',
+      runner: 'codex_goal',
+      verifier: 'true',
+      created_at: '2026-05-02T00:00:00.000Z',
+      updated_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const selected = selectCodexGoalMission(dir);
+    assert.equal(selected.mission.id, 'current-codex-due');
+    assert.equal(selected.reason, 'due');
   } finally {
     cleanupTempDir(dir);
   }


### PR DESCRIPTION
## Summary
- skip paused missions for automatic due selection
- make `atris mission goal` choose the latest runnable caller-session mission instead of inheriting the oldest due queue
- add regressions for paused due missions and stale due Codex goal history

## Verification
- `node --check commands/mission.js`
- `node --test test/mission-status.test.js`
- `node --test --test-name-pattern mission test/commands.test.js test/mission-status.test.js test/mission-xp.test.js test/mission-verifier.test.js`
- `git diff --check`
- Real backend state check: patched CLI selects `mission-2026-05-17-agentxp-contributor-launch-o-465306f7` / BCK-283 from `/Users/keshavrao/arena/atrisos-backend`.

## Note
- Full `npm test` reached 560 passing tests before `test/cli-smoke.test.js` stopped producing output and was interrupted; no mission-selector failures were observed.