### PR TITLE
Release atris 3.15.38 with ax smoke fix

### DIFF
--- a/ax
+++ b/ax
@@ -446,7 +446,14 @@ function resetMarkdownState(state) {
   state.markdownCarry = '';
 }
 
+function ensureMarkdownState(state) {
+  if (!state.markdownMode) state.markdownMode = 'normal';
+  if (typeof state.markdownBuffer !== 'string') state.markdownBuffer = '';
+  if (typeof state.markdownCarry !== 'string') state.markdownCarry = '';
+}
+
 function renderStreamingMarkdown(state, text, options = {}) {
+  ensureMarkdownState(state);
   const input = `${state.markdownCarry || ''}${String(text || '')}`;
   state.markdownCarry = '';
   let out = '';
@@ -512,6 +519,7 @@ function renderStreamingMarkdown(state, text, options = {}) {
 }
 
 function flushStreamingMarkdown(state, output) {
+  ensureMarkdownState(state);
   let out = state.markdownCarry || '';
   if (state.markdownMode === 'bold' && state.markdownBuffer) {
     out += paint(state.markdownBuffer, [ANSI.bold], output);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.37",
+  "version": "3.15.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.37",
+      "version": "3.15.38",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.37",
+  "version": "3.15.38",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",


### PR DESCRIPTION
## Summary
- initialize missing streaming markdown state in `ax.handleEvent` callers
- bump package version to `3.15.38`
- keeps the merged mission-goal selector fix releasable through `atris@latest`

## Verification
- `node --test test/cli-smoke.test.js`
- `node --test test/ax.test.js`
- `node --test test/mission-status.test.js`
- `npm test` -> 589/589 pass
- `npm run publish:release -- --dry-run`
- `git diff --check`