### PR TITLE
Align mission due runner with current Codex goal

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -763,9 +763,13 @@ function selectDueMission(root = process.cwd(), now = new Date()) {
     .filter((mission) => missionDueAt(mission, now));
 
   candidates.sort((a, b) => {
-    const aTime = Date.parse(a.last_tick_at || a.created_at || '') || 0;
-    const bTime = Date.parse(b.last_tick_at || b.created_at || '') || 0;
-    return aTime - bTime;
+    const aCaller = runnerUsesCallerSession(a.runner) ? 1 : 0;
+    const bCaller = runnerUsesCallerSession(b.runner) ? 1 : 0;
+    if (aCaller !== bCaller) return bCaller - aCaller;
+
+    const aTime = missionSortTime(a);
+    const bTime = missionSortTime(b);
+    return bTime - aTime;
   });
   return candidates[0] || null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.38",
+  "version": "3.15.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.38",
+      "version": "3.15.39",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.38",
+  "version": "3.15.39",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -321,6 +321,38 @@ test('mission run --due skips paused missions', () => {
   }
 });
 
+test('mission run --due prefers the latest caller-session mission', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    appendMissionState(dir, {
+      id: 'old-codex-due',
+      slug: 'old-codex-due',
+      objective: 'old codex due mission',
+      status: 'running',
+      runner: 'codex_goal',
+      verifier: 'true',
+      created_at: '2026-05-01T00:00:00.000Z',
+      updated_at: '2026-05-01T00:00:00.000Z',
+    });
+    appendMissionState(dir, {
+      id: 'current-codex-due',
+      slug: 'current-codex-due',
+      objective: 'current codex due mission',
+      status: 'blocked',
+      runner: 'codex_goal',
+      verifier: 'true',
+      created_at: '2026-05-02T00:00:00.000Z',
+      updated_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const due = selectDueMission(dir);
+    assert.equal(due.id, 'current-codex-due');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('mission goal emits the Codex goal candidate from mission state', () => {
   const dir = makeTempDir();
   try {


### PR DESCRIPTION
## Summary
- make `selectDueMission` prefer the latest runnable caller-session mission
- keep `atris mission goal` and `atris mission run --due` aligned on the same current mission
- bump package version to `3.15.39`

## Verification
- `node --test test/mission-status.test.js`
- `npm test` -> 590/590 pass
- `npm run publish:release -- --dry-run`
- `git diff --check`
- Real backend selector check: `selectDueMission` and `selectCodexGoalMission` both choose `mission-2026-05-17-agentxp-contributor-launch-o-465306f7`.