### PR TITLE
Retry npm latest verification after publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.39",
+  "version": "3.15.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.39",
+      "version": "3.15.40",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.39",
+  "version": "3.15.40",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/scripts/publish-atris-release.js
+++ b/scripts/publish-atris-release.js
@@ -106,6 +106,27 @@ function verifyPublishedVersion(version, runner = spawnSync) {
   };
 }
 
+function sleepMs(ms) {
+  if (!ms) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function verifyPublishedVersionWithRetry(version, runner = spawnSync, options = {}) {
+  const attempts = Math.max(1, Number(options.attempts || 6));
+  const delayMs = Math.max(0, Number(options.delayMs ?? 2000));
+  let verification = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    verification = {
+      ...verifyPublishedVersion(version, runner),
+      attempt,
+      attempts,
+    };
+    if (verification.ok) return verification;
+    if (attempt < attempts) sleepMs(delayMs);
+  }
+  return verification;
+}
+
 function renderPublishVerification(verification) {
   if (verification.ok) {
     return `Verified npm latest: atris@${verification.actual} gitHead ${verification.gitHead || 'unknown'}\n`;
@@ -113,7 +134,7 @@ function renderPublishVerification(verification) {
   return `npm latest verification failed: expected ${verification.expected || 'unknown'}, got ${verification.actual || verification.error || 'unknown'}\n`;
 }
 
-function publishAtrisRelease(args = process.argv.slice(2), runner = spawnSync) {
+function publishAtrisRelease(args = process.argv.slice(2), runner = spawnSync, options = {}) {
   const version = readPackageVersion();
   if (args.includes('--help') || args.includes('-h')) {
     console.log('Usage: npm run publish:release -- [--otp <code>] [--dry-run]');
@@ -134,7 +155,10 @@ function publishAtrisRelease(args = process.argv.slice(2), runner = spawnSync) {
     process.stderr.write(renderTrustedPublishHelp());
   }
   if (result.status === 0 && !args.includes('--dry-run')) {
-    const verification = verifyPublishedVersion(version, runner);
+    const verification = verifyPublishedVersionWithRetry(version, runner, {
+      attempts: options.verificationAttempts,
+      delayMs: options.verificationDelayMs,
+    });
     const output = renderPublishVerification(verification);
     if (verification.ok) process.stdout.write(output);
     else process.stderr.write(output);
@@ -157,4 +181,5 @@ module.exports = {
   renderPublishVerification,
   renderTrustedPublishHelp,
   verifyPublishedVersion,
+  verifyPublishedVersionWithRetry,
 };

--- a/test/publish-release.test.js
+++ b/test/publish-release.test.js
@@ -15,6 +15,7 @@ const {
   renderPublishVerification,
   renderTrustedPublishHelp,
   verifyPublishedVersion,
+  verifyPublishedVersionWithRetry,
 } = require('../scripts/publish-atris-release');
 
 const publishWorkflowPath = path.resolve(__dirname, '../.github/workflows/publish.yml');
@@ -81,6 +82,16 @@ test('publish helper fails verification when npm latest is stale', () => {
   }));
   assert.equal(verification.ok, false);
   assert.match(renderPublishVerification(verification), /expected 3\.15\.30, got 3\.15\.23/);
+});
+
+test('publish helper retries stale npm latest verification', () => {
+  const versions = ['3.15.23', '3.15.30'];
+  const verification = verifyPublishedVersionWithRetry('3.15.30', () => ({
+    status: 0,
+    stdout: JSON.stringify({ version: versions.shift(), gitHead: 'abc123' }),
+  }), { attempts: 3, delayMs: 0 });
+  assert.equal(verification.ok, true);
+  assert.equal(verification.attempt, 2);
 });
 
 test('publish helper replays captured npm output and prints OTP help', () => {
@@ -196,6 +207,32 @@ test('publish helper verifies registry latest after a successful publish run', (
     assert.equal(status, 0);
     assert.equal(calls.length, 2);
     assert.match(stdout.join(''), /published/);
+    assert.ok(stdout.join('').includes(`Verified npm latest: atris@${packageVersion} gitHead abc123`));
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+  }
+});
+
+test('publish helper retries registry lag after a successful publish run', () => {
+  const stdout = [];
+  const originalStdoutWrite = process.stdout.write;
+  process.stdout.write = chunk => {
+    stdout.push(String(chunk));
+    return true;
+  };
+  try {
+    let views = 0;
+    const status = publishAtrisRelease([], (cmd, args) => {
+      if (args[0] === 'publish') return { status: 0, stdout: 'published\n', stderr: '' };
+      if (args[0] === 'view') {
+        views += 1;
+        const version = views === 1 ? '3.15.23' : packageVersion;
+        return { status: 0, stdout: JSON.stringify({ version, gitHead: 'abc123' }) };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
+    }, { verificationAttempts: 3, verificationDelayMs: 0 });
+    assert.equal(status, 0);
+    assert.equal(views, 2);
     assert.ok(stdout.join('').includes(`Verified npm latest: atris@${packageVersion} gitHead abc123`));
   } finally {
     process.stdout.write = originalStdoutWrite;


### PR DESCRIPTION
## Summary
- retry npm latest verification after successful publish to handle registry lag
- add tests for stale-then-current verification
- bump package version to `3.15.40`

## Verification
- `node --test test/publish-release.test.js`
- `node --test test/mission-status.test.js`
- `npm test` -> 592/592 pass
- `npm run publish:release -- --dry-run`
- `git diff --check`