### PR TITLE
fix(agentxp): seed public-friendly starter missions

### DIFF
--- a/commands/gm.js
+++ b/commands/gm.js
@@ -150,13 +150,13 @@ function playersFromWorkspace(workspaceRoot) {
 }
 
 function starterMissionTitle() {
-  return 'AgentXP Mode first rep: complete one proof-backed customer-motion mission';
+  return 'AgentXP Mode first rep: complete one proof-backed useful mission';
 }
 
 function starterMissionPrompt(player) {
   return [
     `Player ${player}: enter AgentXP Mode in this local workspace.`,
-    'Pick one concrete customer-motion rep you can finish today.',
+    'Pick one small useful contribution you can finish today: improve a doc, verify setup, create a handoff, or fix a tiny tool.',
     'Use an agent for the artifact and verifier proof.',
     'Human accept/revise gates the XP.',
   ].join(' ');

--- a/commands/play.js
+++ b/commands/play.js
@@ -242,14 +242,14 @@ function selectMission(tasks, player) {
 }
 
 function starterMissionTitle() {
-  return 'AgentXP Mode first rep: complete one proof-backed customer-motion mission';
+  return 'AgentXP Mode first rep: complete one proof-backed useful mission';
 }
 
 function starterMissionPrompt(player) {
   return [
     `Player ${player}: enter AgentXP Mode in this local workspace.`,
-    'Pick one concrete Atris Labs customer-motion rep you can finish today.',
-    'Have an agent help create a real artifact and verifier proof.',
+    'Pick one small useful contribution you can finish today: improve a doc, verify setup, create a handoff, or fix a tiny tool.',
+    'Have an agent help produce a real artifact plus verifier proof.',
     'Do not self-accept; when proof is ready, show accept/revise.',
     'Win condition: one accepted proof-backed rep visible on the local AgentXP card.',
   ].join(' ');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.40",
+  "version": "3.15.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.40",
+      "version": "3.15.41",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.40",
+  "version": "3.15.41",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -3902,7 +3902,7 @@ test('play mode opens the assigned AgentXP mission for a player', () => {
       '--tag',
       'agent-xp',
       '--note',
-      'Win condition: one proof-backed customer-motion rep.',
+      'Win condition: one proof-backed useful rep.',
       '--json',
     ], { cwd: dir, env });
     assert.equal(delegated.status, 0, delegated.stderr);
@@ -3912,7 +3912,7 @@ test('play mode opens the assigned AgentXP mission for a player', () => {
     assert.match(play.stdout, /AgentXP Mode/);
     assert.match(play.stdout, /Player justin/);
     assert.match(play.stdout, /AgentXP Mode first rep/);
-    assert.match(play.stdout, /Win condition: one proof-backed customer-motion rep/);
+    assert.match(play.stdout, /Win condition: one proof-backed useful rep/);
     assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as game-manager/);
     assert.match(play.stdout, /atris task ready [A-Z0-9]{3}-1 --as game-manager --proof/);
     assert.match(play.stdout, /atris xp card --local/);
@@ -3991,7 +3991,7 @@ test('play mode bootstraps a starter mission on a fresh player workspace', () =>
     assert.match(play.stdout, /AgentXP Mode/);
     assert.match(play.stdout, /Player justin/);
     assert.match(play.stdout, /Starter mission created locally/);
-    assert.match(play.stdout, /AgentXP Mode first rep: complete one proof-backed customer-motion mission/);
+    assert.match(play.stdout, /AgentXP Mode first rep: complete one proof-backed useful mission/);
     assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as game-manager/);
 
     const json = runCli(['play', '--json'], { cwd: dir, env });
@@ -4001,7 +4001,7 @@ test('play mode bootstraps a starter mission on a fresh player workspace', () =>
     assert.equal(body.player_source, 'local_user_team_match');
     assert.equal(body.seeded, null);
     assert.equal(body.mission.assigned_to, 'justin');
-    assert.equal(body.mission.title, 'AgentXP Mode first rep: complete one proof-backed customer-motion mission');
+    assert.equal(body.mission.title, 'AgentXP Mode first rep: complete one proof-backed useful mission');
 
     const list = runCli(['task', 'list', '--json'], { cwd: dir, env });
     assert.equal(list.status, 0, list.stderr);
@@ -4026,7 +4026,7 @@ test('play mode makes a plain folder playable on first run', () => {
     assert.equal(body.player, 'justin');
     assert.equal(body.player_source, 'flag');
     assert.equal(body.workspace_root, fs.realpathSync(dir));
-    assert.equal(body.seeded.title, 'AgentXP Mode first rep: complete one proof-backed customer-motion mission');
+    assert.equal(body.seeded.title, 'AgentXP Mode first rep: complete one proof-backed useful mission');
     assert.equal(body.mission.assigned_to, 'justin');
     assert.deepEqual(body.next_commands.slice(0, 2), [
       `atris task claim ${body.mission.ref} --as game-manager`,


### PR DESCRIPTION
## What changed
- Changes the AgentXP play/gm starter mission from insider customer-motion wording to a generic useful-contribution mission.
- Gives new players concrete contribution examples: improve a doc, verify setup, create a handoff, or fix a tiny tool.
- Bumps atris to 3.15.41 for npm release.

## Why
A random internet contributor can run atris play from a blank folder. The starter mission should feel immediately actionable without needing Atris Labs context.

## Verification
- node --check commands/play.js && node --check commands/gm.js
- node --test --test-name-pattern "play mode|gm mode" test/commands.test.js test/gm.test.js -> 7 passed
- npm test -> 592 passed
- npm run publish:release -- --dry-run -> atris@3.15.41 tarball dry run
- Fresh-folder dogfood: node bin/atris.js play --as internet-new --json seeded 'AgentXP Mode first rep: complete one proof-backed useful mission'
- git diff --check

## Risk
Low. Copy-only change to the seeded starter mission and matching tests; existing task mechanics and sync behavior are unchanged.