### PR TITLE
fix(agentxp): show proof recipe in play mode

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -250,9 +250,19 @@ function starterMissionPrompt(player) {
     `Player ${player}: enter AgentXP Mode in this local workspace.`,
     'Pick one small useful contribution you can finish today: improve a doc, verify setup, create a handoff, or fix a tiny tool.',
     'Have an agent help produce a real artifact plus verifier proof.',
-    'Do not self-accept; when proof is ready, show accept/revise.',
+    'When proof is ready, review it before accept/revise; weak proof should be revised.',
     'Win condition: one accepted proof-backed rep visible on the local AgentXP card.',
   ].join(' ');
+}
+
+function proofRecipe() {
+  return {
+    artifact: 'Create or update one concrete artifact in this folder, for example AGENTXP_PROOF.md, README.md, or a small fixed file.',
+    verifier: 'Run a command that can fail if proof is missing or broken, for example test -s AGENTXP_PROOF.md or npm test.',
+    ready_proof: 'Paste the artifact path and verifier result into atris task ready.',
+    review: 'Accept only after reviewing the proof; weak proof should be revised.',
+    solo_review_rule: 'For a solo public smoke, accept only after you inspect the proof. For team missions, use a separate human reviewer.',
+  };
 }
 
 function globalSyncCommands(player) {
@@ -319,7 +329,7 @@ function nextCommands(task, player) {
   if (task.status === 'open') {
     return [
       `atris task claim ${ref} --as ${helper}`,
-      `atris task ready ${ref} --as ${helper} --proof "<artifact path + verifier result>"`,
+      `atris task ready ${ref} --as ${helper} --proof "AGENTXP_PROOF.md + test -s AGENTXP_PROOF.md passed"`,
       `atris task accept ${ref} --as ${player} --proof "<human review>"`,
       'atris xp card --local',
       ...globalSyncCommands(player),
@@ -329,7 +339,7 @@ function nextCommands(task, player) {
   if (task.status === 'claimed') {
     const actor = task.claimed_by || helper;
     return [
-      `atris task ready ${ref} --as ${actor} --proof "<artifact path + verifier result>"`,
+      `atris task ready ${ref} --as ${actor} --proof "AGENTXP_PROOF.md + test -s AGENTXP_PROOF.md passed"`,
       `atris task accept ${ref} --as ${player} --proof "<human review>"`,
       'atris xp card --local',
       ...globalSyncCommands(player),
@@ -396,7 +406,8 @@ function modeState(args = []) {
       claimed_by: mission.claimed_by || null,
       prompt: latestMessage(events),
     } : null,
-    xp_rule: 'AgentXP lands only after proof is ready and a human accepts the task.',
+    proof_recipe: proofRecipe(),
+    xp_rule: 'AgentXP lands only after a useful artifact has verifier proof and review accepts it.',
     global_sync_rule: AGENTXP_GLOBAL_SYNC_RULE,
     leaderboard_url: AGENTXP_LEADERBOARD_URL,
     next_commands: commandList,
@@ -430,9 +441,17 @@ function render(state) {
   }
   console.log('');
   console.log('Win condition: real artifact + verifier + human accept.');
-  console.log('XP rule: no proof, no AgentXP; accept/revise stays human-gated.');
+  console.log('XP rule: no proof, no AgentXP; accept/revise is the review gate.');
   console.log('Global sync: run atris login, then sync; owner tokens are guided-demo fallback only.');
   console.log(`Leaderboard: ${state.leaderboard_url}`);
+  if (state.proof_recipe) {
+    console.log('');
+    console.log('Proof recipe:');
+    console.log(`- Artifact: ${state.proof_recipe.artifact}`);
+    console.log(`- Verifier: ${state.proof_recipe.verifier}`);
+    console.log(`- Ready proof: ${state.proof_recipe.ready_proof}`);
+    console.log(`- Review: ${state.proof_recipe.review}`);
+  }
   console.log('');
   console.log('Next commands:');
   for (const command of state.next_commands) console.log(`- ${command}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.41",
+  "version": "3.15.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.41",
+      "version": "3.15.42",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.41",
+  "version": "3.15.42",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -3920,6 +3920,8 @@ test('play mode opens the assigned AgentXP mission for a player', () => {
     assert.match(play.stdout, /atris login/);
     assert.match(play.stdout, /atris xp sync --local/);
     assert.match(play.stdout, /Leaderboard: https:\/\/api\.atris\.ai\/api\/agentxp\/leaderboard/);
+    assert.match(play.stdout, /Proof recipe:/);
+    assert.match(play.stdout, /Ready proof:/);
 
     const json = runCli(['play', '--as', 'justin', '--json'], { cwd: dir, env: { ...env, USER: 'keshav' } });
     assert.equal(json.status, 0, json.stderr);
@@ -3931,6 +3933,8 @@ test('play mode opens the assigned AgentXP mission for a player', () => {
     assert.equal(body.mission.assigned_to, 'justin');
     assert.equal(body.global_sync_rule, 'Run atris login, then sync. Owner-provided sync tokens are guided-demo fallback only.');
     assert.equal(body.leaderboard_url, 'https://api.atris.ai/api/agentxp/leaderboard');
+    assert.match(body.proof_recipe.verifier, /test -s AGENTXP_PROOF\.md/);
+    assert.match(body.proof_recipe.solo_review_rule, /solo public smoke/);
     assert.equal(body.next_commands[0], `atris task claim ${body.mission.ref} --as game-manager`);
     assert.ok(
       body.next_commands.indexOf('atris login')
@@ -4002,6 +4006,9 @@ test('play mode bootstraps a starter mission on a fresh player workspace', () =>
     assert.equal(body.seeded, null);
     assert.equal(body.mission.assigned_to, 'justin');
     assert.equal(body.mission.title, 'AgentXP Mode first rep: complete one proof-backed useful mission');
+    assert.doesNotMatch(body.mission.prompt, /Do not self-accept/);
+    assert.match(body.mission.prompt, /weak proof should be revised/);
+    assert.match(body.proof_recipe.ready_proof, /atris task ready/);
 
     const list = runCli(['task', 'list', '--json'], { cwd: dir, env });
     assert.equal(list.status, 0, list.stderr);
@@ -4030,8 +4037,9 @@ test('play mode makes a plain folder playable on first run', () => {
     assert.equal(body.mission.assigned_to, 'justin');
     assert.deepEqual(body.next_commands.slice(0, 2), [
       `atris task claim ${body.mission.ref} --as game-manager`,
-      `atris task ready ${body.mission.ref} --as game-manager --proof "<artifact path + verifier result>"`,
+      `atris task ready ${body.mission.ref} --as game-manager --proof "AGENTXP_PROOF.md + test -s AGENTXP_PROOF.md passed"`,
     ]);
+    assert.match(body.proof_recipe.artifact, /AGENTXP_PROOF\.md/);
     assert.equal(body.next_commands.includes('atris xp sync --local --token <owner-provided-token>'), true);
     assert.equal(body.next_commands.includes('atris login'), true);
     assert.equal(body.next_commands.includes('atris xp sync --local'), true);


### PR DESCRIPTION
## Summary
- Add an AgentXP proof recipe to atris play human and JSON output.
- Replace contradictory starter copy with review-first proof guidance.
- Bump CLI package metadata to 3.15.42.

## Proof
- node --check commands/play.js
- node --test --test-name-pattern "play mode" test/commands.test.js
- npm test: 594/594 passed
- fresh plain-folder dogfood for atris play --json and human output
- git diff --check
- npm run publish:release -- --dry-run