### PR TITLE
Clarify AgentXP play handle source

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -273,6 +273,16 @@ function globalSyncCommands(player) {
   ];
 }
 
+function handleSourceLine(state) {
+  const source = state.player_source || 'unknown';
+  if (source === 'flag') return 'Handle source: --as/--player.';
+  if (source === 'env') return 'Handle source: ATRIS_PLAYER/ATRIS_USERNAME.';
+  if (source === 'atris_account' || source === 'atris_session' || source === 'atris_profile') {
+    return `Handle source: ${source.replace(/_/g, ' ')}.`;
+  }
+  return 'Handle source: inferred. To choose one, run atris play --as <handle> or ATRIS_PLAYER=<handle> atris play.';
+}
+
 function ensureStarterMission(taskDb, db, workspaceRoot, player, tasks, args = []) {
   if (hasFlag(args, '--no-seed')) return { tasks, seeded: null };
   if (selectMission(tasks, player)) return { tasks, seeded: null };
@@ -418,6 +428,7 @@ function render(state) {
   console.log('');
   console.log('AgentXP Mode');
   console.log(`Player ${state.player} | Workspace ${state.workspace_name}`);
+  console.log(handleSourceLine(state));
   console.log('');
 
   if (!state.mission) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.42",
+  "version": "3.15.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.42",
+      "version": "3.15.43",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.42",
+  "version": "3.15.43",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -3911,6 +3911,7 @@ test('play mode opens the assigned AgentXP mission for a player', () => {
     assert.equal(play.status, 0, play.stderr);
     assert.match(play.stdout, /AgentXP Mode/);
     assert.match(play.stdout, /Player justin/);
+    assert.match(play.stdout, /Handle source: --as\/--player\./);
     assert.match(play.stdout, /AgentXP Mode first rep/);
     assert.match(play.stdout, /Win condition: one proof-backed useful rep/);
     assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as game-manager/);
@@ -3994,6 +3995,7 @@ test('play mode bootstraps a starter mission on a fresh player workspace', () =>
     assert.equal(play.status, 0, play.stderr);
     assert.match(play.stdout, /AgentXP Mode/);
     assert.match(play.stdout, /Player justin/);
+    assert.match(play.stdout, /Handle source: inferred\. To choose one, run atris play --as <handle> or ATRIS_PLAYER=<handle> atris play\./);
     assert.match(play.stdout, /Starter mission created locally/);
     assert.match(play.stdout, /AgentXP Mode first rep: complete one proof-backed useful mission/);
     assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as game-manager/);


### PR DESCRIPTION
## Summary
- show the inferred AgentXP handle source in human `atris play` output
- tell public players how to override the inferred handle with `--as` or `ATRIS_PLAYER`
- bump package version to 3.15.43 for npm publish

## Tests
- node --test --test-name-pattern="play mode" test/commands.test.js
- node --test test/publish-release.test.js
- npm pack --dry-run
