### PR TITLE
Release atris 3.15.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.44",
+  "version": "3.15.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.44",
+      "version": "3.15.45",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.44",
+  "version": "3.15.45",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",


### PR DESCRIPTION
## Summary
- bump atris package version to 3.15.45 so the merged AgentXP org attribution sync can publish to npm latest

## Validation
- node --test test/xp.test.js
- git diff --check

## Risk
- GitHub Actions or npm trusted publishing may still be blocked by account billing/auth; publish verification required after merge