### PR TITLE
Release atris 3.15.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.48",
+  "version": "3.15.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.48",
+      "version": "3.15.49",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.48",
+  "version": "3.15.49",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",


### PR DESCRIPTION
## What changed
- Bump atris package version from 3.15.48 to 3.15.49.
- Keeps package-lock version in sync.

## Why
- PR #31 is merged, but npm latest still points at 3.15.48, so internet users do not get the quiet computer chat --message fix until this release publishes.

## Verification
- git diff --check
- npm test => 630/630 pass

## Risk
- Low: version-only release bump. Publish workflow still gates duplicate versions and runs tests before npm publish.