### PR TITLE
Harden computer status and chat message mode

### DIFF
--- a/commands/computer.js
+++ b/commands/computer.js
@@ -1290,7 +1290,7 @@ async function probeAttachedWorkspace(token, ctx) {
   return { workspaceId: null, health: 'degraded', result };
 }
 
-async function bootstrapBusinessComputerRuntime(token, ctx, boundary = 'computer-wake') {
+async function bootstrapBusinessComputerRuntime(token, ctx, boundary = 'computer-wake', options = {}) {
   if (!ctx?.businessId || !ctx?.workspaceId) {
     return { ok: false, skipped: true, reason: 'missing_workspace' };
   }
@@ -1306,8 +1306,10 @@ async function bootstrapBusinessComputerRuntime(token, ctx, boundary = 'computer
   });
   const result = await runBusinessTerminalCommand(token, ctx, command, 120);
   if (!result.ok) {
-    console.log('  Runtime: bootstrap could not run.');
-    console.log(`  Recovery: atris computer run "npm install --prefix /workspace/.atris-npm atris@latest && /workspace/.atris-npm/node_modules/.bin/atris update" --business ${ctx.slug || ctx.businessId} --workspace ${ctx.workspaceId}`);
+    if (!options.quiet) {
+      console.log('  Runtime: bootstrap could not run.');
+      console.log(`  Recovery: atris computer run "npm install --prefix /workspace/.atris-npm atris@latest && /workspace/.atris-npm/node_modules/.bin/atris update" --business ${ctx.slug || ctx.businessId} --workspace ${ctx.workspaceId}`);
+    }
     return { ok: false, result };
   }
 
@@ -1315,13 +1317,15 @@ async function bootstrapBusinessComputerRuntime(token, ctx, boundary = 'computer
   const output = String(data.stdout || data.output || data.result || '').trim();
   const line = output.split('\n').find((entry) => entry.includes('atris_runtime_bootstrap'));
   const recovery = output.split('\n').find((entry) => entry.startsWith('recovery='));
-  if (line) {
-    console.log(`  Runtime: ${line.replace(/^atris_runtime_bootstrap\s*/, '')}`);
-  } else {
-    console.log('  Runtime: Atris bootstrap receipt written.');
-  }
-  if (recovery) {
-    console.log(`  Recovery: atris computer run "${recovery.slice('recovery='.length)}" --business ${ctx.slug || ctx.businessId} --workspace ${ctx.workspaceId}`);
+  if (!options.quiet) {
+    if (line) {
+      console.log(`  Runtime: ${line.replace(/^atris_runtime_bootstrap\s*/, '')}`);
+    } else {
+      console.log('  Runtime: Atris bootstrap receipt written.');
+    }
+    if (recovery) {
+      console.log(`  Recovery: atris computer run "${recovery.slice('recovery='.length)}" --business ${ctx.slug || ctx.businessId} --workspace ${ctx.workspaceId}`);
+    }
   }
   return { ok: true, output };
 }
@@ -1489,7 +1493,7 @@ async function ensureBusinessAwake(token, ctx, maxWaitSec = 90, options = {}) {
     if (next.ok && next.data && next.data.status === 'running' && next.data.endpoint) {
       const elapsed = Math.floor((Date.now() - start) / 1000);
       if (!options.quiet) console.log(`awake (${elapsed}s)`);
-      await bootstrapBusinessComputerRuntime(token, ctx, 'computer-auto-wake');
+      await bootstrapBusinessComputerRuntime(token, ctx, 'computer-auto-wake', options);
       return true;
     }
   }
@@ -2613,10 +2617,10 @@ async function computerChat(token, ctx, initialOptions = {}) {
   }
 
   const isCodeOps = initialOptions.mode === 'codeops' || ctx.slug === 'atris-codeops';
+  const oneShotMessage = initialOptions.message != null;
   const chatSystemPrompt = isCodeOps
     ? appendSystemPrompt(initialOptions.systemPrompt, CODEOPS_WORKFLOW_PROMPT)
     : initialOptions.systemPrompt;
-  const oneShotMessage = initialOptions.message != null;
   let sessionId = `biz-${ctx.businessId.slice(0, 8)}-${Date.now().toString(36)}`;
   const pipedInput = initialOptions.message != null ? null : await readPipedStdin();
   const scriptedInput = initialOptions.message != null ? String(initialOptions.message) : pipedInput;

--- a/commands/computer.js
+++ b/commands/computer.js
@@ -544,6 +544,7 @@ function parseComputerOptions(argv) {
   let workspaceId = null;
   let waitForResult = true;
   let message = null;
+  let force = false;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -600,6 +601,10 @@ function parseComputerOptions(argv) {
       waitForResult = false;
       continue;
     }
+    if (arg === '--force') {
+      force = true;
+      continue;
+    }
     positional.push(arg);
   }
 
@@ -618,6 +623,7 @@ function parseComputerOptions(argv) {
       workspaceId: workspaceId ? String(workspaceId).trim() : null,
       waitForResult,
       message,
+      force,
     },
   };
 }
@@ -1174,7 +1180,8 @@ function printComputerCommandFailure(result, ctx = null) {
   if (result?.status === 409) {
     const mismatch = extractAttachedWorkspaceMismatch(detail, result?.data);
     const targetWorkspace = mismatch?.requestedWorkspaceId || ctx?.workspaceId || '<workspace-id>';
-    console.error(`Run: atris computer activate --business ${businessSelector(ctx)} --workspace ${targetWorkspace}`);
+    const forceFlag = /--force|force to take over|re-run with --force/i.test(detail) ? ' --force' : '';
+    console.error(`Run: atris computer activate --business ${businessSelector(ctx)} --workspace ${targetWorkspace}${forceFlag}`);
   }
 }
 
@@ -1251,6 +1258,17 @@ async function listBusinessWorkspaces(token, ctx) {
 function formatWorkspaceRef(workspace) {
   if (!workspace) return '-';
   return workspace.name ? `${workspace.name} (${workspace.id})` : workspace.id;
+}
+
+function formatLeaseAge(seconds) {
+  const value = Number(seconds);
+  if (!Number.isFinite(value) || value < 0) return '-';
+  if (value < 60) return `${Math.floor(value)}s`;
+  const minutes = Math.floor(value / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
 }
 
 async function probeAttachedWorkspace(token, ctx) {
@@ -1500,10 +1518,24 @@ async function computerStatus(token, ctx = null) {
     const targetWorkspace = workspaces.find((workspace) => workspace.id === ctx.workspaceId) || (ctx.workspaceId ? { id: ctx.workspaceId } : null);
     console.log(`    Default workspace:  ${formatWorkspaceRef(defaultWorkspace)}`);
     console.log(`    Target workspace:   ${formatWorkspaceRef(targetWorkspace)}`);
+    const attachedFromStatus = d.attached_workspace_id
+      ? { workspaceId: d.attached_workspace_id, health: null }
+      : null;
+    if (attachedFromStatus) {
+      const attachedWorkspace = workspaces.find((workspace) => workspace.id === attachedFromStatus.workspaceId)
+        || { id: attachedFromStatus.workspaceId, name: d.attached_workspace_name || null };
+      console.log(`    Attached workspace: ${formatWorkspaceRef(attachedWorkspace)}`);
+      console.log(`    Attached by:        ${d.attached_by || '-'}`);
+      console.log(`    Attached at:        ${d.attached_at || '-'}`);
+      console.log(`    Lease age:          ${formatLeaseAge(d.lease_age_seconds)}`);
+      if (d.takeover_hint) console.log(`    Takeover hint:      ${d.takeover_hint}`);
+    }
     if (status === 'running' && d.endpoint && ctx.workspaceId) {
       const attached = await probeAttachedWorkspace(token, ctx);
-      const attachedWorkspace = workspaces.find((workspace) => workspace.id === attached.workspaceId) || (attached.workspaceId ? { id: attached.workspaceId } : null);
-      console.log(`    Attached workspace: ${formatWorkspaceRef(attachedWorkspace)}`);
+      if (!attachedFromStatus) {
+        const attachedWorkspace = workspaces.find((workspace) => workspace.id === attached.workspaceId) || (attached.workspaceId ? { id: attached.workspaceId } : null);
+        console.log(`    Attached workspace: ${formatWorkspaceRef(attachedWorkspace)}`);
+      }
       if (attached.health === 'workspace_mismatch') {
         printComputerCommandFailure(attached.result, ctx);
       } else if (attached.health !== 'ready') {
@@ -1686,7 +1718,7 @@ async function computerCreate(token, args = [], defaults = {}) {
   console.log(`  atris computer sleep --business ${owner} --workspace ${workspaceId}`);
 }
 
-async function computerActivate(token, ctx = null) {
+async function computerActivate(token, ctx = null, options = {}) {
   if (!ctx?.businessId || !ctx?.workspaceId) {
     console.error('Usage: atris computer activate --business <slug> --workspace <id>');
     process.exitCode = 1;
@@ -1696,7 +1728,7 @@ async function computerActivate(token, ctx = null) {
   const result = await apiRequestJson(`/business/${ctx.businessId}/workspaces/${ctx.workspaceId}/activate`, {
     method: 'POST',
     token,
-    body: {},
+    body: { force: Boolean(options.force) },
   });
   if (!result.ok) {
     printComputerCommandFailure(result, ctx);
@@ -3398,7 +3430,7 @@ async function runComputer() {
     case 'chat': return computerChat(token, ctx, cloudOptions);
     case 'card': return computerCard(args.slice(1));
     case 'proof': return computerProof(token, ctx, cloudOptions);
-    case 'activate': return computerActivate(token, ctx);
+    case 'activate': return computerActivate(token, ctx, cloudOptions);
     case 'status': return computerStatus(token, ctx);
     case 'up':
     case 'wake': return computerWake(token, ctx);

--- a/test/computer-create.test.js
+++ b/test/computer-create.test.js
@@ -137,7 +137,8 @@ function startApiServer(requests) {
           send(200, { status: 'failed', events: [{ type: 'error', error: 'stream failed for test' }] });
           return;
         }
-        send(200, { status: 'completed', events: [{ type: 'assistant_text', content: '4' }, { type: 'complete' }] });
+        const reply = lastChatMessage.includes('CHAT_OK') ? 'CHAT_OK' : '4';
+        send(200, { status: 'completed', events: [{ type: 'assistant_text', content: reply }, { type: 'complete' }] });
         return;
       }
       if (
@@ -719,7 +720,7 @@ test('computer chat sends piped prompts non-interactively', async () => {
   }
 });
 
-test('computer chat --message sends one non-interactive prompt', async () => {
+test('computer chat --message sends one quiet non-interactive prompt', async () => {
   const home = makeTempDir();
   const cwd = makeTempDir();
   const requests = [];
@@ -742,18 +743,20 @@ test('computer chat --message sends one non-interactive prompt', async () => {
       'atris-labs',
       '--workspace',
       'ws-new',
+      '--worker',
+      'claude',
       '--message',
-      'What is 2+2?',
+      'Reply exactly CHAT_OK',
     ], { cwd, env });
 
     assert.equal(res.status, 0, res.stderr || res.stdout);
-    assert.equal(res.stdout, '4\n');
+    assert.equal(res.stdout.trim(), 'CHAT_OK');
     assert.doesNotMatch(res.stdout, /Atris Cloud Computer/);
     assert.doesNotMatch(res.stdout, /Running on cloud/);
     assert.ok(requests.some((request) => (
       request.method === 'POST' &&
       request.url === '/api/business/biz-1/chat' &&
-      request.body?.message === 'What is 2+2?' &&
+      request.body?.message === 'Reply exactly CHAT_OK' &&
       request.body?.worker === 'claude'
     )));
   } finally {

--- a/test/computer-create.test.js
+++ b/test/computer-create.test.js
@@ -115,6 +115,12 @@ function startApiServer(requests) {
           status: 'running',
           business_id: 'biz-1',
           endpoint: 'https://runner.example',
+          attached_workspace_id: 'ws-new',
+          attached_workspace_name: 'My Business Computer',
+          attached_by: 'operator-1',
+          attached_at: '2026-05-19T09:00:00+00:00',
+          lease_age_seconds: 120,
+          takeover_hint: 'Use --force to take over Main.',
         });
         return;
       }
@@ -462,7 +468,46 @@ test('computer activate attaches workspace and updates the cached default', asyn
     assert.match(res.stdout, /CLI default: ws-new/);
     const cache = JSON.parse(fs.readFileSync(path.join(home, '.atris', 'businesses.json'), 'utf8'));
     assert.equal(cache['atris-labs'].workspace_id, 'ws-new');
-    assert.ok(requests.some((request) => request.method === 'POST' && request.url === '/api/business/biz-1/workspaces/ws-new/activate'));
+    const activateRequest = requests.find((request) => request.method === 'POST' && request.url === '/api/business/biz-1/workspaces/ws-new/activate');
+    assert.ok(activateRequest);
+    assert.equal(activateRequest.body.force, false);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    cleanupTempDir(home);
+    cleanupTempDir(cwd);
+  }
+});
+
+test('computer activate --force sends explicit takeover flag', async () => {
+  const home = makeTempDir();
+  const cwd = makeTempDir();
+  const requests = [];
+  const server = await startApiServer(requests);
+  try {
+    writeCredentials(home);
+    const { port } = server.address();
+    const env = {
+      ...process.env,
+      HOME: home,
+      ATRIS_API_URL: `http://127.0.0.1:${port}/api`,
+      ATRIS_NO_INTERACTIVE: '1',
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+    };
+
+    const res = await runCliAsync([
+      'computer',
+      'activate',
+      '--business',
+      'atris-labs',
+      '--workspace',
+      'ws-new',
+      '--force',
+    ], { cwd, env });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    const activateRequest = requests.find((request) => request.method === 'POST' && request.url === '/api/business/biz-1/workspaces/ws-new/activate');
+    assert.ok(activateRequest);
+    assert.equal(activateRequest.body.force, true);
   } finally {
     await new Promise((resolve) => server.close(resolve));
     cleanupTempDir(home);
@@ -538,6 +583,10 @@ test('computer status shows default target and attached workspace truth', async 
     assert.match(res.stdout, /Default workspace:\s+Main \(ws-old\)/);
     assert.match(res.stdout, /Target workspace:\s+My Business Computer \(ws-new\)/);
     assert.match(res.stdout, /Attached workspace:\s+My Business Computer \(ws-new\)/);
+    assert.match(res.stdout, /Attached by:\s+operator-1/);
+    assert.match(res.stdout, /Attached at:\s+2026-05-19T09:00:00\+00:00/);
+    assert.match(res.stdout, /Lease age:\s+2m/);
+    assert.match(res.stdout, /Takeover hint:\s+Use --force to take over Main\./);
     assert.match(res.stdout, /Health:\s+ready/);
   } finally {
     await new Promise((resolve) => server.close(resolve));


### PR DESCRIPTION
## Summary
- show backend workspace lease fields in atris computer status
- pass --force through activate and include a force hint on lease conflicts
- make atris computer chat --message a quiet one-shot path with no picker/banner/status chatter

## Validation
- git diff --check
- node --test test/computer-create.test.js
- live worktree proof: node bin/atris.js computer chat --business atris-labs --worker claude --message "Reply exactly CHAT_OK" printed only CHAT_OK and exited 0

## Risk
- --message behavior intentionally suppresses UI chrome; interactive chat and piped prompts keep their existing flow
- global/npm atris needs release before this is available through the installed command