### PR TITLE
Release atris 3.15.50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.49",
+  "version": "3.15.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.49",
+      "version": "3.15.50",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.49",
+  "version": "3.15.50",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",


### PR DESCRIPTION
## Summary
- bump atris package metadata to 3.15.50 after computer hardening merge
- includes merged CLI lease/status and chat message hardening from #33

## Validation
- git diff --check
- node --test test/computer-create.test.js test/publish-release.test.js
- node bin/atris.js version => atris v3.15.50

## Risk
- release metadata only; publishing still depends on tag-triggered publish workflow/trusted publishing