### PR TITLE
Fix task review certification with reward

### DIFF
--- a/lib/task-db.js
+++ b/lib/task-db.js
@@ -572,7 +572,6 @@ function reviewTask(db, { id, actor, reward, lesson, nextTask, proof, careerXpEl
   const metadata = row.metadata && typeof row.metadata === 'object' ? { ...row.metadata } : {};
   const reviewingPendingProof = row.status === 'review'
     && metadata.approval_status === 'pending'
-    && numericReward <= 0
     && metadata.agent_certified !== true;
   let reviewPassCount = Number(metadata.agent_review_pass_count || 0);
   if (reviewingPendingProof) {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4440,15 +4440,17 @@ test('task ready holds work in review until human accept', () => {
 
     const prooflessReview = runCli([
       'task', 'review', ref,
-      '--reward', '0',
+      '--reward', '1',
       '--as', 'validator',
       '--json',
     ], { cwd: dir, env });
     assert.equal(prooflessReview.status, 0, prooflessReview.stderr);
-    assert.equal(JSON.parse(prooflessReview.stdout).task.review.proof, 'typecheck passed and diff reviewed');
-    assert.equal(JSON.parse(prooflessReview.stdout).task.review.agent_review_pass_count, 2);
-    assert.equal(JSON.parse(prooflessReview.stdout).task.review.agent_certified, true);
-    assert.equal(JSON.parse(prooflessReview.stdout).task.metadata.agent_certified, true);
+    const prooflessReviewPayload = JSON.parse(prooflessReview.stdout);
+    assert.equal(prooflessReviewPayload.task.review.proof, 'typecheck passed and diff reviewed');
+    assert.equal(prooflessReviewPayload.task.review.agent_review_pass_count, 2);
+    assert.equal(prooflessReviewPayload.task.review.agent_certified, true);
+    assert.equal(prooflessReviewPayload.task.metadata.agent_certified, true);
+    assert.equal(prooflessReviewPayload.episode.career_xp.eligible, false);
 
     const nextAfterReviewCertification = runCli(['task', 'next', '--as', 'codex', '--json'], { cwd: dir, env });
     assert.equal(nextAfterReviewCertification.status, 0, nextAfterReviewCertification.stderr);


### PR DESCRIPTION
## Summary
- count pending proof reviews as agent review passes even when the reviewer supplies a positive reward
- keep Career XP ineligible until human accept
- add regression coverage for reward=1 pending proof review certification

## Verification
- node --test --test-name-pattern "task ready holds work in review until human accept|task review does not mint AgentXP before the task is done" test/commands.test.js
- node --test --test-name-pattern "task review|task ready|task reviews" test/commands.test.js
- node --test test/cli-smoke.test.js
- git diff --check