### PR TITLE
Fix radar business computer count from runtime receipt

### DIFF
--- a/commands/radar.js
+++ b/commands/radar.js
@@ -332,6 +332,8 @@ function loadBusinessCollaboration(root, deps, team = {}) {
   const episodes = countJsonLines(path.join(root, '.atris', 'state', 'episodes.jsonl'), deps);
   const scorecards = countJsonLines(path.join(root, '.atris', 'state', 'scorecards.jsonl'), deps);
   const computerDirs = countDirectoryEntries(path.join(root, 'atris', 'computers'), deps, name => !name.startsWith('.'));
+  const runtimeComputer = runtime && (runtime.workspace_id || runtime.business_id || runtime.scope === 'local-business-computer') ? 1 : 0;
+  const computers = Math.max(computerDirs, runtimeComputer);
   const hasOnboarding = ingestPacks > 0 || starterBriefs > 0 || onePagers > 0;
   const hasProofLoop = events > 0 || episodes > 0 || scorecards > 0 || localReceipts > 0;
   const hasTeam = Number(team.total || 0) > 0;
@@ -360,7 +362,7 @@ function loadBusinessCollaboration(root, deps, team = {}) {
     } : null,
     onboarding: { packs: ingestPacks, starter_briefs: starterBriefs, first_loops: firstLoops, one_pagers: onePagers, reports },
     proof: { events, episodes, scorecards, receipts: localReceipts },
-    computers: computerDirs,
+    computers,
     team_members: Number(team.total || 0),
     active_goal_members: Number(team.active_goal_members || 0),
     share_ready: missing.length === 0,

--- a/test/radar.test.js
+++ b/test/radar.test.js
@@ -226,6 +226,37 @@ test('collectRadar joins live agents with task, mission, and worktree state', ()
   assert.match(payload.next_action, /close or hand off 1 session still bound to review task CLI-95/);
 });
 
+test('collectRadar counts a bound runtime receipt as a business computer', () => {
+  const root = '/tmp/atris-runtime-computer';
+  const businessFile = path.join(root, '.atris', 'business.json');
+  const runtimeFile = path.join(root, '.atris', 'state', 'runtime.json');
+  const syncFile = path.join(root, '.atris', 'state', '_sync.json');
+  const files = new Map([
+    [businessFile, JSON.stringify({ business_id: 'biz-42', workspace_id: 'ws-42', name: 'Cashmere AI', slug: 'cashmere-ai', workspace_template: 'business' })],
+    [runtimeFile, JSON.stringify({ scope: 'local-business-computer', business_id: 'biz-42', workspace_id: 'ws-42', install_status: 'local_cli_present' })],
+    [syncFile, JSON.stringify({ workspace_slug: 'cashmere-ai', business_id: 'biz-42', workspace_id: 'ws-42', workspace_template: 'business' })],
+  ]);
+  const dirs = new Set([
+    path.join(root, 'atris'),
+    path.join(root, 'atris', 'context', '_ingest'),
+    path.join(root, 'atris', 'wiki', 'briefs'),
+    path.join(root, 'atris', 'wiki', 'concepts'),
+    path.join(root, 'atris', 'reports'),
+    path.join(root, 'atris', 'team'),
+  ]);
+  const data = collectRadar({
+    root,
+    platform: 'darwin',
+    execFileSync: () => '',
+    existsSync: file => files.has(file) || dirs.has(file) || ['MAP.md', 'TODO.md', 'PERSONA.md'].some(name => file === path.join(root, 'atris', name)),
+    readFileSync: file => files.get(file) || '',
+    readdirSync: () => [],
+  });
+
+  assert.equal(data.os.business.computers, 1);
+  assert.match(renderRadar(data), /computers 1/);
+});
+
 test('renderAgentTop explains workspaces with no active task', () => {
   const data = {
     root: '/tmp/root',


### PR DESCRIPTION
## Summary
- count a bound `.atris/state/runtime.json` receipt as one business computer when no `atris/computers/*` folder exists
- keep existing local computer-folder counting behavior
- add radar coverage for runtime-bound business computers

## Verification
- node --test test/radar.test.js
- git diff --check
- local smoke from atrisos-backend with patched CLI: radar prints `computers 1` for Atris Labs