### PR TITLE
Prepare atris 3.15.51 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.50",
+  "version": "3.15.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.50",
+      "version": "3.15.51",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.50",
+  "version": "3.15.51",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",


### PR DESCRIPTION
## Summary
- bump package.json and package-lock.json to 3.15.51
- prepares npm release for the already-merged task-review certification and radar runtime-computer fixes
- does not publish npm or create a tag

## Proof
- node --test test/radar.test.js
- node --test --test-name-pattern "task ready holds work in review until human accept|task review does not mint AgentXP before the task is done|task review" test/commands.test.js
- node --test test/cli-smoke.test.js
- npm pack --dry-run
- git diff --check
- node bin/atris.js version
- node /Users/keshavrao/arena/atris-cli-worktrees/codex-atris-31551-release-prep-202605191217/bin/atris.js radar from atrisos-backend shows computers 1