### PR TITLE
fix(radar): flag owner-only active tasks

### DIFF
--- a/commands/radar.js
+++ b/commands/radar.js
@@ -114,18 +114,26 @@ function loadTasks(root, deps) {
   if (!deps.exists(file)) return [];
   const payload = safeJson(deps.readFile(file, 'utf8'), {});
   const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
-  return tasks.map(task => ({
-    id: task.id,
-    display_id: task.display_id,
-    legacy_ref: task.legacy_ref,
-    title: task.title,
-    status: task.status,
-    tag: task.tag,
-    workspace_root: task.workspace_root,
-    claimed_by: task.claimed_by,
-    assigned_to: task.metadata?.assigned_to || task.assigned_to || null,
-    metadata: task.metadata || {},
-  }));
+  return tasks.map(task => {
+    const messages = Array.isArray(task.messages) ? task.messages : [];
+    const row = {
+      id: task.id,
+      display_id: task.display_id,
+      legacy_ref: task.legacy_ref,
+      title: task.title,
+      status: task.status,
+      tag: task.tag,
+      workspace_root: task.workspace_root,
+      claimed_by: task.claimed_by,
+      assigned_to: task.metadata?.assigned_to || task.assigned_to || null,
+      metadata: task.metadata || {},
+    };
+    Object.defineProperty(row, 'routing_text', {
+      enumerable: false,
+      value: messages.map(message => message && message.content).filter(Boolean).join(' '),
+    });
+    return row;
+  });
 }
 
 function findTaskWorkspaceRoot(cwd, deps) {
@@ -439,9 +447,31 @@ function summarize(tasks, missions, worktrees, agents) {
   };
 }
 
+function ownerActionRequired(task) {
+  const metadata = task?.metadata || {};
+  if (metadata.owner_action_required === true || metadata.agent_executable === false) return true;
+  if (String(metadata.agent_executable || '').toLowerCase() === 'false') return true;
+  const text = [
+    task?.title,
+    task?.tag,
+    metadata.status,
+    metadata.blocker,
+    metadata.human_revision_note,
+    metadata.latest_agent_proof,
+    metadata.latest_agent_lesson,
+    task?.routing_text,
+  ].filter(Boolean).join(' ').toLowerCase();
+  if (text.includes('owner_action_required') || text.includes('agent_executable=false')) return true;
+  if (text.includes('owner-only') || text.includes('owner only') || text.includes('not agent-executable')) return true;
+  return text.includes('owner') && text.includes('billing') && (text.includes('spending limit') || text.includes('failed payments'));
+}
+
 function nextAction(tasks, missions, worktrees, agents, os = {}) {
-  const activeTask = tasks.find(t => t.status === 'claimed' || t.status === 'open');
+  const activeTasks = tasks.filter(t => t.status === 'claimed' || t.status === 'open');
+  const activeTask = activeTasks.find(t => !ownerActionRequired(t));
   if (activeTask) return `work ${taskRef(activeTask)}: ${activeTask.title || 'active task'}`;
+  const ownerTask = activeTasks.find(ownerActionRequired);
+  if (ownerTask) return `owner action required ${taskRef(ownerTask)}: ${ownerTask.title || 'owner-only task'}`;
   const needsReview = tasks.find(t => t.status === 'review' && !(t.metadata && t.metadata.agent_certified));
   if (needsReview) return `review ${taskRef(needsReview)}: ${needsReview.title || 'uncertified review task'}`;
   const certified = tasks.find(t => t.status === 'review' && t.metadata && t.metadata.agent_certified);

--- a/test/radar.test.js
+++ b/test/radar.test.js
@@ -41,6 +41,46 @@ test('parseWorktrees reads porcelain worktree output', () => {
   assert.deepEqual(rows.map(row => [row.path, row.branch]), [['/repo', 'main'], ['/repo-wt', 'agent/test']]);
 });
 
+test('collectRadar surfaces owner-only active tasks without calling them agent work', () => {
+  const root = '/tmp/atris-owner-gate';
+  const taskFile = path.join(root, '.atris', 'state', 'tasks.projection.json');
+  const files = new Map([
+    [taskFile, JSON.stringify({
+      tasks: [
+        {
+          display_id: 'BCK-292',
+          title: 'Owner gate: unblock backend Actions billing',
+          status: 'claimed',
+          workspace_root: root,
+          claimed_by: 'keshavrao',
+          metadata: {
+            approval_status: 'revise',
+            human_revision_note: 'GitHub Actions billing is blocked because failed payments require owner billing action.',
+          },
+          messages: [
+            { content: 'status=owner_action_required, agent_executable=false, blocker=github_actions_billing_or_spending_limit' },
+          ],
+        },
+      ],
+    })],
+  ]);
+
+  const data = collectRadar({
+    root,
+    platform: 'darwin',
+    execFileSync: cmd => {
+      if (cmd === 'ps') return '';
+      throw new Error(`unexpected command ${cmd}`);
+    },
+    existsSync: file => files.has(file),
+    readFileSync: file => files.get(file) || '',
+  });
+
+  assert.match(data.next_action, /owner action required BCK-292/);
+  assert.doesNotMatch(data.next_action, /^work BCK-292/);
+  assert.match(renderRadar(data), /Next: owner action required BCK-292/);
+});
+
 test('collectRadar joins live agents with task, mission, and worktree state', () => {
   const root = '/tmp/atris-radar';
   const otherRoot = '/tmp/other';


### PR DESCRIPTION
## Summary
- classify active tasks with owner_action_required / agent_executable=false / owner billing-spending-limit signals as owner action, not agent work
- keep task message text internal to routing so radar --json does not expose full message history
- add regression coverage for BCK-292-style owner gates

## Verification
- node --test test/radar.test.js
- npm test
- git diff --check
- live backend smoke: patched atris radar reports `owner action required BCK-292` instead of `work BCK-292`

## Risk
- heuristic wording could miss a new owner-blocker phrase until that blocker writes structured metadata or a covered receipt phrase