### PR TITLE
chore(release): prep atris 3.15.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.51",
+  "version": "3.15.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.51",
+      "version": "3.15.52",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.51",
+  "version": "3.15.52",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",


### PR DESCRIPTION
## Summary
- bump atris package metadata from 3.15.51 to 3.15.52
- create a clean publish target for the merged radar owner-gate fix from PR #38

## Why
- npm `atris@3.15.51` already exists and points at gitHead d1953e6, before PR #38
- publishing the current master contents needs a new semver patch to avoid version collision

## Verification
- node --test test/radar.test.js test/publish-release.test.js
- git diff --check
- npm view atris@3.15.52 version returns E404, so the version is free
- npm pack --dry-run builds atris@3.15.52

## Risk
- this does not publish npm; owner/release automation still must publish 3.15.52 and verify npm latest before users get the fix through `npm install -g atris@latest`