### PR TITLE
fix(release): preflight npm version availability

### DIFF
--- a/scripts/publish-atris-release.js
+++ b/scripts/publish-atris-release.js
@@ -83,6 +83,52 @@ function renderTrustedPublishHelp() {
   ].join('\n');
 }
 
+function checkVersionAvailability(version, runner = spawnSync) {
+  const result = runner('npm', ['view', `atris@${version}`, 'version', 'gitHead', '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (result.status === 0) {
+    let payload = {};
+    try {
+      payload = JSON.parse(result.stdout || '{}');
+    } catch {}
+    return {
+      ok: false,
+      reason: 'version_exists',
+      version: payload.version || version,
+      gitHead: payload.gitHead || null,
+    };
+  }
+  const text = `${result.stderr || ''}\n${result.stdout || ''}`;
+  if (text.includes('E404') || text.includes('No match found')) {
+    return { ok: true, version };
+  }
+  return {
+    ok: false,
+    reason: 'version_check_failed',
+    version,
+    error: result.stderr || result.stdout || 'npm view failed',
+  };
+}
+
+function renderVersionAvailabilityFailure(check) {
+  if (check.reason === 'version_exists') {
+    return [
+      `npm already has atris@${check.version}.`,
+      check.gitHead ? `Published gitHead: ${check.gitHead}` : null,
+      'Bump package.json and package-lock.json before publishing.',
+      '',
+    ].filter(Boolean).join('\n');
+  }
+  return [
+    `Could not verify npm availability for atris@${check.version}.`,
+    String(check.error || '').trim(),
+    'Refusing to publish until the registry preflight is clear.',
+    '',
+  ].filter(Boolean).join('\n');
+}
+
 function verifyPublishedVersion(version, runner = spawnSync) {
   const result = runner('npm', ['view', 'atris', 'version', 'gitHead', '--json'], {
     cwd: repoRoot,
@@ -143,6 +189,14 @@ function publishAtrisRelease(args = process.argv.slice(2), runner = spawnSync, o
     return 0;
   }
 
+  if (!args.includes('--dry-run') && !options.skipVersionPreflight) {
+    const availability = checkVersionAvailability(version, runner);
+    if (!availability.ok) {
+      process.stderr.write(renderVersionAvailabilityFailure(availability));
+      return 1;
+    }
+  }
+
   const result = runner('npm', buildPublishArgs(args), {
     cwd: repoRoot,
     encoding: 'utf8',
@@ -173,6 +227,7 @@ if (require.main === module) {
 
 module.exports = {
   buildPublishArgs,
+  checkVersionAvailability,
   currentGitRef,
   isOtpFailure,
   isTrustedPublishAuthFailure,
@@ -180,6 +235,7 @@ module.exports = {
   renderOtpHelp,
   renderPublishVerification,
   renderTrustedPublishHelp,
+  renderVersionAvailabilityFailure,
   verifyPublishedVersion,
   verifyPublishedVersionWithRetry,
 };

--- a/test/publish-release.test.js
+++ b/test/publish-release.test.js
@@ -7,6 +7,7 @@ const packageVersion = require('../package.json').version;
 
 const {
   buildPublishArgs,
+  checkVersionAvailability,
   currentGitRef,
   isOtpFailure,
   isTrustedPublishAuthFailure,
@@ -14,6 +15,7 @@ const {
   renderOtpHelp,
   renderPublishVerification,
   renderTrustedPublishHelp,
+  renderVersionAvailabilityFailure,
   verifyPublishedVersion,
   verifyPublishedVersionWithRetry,
 } = require('../scripts/publish-atris-release');
@@ -66,6 +68,47 @@ test('publish helper reads current git ref for fallback help', () => {
   assert.equal(ref, 'abc123');
 });
 
+test('publish helper detects an already-published package version', () => {
+  const check = checkVersionAvailability('3.15.51', (cmd, args) => {
+    assert.equal(cmd, 'npm');
+    assert.deepEqual(args, ['view', 'atris@3.15.51', 'version', 'gitHead', '--json']);
+    return { status: 0, stdout: JSON.stringify({ version: '3.15.51', gitHead: 'old-head' }) };
+  });
+  assert.equal(check.ok, false);
+  assert.equal(check.reason, 'version_exists');
+  assert.match(renderVersionAvailabilityFailure(check), /npm already has atris@3\.15\.51/);
+  assert.match(renderVersionAvailabilityFailure(check), /Bump package\.json and package-lock\.json/);
+});
+
+test('publish helper treats npm E404 as an available package version', () => {
+  const check = checkVersionAvailability('3.15.52', () => ({
+    status: 1,
+    stderr: 'npm error code E404\nnpm error 404 No match found for version 3.15.52',
+  }));
+  assert.equal(check.ok, true);
+});
+
+test('publish helper refuses to publish when version preflight is inconclusive', () => {
+  const stderr = [];
+  const originalStderrWrite = process.stderr.write;
+  process.stderr.write = chunk => {
+    stderr.push(String(chunk));
+    return true;
+  };
+  try {
+    const status = publishAtrisRelease([], (cmd, args) => {
+      assert.equal(cmd, 'npm');
+      assert.equal(args[0], 'view');
+      return { status: 1, stderr: 'npm registry timeout\n' };
+    });
+    assert.equal(status, 1);
+    assert.match(stderr.join(''), /Could not verify npm availability/);
+    assert.match(stderr.join(''), /Refusing to publish/);
+  } finally {
+    process.stderr.write = originalStderrWrite;
+  }
+});
+
 test('publish helper verifies npm latest after successful publish', () => {
   const verification = verifyPublishedVersion('3.15.30', () => ({
     status: 0,
@@ -111,6 +154,7 @@ test('publish helper replays captured npm output and prints OTP help', () => {
     const status = publishAtrisRelease([], (cmd, args) => {
       if (cmd === 'git') return { status: 0, stdout: 'abc123\n' };
       assert.equal(cmd, 'npm');
+      if (args[0] === 'view') return { status: 1, stderr: 'npm error code E404\n' };
       assert.deepEqual(args, ['publish', '--access', 'public']);
       return {
         status: 1,
@@ -141,6 +185,7 @@ test('publish helper prints trusted publisher setup help in GitHub Actions', () 
   try {
     const status = publishAtrisRelease([], (cmd, args) => {
       assert.equal(cmd, 'npm');
+      if (args[0] === 'view') return { status: 1, stderr: 'npm error code E404\n' };
       assert.deepEqual(args, ['publish', '--access', 'public']);
       return {
         status: 1,
@@ -170,6 +215,7 @@ test('publish helper prints trusted publisher setup help for GitHub ENEEDAUTH', 
   try {
     const status = publishAtrisRelease([], (cmd, args) => {
       assert.equal(cmd, 'npm');
+      if (args[0] === 'view') return { status: 1, stderr: 'npm error code E404\n' };
       assert.deepEqual(args, ['publish', '--access', 'public']);
       return {
         status: 1,
@@ -199,13 +245,16 @@ test('publish helper verifies registry latest after a successful publish run', (
     const status = publishAtrisRelease([], (cmd, args) => {
       calls.push([cmd, args]);
       if (args[0] === 'publish') return { status: 0, stdout: 'published\n', stderr: '' };
+      if (args[0] === 'view' && String(args[1] || '').startsWith('atris@')) {
+        return { status: 1, stderr: 'npm error code E404\n' };
+      }
       if (args[0] === 'view') {
         return { status: 0, stdout: JSON.stringify({ version: packageVersion, gitHead: 'abc123' }) };
       }
       throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
     });
     assert.equal(status, 0);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 3);
     assert.match(stdout.join(''), /published/);
     assert.ok(stdout.join('').includes(`Verified npm latest: atris@${packageVersion} gitHead abc123`));
   } finally {
@@ -224,6 +273,9 @@ test('publish helper retries registry lag after a successful publish run', () =>
     let views = 0;
     const status = publishAtrisRelease([], (cmd, args) => {
       if (args[0] === 'publish') return { status: 0, stdout: 'published\n', stderr: '' };
+      if (args[0] === 'view' && String(args[1] || '').startsWith('atris@')) {
+        return { status: 1, stderr: 'npm error code E404\n' };
+      }
       if (args[0] === 'view') {
         views += 1;
         const version = views === 1 ? '3.15.23' : packageVersion;


### PR DESCRIPTION
## Summary
- check `npm view atris@<local-version>` before real publishes
- fail before `npm publish` when the version is already occupied or the registry preflight is inconclusive
- keep dry-run behavior unchanged and add regression coverage

## Why
- npm `atris@3.15.51` was already published from gitHead d1953e6 before the radar owner-gate fix landed
- this guard makes that mismatch obvious and tells the releaser to bump package metadata instead of trying to publish an immutable version

## Verification
- node --test test/publish-release.test.js
- npm test
- git diff --check
- live preflight on package version 3.15.52 returned `{ ok: true, version: "3.15.52" }`

## Risk
- release publish now depends on npm registry preflight availability; if npm view is down, publishing fails closed until the registry check recovers