### PR TITLE
fix(play): use player handle in first-rep commands

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -327,7 +327,7 @@ function playWorkspaceRoot(taskDb, workspaceArg) {
 }
 
 function nextCommands(task, player) {
-  const helper = 'game-manager';
+  const helper = player || 'player';
   if (!task) {
     return [
       `atris task delegate "AgentXP first rep: one proof-backed mission" --to ${player} --tag agent-xp`,

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4092,8 +4092,8 @@ test('play mode opens the assigned AgentXP mission for a player', () => {
     assert.match(play.stdout, /Handle source: --as\/--player\./);
     assert.match(play.stdout, /AgentXP Mode first rep/);
     assert.match(play.stdout, /Win condition: one proof-backed useful rep/);
-    assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as game-manager/);
-    assert.match(play.stdout, /atris task ready [A-Z0-9]{3}-1 --as game-manager --proof/);
+    assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as justin/);
+    assert.match(play.stdout, /atris task ready [A-Z0-9]{3}-1 --as justin --proof/);
     assert.match(play.stdout, /atris xp card --local/);
     assert.match(play.stdout, /atris xp sync --local --token <owner-provided-token>/);
     assert.match(play.stdout, /atris login/);
@@ -4114,7 +4114,7 @@ test('play mode opens the assigned AgentXP mission for a player', () => {
     assert.equal(body.leaderboard_url, 'https://api.atris.ai/api/agentxp/leaderboard');
     assert.match(body.proof_recipe.verifier, /test -s AGENTXP_PROOF\.md/);
     assert.match(body.proof_recipe.solo_review_rule, /solo public smoke/);
-    assert.equal(body.next_commands[0], `atris task claim ${body.mission.ref} --as game-manager`);
+    assert.equal(body.next_commands[0], `atris task claim ${body.mission.ref} --as justin`);
     assert.ok(
       body.next_commands.indexOf('atris login')
         < body.next_commands.indexOf('atris xp sync --local --token <owner-provided-token>')
@@ -4176,7 +4176,7 @@ test('play mode bootstraps a starter mission on a fresh player workspace', () =>
     assert.match(play.stdout, /Handle source: inferred\. To choose one, run atris play --as <handle> or ATRIS_PLAYER=<handle> atris play\./);
     assert.match(play.stdout, /Starter mission created locally/);
     assert.match(play.stdout, /AgentXP Mode first rep: complete one proof-backed useful mission/);
-    assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as game-manager/);
+    assert.match(play.stdout, /atris task claim [A-Z0-9]{3}-1 --as justin/);
 
     const json = runCli(['play', '--json'], { cwd: dir, env });
     assert.equal(json.status, 0, json.stderr);
@@ -4216,8 +4216,8 @@ test('play mode makes a plain folder playable on first run', () => {
     assert.equal(body.seeded.title, 'AgentXP Mode first rep: complete one proof-backed useful mission');
     assert.equal(body.mission.assigned_to, 'justin');
     assert.deepEqual(body.next_commands.slice(0, 2), [
-      `atris task claim ${body.mission.ref} --as game-manager`,
-      `atris task ready ${body.mission.ref} --as game-manager --proof "AGENTXP_PROOF.md + test -s AGENTXP_PROOF.md passed"`,
+      `atris task claim ${body.mission.ref} --as justin`,
+      `atris task ready ${body.mission.ref} --as justin --proof "AGENTXP_PROOF.md + test -s AGENTXP_PROOF.md passed"`,
     ]);
     assert.match(body.proof_recipe.artifact, /AGENTXP_PROOF\.md/);
     assert.equal(body.next_commands.includes('atris xp sync --local --token <owner-provided-token>'), true);


### PR DESCRIPTION
## Summary
- make `atris play` open-task next commands use the selected player handle for claim/ready
- keep GM mode behavior unchanged: GM still acts as game-manager
- update AgentXP play tests for the player-facing command path

## Why
- public `atris play --as internet-smoke` assigned the starter mission to internet-smoke but suggested `--as game-manager` for claim/ready
- that is confusing for first-run contributors and breaks the feel of the flow

## Verification
- node --test test/commands.test.js
- node --test test/gm.test.js
- git diff --check
- fresh temp-folder smoke prints claim/ready/accept commands with `--as internet-smoke`

## Risk
- existing scripts that copied old `game-manager` play commands should use the player handle now; GM mode remains available for manager-owned flows