### PR TITLE
fix(computer): replay completed exec results

### DIFF
--- a/commands/computer.js
+++ b/commands/computer.js
@@ -2550,34 +2550,56 @@ async function streamBusinessChatResult(token, ctx, executionId, rl = null, opti
 
       errors = 0;
       let done = false;
-      for (const event of (events.data?.events || [])) {
-        fromIndex++;
-        if (event.type === 'assistant_text' && event.content) {
-          sawVisibleOutput = true;
-          process.stdout.write(event.content);
-        } else if (event.type === 'result' && event.result && !sawVisibleOutput) {
-          sawVisibleOutput = true;
-          process.stdout.write(String(event.result));
-        } else if (!options.quiet && event.type === 'tool_use' && event.tool) {
-          const arg = event.input?.file_path || event.input?.path || event.input?.pattern || event.input?.command || '';
-          if (arg) {
-            console.log(`\n  [${event.tool}] ${String(arg).slice(0, 120)}`);
-          } else {
-            console.log(`\n  [${event.tool}]`);
+      const emitEvents = (items, { showTools = true } = {}) => {
+        let batchDone = false;
+        for (const event of (items || [])) {
+          if ((event.type === 'assistant_text' || event.type === 'text') && event.content) {
+            sawVisibleOutput = true;
+            process.stdout.write(event.content);
+          } else if (event.type === 'result' && event.result && !sawVisibleOutput) {
+            sawVisibleOutput = true;
+            process.stdout.write(String(event.result));
+          } else if (showTools && !options.quiet && event.type === 'tool_use' && event.tool) {
+            const arg = event.input?.file_path || event.input?.path || event.input?.pattern || event.input?.command || '';
+            if (arg) {
+              console.log(`\n  [${event.tool}] ${String(arg).slice(0, 120)}`);
+            } else {
+              console.log(`\n  [${event.tool}]`);
+            }
+          } else if (event.type === 'error') {
+            if (event.error) console.error(`\n${event.error}`);
+            terminalStatus = 'error';
+            batchDone = true;
+            break;
+          } else if (event.type === 'complete') {
+            terminalStatus = 'completed';
+            batchDone = true;
+            break;
           }
-        } else if (event.type === 'error') {
-          if (event.error) console.error(`\n${event.error}`);
-          terminalStatus = 'error';
-          done = true;
-          break;
-        } else if (event.type === 'complete') {
-          terminalStatus = 'completed';
-          done = true;
-          break;
         }
+        return batchDone;
+      };
+
+      const batch = events.data?.events || [];
+      done = emitEvents(batch);
+      const nextIndex = events.data?.next_index;
+      if (Number.isInteger(nextIndex) && nextIndex >= fromIndex) {
+        fromIndex = nextIndex;
+      } else {
+        fromIndex += batch.length;
       }
 
       if (done || ['completed', 'error', 'failed', 'cancelled'].includes(events.data?.status)) {
+        if (!sawVisibleOutput && events.data?.status === 'completed') {
+          const fullEvents = await apiRequestJson(
+            `/business/${ctx.businessId}/chat/events?execution_id=${executionId}&workspace_id=${ctx.workspaceId}&from_index=0`,
+            { method: 'GET', token, timeoutMs: 60000 }
+          );
+          if (fullEvents.ok) {
+            emitEvents(fullEvents.data?.events || [], { showTools: false });
+          }
+        }
+
         if (!process.stdout.write('\n')) {
           // no-op: keep line handling stable
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.15.56",
+  "version": "3.15.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.15.56",
+      "version": "3.15.57",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.15.56",
+  "version": "3.15.57",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/computer-create.test.js
+++ b/test/computer-create.test.js
@@ -33,6 +33,7 @@ function writeCredentials(home) {
 
 function startApiServer(requests) {
   let lastChatMessage = '';
+  let emptyDeltaReplayServed = false;
   const server = http.createServer((req, res) => {
     const chunks = [];
     req.on('data', (chunk) => chunks.push(chunk));
@@ -135,6 +136,15 @@ function startApiServer(requests) {
       if (req.method === 'GET' && req.url.startsWith('/api/business/biz-1/chat/events?')) {
         if (lastChatMessage.includes('FAIL_STREAM')) {
           send(200, { status: 'failed', events: [{ type: 'error', error: 'stream failed for test' }] });
+          return;
+        }
+        if (lastChatMessage.includes('EMPTY_DELTA_REFETCH')) {
+          if (!emptyDeltaReplayServed) {
+            emptyDeltaReplayServed = true;
+            send(200, { status: 'completed', events: [], next_index: 2 });
+            return;
+          }
+          send(200, { status: 'completed', events: [{ type: 'assistant_text', content: 'RECOVERED_RESULT' }, { type: 'complete' }], next_index: 2 });
           return;
         }
         const reply = lastChatMessage.includes('CHAT_OK') ? 'CHAT_OK' : '4';
@@ -741,6 +751,45 @@ test('computer exec waits and streams the business chat result by default', asyn
     assert.doesNotMatch(res.stdout, /Use the stream URL/);
     assert.ok(requests.some((request) => request.url.startsWith('/api/business/biz-1/chat/events?')));
     assert.ok(requests.some((request) => request.method === 'POST' && request.url === '/api/business/biz-1/chat' && request.body?.worker === 'claude'));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    cleanupTempDir(home);
+    cleanupTempDir(cwd);
+  }
+});
+
+test('computer exec replays buffered result when completed poll delta is empty', async () => {
+  const home = makeTempDir();
+  const cwd = makeTempDir();
+  const requests = [];
+  const server = await startApiServer(requests);
+  try {
+    writeCredentials(home);
+    const { port } = server.address();
+    const env = {
+      ...process.env,
+      HOME: home,
+      ATRIS_API_URL: `http://127.0.0.1:${port}/api`,
+      ATRIS_NO_INTERACTIVE: '1',
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+    };
+
+    const res = await runCliAsync([
+      'computer',
+      'exec',
+      '--business',
+      'atris-labs',
+      '--workspace',
+      'ws-new',
+      'EMPTY_DELTA_REFETCH',
+    ], { cwd, env });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /RECOVERED_RESULT/);
+    assert.doesNotMatch(res.stdout, /\(no result\)/);
+    const eventPolls = requests.filter((request) => request.url.startsWith('/api/business/biz-1/chat/events?'));
+    assert.equal(eventPolls.length, 2);
+    assert.ok(eventPolls.every((request) => request.url.includes('from_index=0')));
   } finally {
     await new Promise((resolve) => server.close(resolve));
     cleanupTempDir(home);


### PR DESCRIPTION
## Summary
- replay the full business chat event buffer when a completed poll page has no visible output
- use server next_index for polling progress instead of only incrementing by local delta length
- add a regression for empty completed delta followed by buffered assistant output
- bump package version to 3.15.57 so the fix can publish over npm latest 3.15.56

## Proof
- node --check commands/computer.js
- node --test test/computer-create.test.js
- git diff --check
- node --test test/commands.test.js test/computer-create.test.js
- npm view atris@3.15.57 version --json returns E404, so version is available

## Risk
- Low. Scoped to CLI result collection after terminal completion; no backend API contract or send side effects changed.