### PR TITLE
Codify task done AgentXP receipt policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ The manager path:
 atris gm --player justin
 ```
 
-No proof, no AgentXP. Human accept/revise is the gate before XP can count on
-the local card or hosted leaderboard.
+No proof, no AgentXP. `atris task done --proof` records review/RL context, but
+only human `atris task accept` mints Career XP for the local card or hosted
+leaderboard.
 
 ## Business Owners
 

--- a/commands/xp.js
+++ b/commands/xp.js
@@ -30,7 +30,11 @@ const EARNING_MODEL = {
   schema: 'atris.agentxp_earning_model.v1',
   score_name: AGENT_XP_LABEL,
   primary_public_source: 'accepted_task_receipt',
-  public_rule: 'No accepted proof-backed task episodes means no AgentXP leaderboard movement.',
+  public_rule: 'No human-accepted proof-backed task episodes means no AgentXP leaderboard movement.',
+  policies: {
+    task_done_with_proof: 'Records proof for review and RL context; emits no Career XP receipt until human accept.',
+    task_accept: 'Human accept with proof and positive reward is the Career XP receipt boundary.',
+  },
   weights: [
     {
       id: 'accepted_task_receipt',
@@ -674,6 +678,7 @@ function buildAtrisActionSignalFromRows(rows = []) {
     included_in_total_agent_xp: false,
     public_leaderboard: false,
     role: 'rl_routing_only',
+    note: 'Task done/finish proof can count here as non-public action context; Career XP still requires human accept.',
   };
 }
 

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4424,6 +4424,10 @@ test('task done with proof writes a reviewed proof event', () => {
     assert.equal(donePayload.episode.career_xp.eligible, false);
     assert.equal(donePayload.xp_projection.total_xp, 0);
     assert.equal(donePayload.xp_projection.collected_receipts, 0);
+    assert.equal(
+      donePayload.xp_projection.earning_model.policies.task_done_with_proof,
+      'Records proof for review and RL context; emits no Career XP receipt until human accept.',
+    );
 
     const show = runCli(['task', 'show', id, '--json'], { cwd: dir, env });
     assert.equal(show.status, 0, show.stderr);


### PR DESCRIPTION
## Summary
- Decide and codify the BCK-653 policy: task done/finish with proof records review/RL context only; it does not emit Career XP receipts.
- Add machine-readable earning model policies for task_done_with_proof and task_accept.
- Update README AgentXP path and pin the no-XP behavior with a regression assertion.

## Proof
- node --test --test-name-pattern "task done with proof|task accept automatically|AgentXP|xp status|business share" test/commands.test.js
- node --test test/commands.test.js
- node --check commands/xp.js
- git diff --check

## Decision
Human accept with proof and positive reward remains the Career XP receipt boundary. Proof-backed task done events remain useful non-public RL/action signals until accepted.