### PR TITLE
Guard always-on mission next actions

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -739,7 +739,8 @@ function runnerUsesCallerSession(runner) {
 }
 
 function nextCandidateTickAction(mission) {
-  return `next move: run atris mission run ${mission.id} --complete-on-pass`;
+  const completeFlag = mission.always_on ? '' : ' --complete-on-pass';
+  return `next move: run atris mission run ${mission.id}${completeFlag}`;
 }
 
 function missionVerifierPassed(mission) {
@@ -803,9 +804,17 @@ function selectDueMission(root = process.cwd(), now = new Date()) {
   return candidates[0] || null;
 }
 
+function missionSelectableForCodexGoal(mission, now = new Date()) {
+  if (!missionIsRunnable(mission)) return false;
+  if (mission.always_on && missionVerifierPassed(mission) && !missionDueAt(mission, now)) {
+    return parseCadenceSeconds(mission.cadence) > 0;
+  }
+  return true;
+}
+
 function selectCodexGoalMission(root = process.cwd(), now = new Date()) {
   const candidates = listMissions(root)
-    .filter((mission) => missionSelectableForLoop(mission, now));
+    .filter((mission) => missionSelectableForCodexGoal(mission, now));
 
   candidates.sort((a, b) => {
     const aCaller = runnerUsesCallerSession(a.runner) ? 1 : 0;
@@ -837,7 +846,8 @@ function codexGoalNextCommand(mission) {
     if (xpAction) return xpAction.replace(/^queue AgentXP review: /, '');
   }
   if (mission.verifier && missionDueAt(mission)) {
-    return 'atris mission run --due --max-ticks 1 --complete-on-pass';
+    const completeFlag = mission.always_on ? '' : ' --complete-on-pass';
+    return `atris mission run --due --max-ticks 1${completeFlag}`;
   }
   if (mission.verifier) {
     return `atris mission tick ${mission.id} --verify --summary "<what changed>"`;

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -197,6 +197,49 @@ test('mission status rejects invalid filters before listing history', () => {
   }
 });
 
+test('always-on mission next action does not suggest completion flag', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const started = runCli([
+      'mission',
+      'start',
+      'watchdog mission',
+      '--owner',
+      'mission-lead',
+      '--verify',
+      'node -e "process.exit(0)"',
+      '--always-on',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(started.status, 0, started.stderr || started.stdout);
+    const mission = JSON.parse(started.stdout).mission;
+    assert.match(mission.next_action, new RegExp(`atris mission run ${mission.id}`));
+    assert.doesNotMatch(mission.next_action, /--complete-on-pass/);
+
+    const goal = runCli(['mission', 'goal', '--json'], { cwd: dir });
+    assert.equal(goal.status, 0, goal.stderr || goal.stdout);
+    const goalPayload = JSON.parse(goal.stdout);
+    assert.equal(goalPayload.goal.mission_id, mission.id);
+    assert.equal(goalPayload.goal.next_command, 'atris mission run --due --max-ticks 1');
+
+    const heartbeat = runCli(['mission', 'goal', '--heartbeat', '--json'], { cwd: dir });
+    assert.equal(heartbeat.status, 0, heartbeat.stderr || heartbeat.stdout);
+    const heartbeatPayload = JSON.parse(heartbeat.stdout);
+    assert.equal(heartbeatPayload.goal.mission_id, mission.id);
+    assert.equal(heartbeatPayload.heartbeat.next_heavy_command, 'atris mission run --due --max-ticks 1');
+
+    const tick = runCli(['mission', 'tick', mission.id, '--verify', '--complete-on-pass', '--json'], { cwd: dir });
+    assert.equal(tick.status, 0, tick.stderr || tick.stdout);
+    const tickPayload = JSON.parse(tick.stdout);
+    assert.equal(tickPayload.mission.status, 'ready');
+    assert.match(tickPayload.mission.next_action, new RegExp(`atris mission run ${mission.id}`));
+    assert.doesNotMatch(tickPayload.mission.next_action, /--complete-on-pass/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('mission status normalizes stale terminal next actions', () => {
   const dir = makeTempDir();
   try {
@@ -798,7 +841,7 @@ test('always-on missions become due again after cadence even after verifier pass
       'node -e "process.exit(0)"',
       '--always-on',
       '--cadence',
-      '1s',
+      '1h',
       '--json',
     ], { cwd: dir });
     assert.equal(started.status, 0, started.stderr || started.stdout);
@@ -811,7 +854,15 @@ test('always-on missions become due again after cadence even after verifier pass
     assert.equal(firstPayload.mission.last_tick_index, 1);
     assert.equal(firstPayload.mission.verifier_result.passed, true);
 
-    const afterCadence = new Date(Date.parse(firstPayload.mission.last_tick_at) + 2000);
+    const heartbeat = runCli(['mission', 'goal', '--heartbeat', '--json'], { cwd: dir });
+    assert.equal(heartbeat.status, 0, heartbeat.stderr || heartbeat.stdout);
+    const heartbeatPayload = JSON.parse(heartbeat.stdout);
+    assert.equal(heartbeatPayload.goal.mission_id, firstPayload.mission.id);
+    assert.equal(heartbeatPayload.goal.reason, 'active');
+    assert.equal(heartbeatPayload.heartbeat.due, false);
+    assert.equal(heartbeatPayload.heartbeat.next_heavy_command, `atris mission tick ${firstPayload.mission.id} --verify --summary "<what changed>"`);
+
+    const afterCadence = new Date(Date.parse(firstPayload.mission.last_tick_at) + (60 * 60 * 1000) + 1000);
     const dueAgain = selectDueMission(dir, afterCadence);
     assert.equal(dueAgain.id, firstPayload.mission.id);
 


### PR DESCRIPTION
## Summary
- keep always-on mission next_action guidance on the recurring run command instead of suggesting --complete-on-pass
- add a regression test for always-on mission status/tick next_action behavior

## Tests
- node --check commands/mission.js
- git diff --check
- node --test test/mission-status.test.js
- node --test test/mission-status.test.js test/mission-xp.test.js

Backend tracking: BCK-660