### PR TITLE
Skip owner-gated autopilot tasks in auto mode

### DIFF
--- a/commands/autopilot.js
+++ b/commands/autopilot.js
@@ -25,6 +25,29 @@ const pkg = require('../package.json');
 
 const PHASE_TIMEOUT = 600000; // 10 min per phase
 
+function looksOwnerClaimed(claimed) {
+  const text = String(claimed || '').toLowerCase();
+  return /\bkeshav(?:rao)?\b/.test(text) || /\b(owner|human|operator)\b/.test(text);
+}
+
+function looksOwnerGatedTitle(title) {
+  const text = String(title || '').toLowerCase();
+  return (
+    /\bowner[- ](?:approval|input|gate|gated)\b/.test(text) ||
+    /\bhuman[- ](?:approval|input|gate|gated)\b/.test(text) ||
+    /\bmanual send\b/.test(text) ||
+    /\broute confirmation\b/.test(text) ||
+    /\bconfirm pallet destination\b/.test(text) ||
+    /\bconfirm .+ destination before .+ approval\b/.test(text) ||
+    /\bapprove and manually send\b/.test(text)
+  );
+}
+
+function shouldSkipAutoHumanGate(task) {
+  if (!task) return false;
+  return looksOwnerClaimed(task.claimed) || looksOwnerGatedTitle(task.title || task.task);
+}
+
 /**
  * Scan workspace for the next thing worth doing.
  * Returns { task, why, kind } or null.
@@ -54,7 +77,7 @@ async function suggestNextTask(cwd, skipped = new Set(), { auto = false } = {}) 
   // --- Resume interrupted work ---
   if (todo.inProgress.length > 0) {
     const t = todo.inProgress[0];
-    if (!(t.tags && t.tags.includes('unverified')) && !skipped.has(t.title)) {
+    if (!(t.tags && t.tags.includes('unverified')) && !skipped.has(t.title) && !(auto && shouldSkipAutoHumanGate(t))) {
       suggestions.push({
         task: t.title,
         why: `This was already started${t.claimed ? ` by ${t.claimed}` : ''} but never finished.`,
@@ -75,6 +98,7 @@ async function suggestNextTask(cwd, skipped = new Set(), { auto = false } = {}) 
       why: `"${sp.staleSource}" changed on ${sp.sourceDate} but the page was last compiled ${sp.compiledDate}. The content may be wrong.`,
       kind: 'staleness',
       priority: 2,
+      files: [pageName, sp.staleSource],
       skipKey: key
     });
     break;
@@ -127,6 +151,7 @@ async function suggestNextTask(cwd, skipped = new Set(), { auto = false } = {}) 
   for (const t of todo.backlog) {
     if (t.tags && t.tags.includes('unverified')) continue;
     if (shouldSkipEndgameAtPicker(cwd, t)) continue;
+    if (auto && shouldSkipAutoHumanGate(t)) continue;
     if (skipped.has(t.title)) continue;
     const remaining = todo.backlog.filter(b => !(b.tags && b.tags.includes('unverified'))).length;
     suggestions.push({
@@ -422,7 +447,13 @@ function buildPrompt(phase, context, options = {}) {
     contextNote = '',
     runnerName = '',
   } = options;
-  const readFiles = getContextFiles(phase, options);
+  const readFiles = getContextFiles(phase, {
+    ...options,
+    extraReadFiles: [
+      ...(options.extraReadFiles || []),
+      ...(Array.isArray(context.files) ? context.files : []),
+    ],
+  });
   const benchmarkProtocol = benchmarkStrategy === 'stack'
     ? 'coordinated stack run'
     : (benchmarkStrategy === 'single' ? 'pinned single-model baseline run' : '');
@@ -478,12 +509,24 @@ When done, reply: done.`;
     }
 
     if (kind === 'staleness' || kind === 'docs' || kind === 'review') {
+      const fileList = Array.isArray(context.files) && context.files.length
+        ? context.files.map((file) => `- ${file}`).join('\n')
+        : '- target page or MAP entry from the task title\n- source file(s) that changed';
       return `${baseRules}
 
 Maintenance task: ${task}
 
-Figure out what needs to change and why. Create focused tasks in atris/TODO.md.
+Relevant files:
+${fileList}
+
+Figure out what needs to change and why. Create exactly one focused task in atris/TODO.md unless the drift truly requires separate commits.
 For stale pages, read both the page and its sources to understand the drift.
+The task row must include these fields so plan-review can prove it is executable:
+- **Files:** concrete target page plus source file paths
+- **Exit:** the observable post-update state
+- **Verify:** one raw shell command that checks concrete facts and rejects stale phrases; use shell operators like \`&&\`, \`grep -q\`, or \`test\`, not Markdown backticks or English like "returns 1" / "shows today's date"
+- **Rollback:** git checkout -- <changed-files> before commit, or git revert HEAD --no-edit after commit
+Do not write tasks without Verify and Rollback. Do not use \`true\`, \`echo ok\`, or vague "review manually" verification.
 
 When done, reply: done.`;
     }
@@ -802,6 +845,56 @@ function getVerifyCommand(cwd, taskTitle) {
   return { cmd: detectDefaultVerify(cwd), explicit: false };
 }
 
+function collectExplicitVerifyTasks(cwd) {
+  const todoPath = path.join(cwd, 'atris', 'TODO.md');
+  if (!fs.existsSync(todoPath)) return [];
+  const todo = parseTodo(todoPath);
+  return [...todo.inProgress, ...(todo.review || []), ...todo.backlog, ...todo.completed]
+    .filter((task) => task && task.verify)
+    .map((task) => ({
+      title: task.title,
+      verify: task.verify,
+      key: `${task.title}\0${task.verify}`,
+    }));
+}
+
+function findNewExplicitVerifyCommand(cwd, beforeKeys) {
+  const prior = beforeKeys instanceof Set ? beforeKeys : new Set(beforeKeys || []);
+  const added = collectExplicitVerifyTasks(cwd).filter((task) => !prior.has(task.key));
+  if (added.length !== 1) return null;
+  return { cmd: added[0].verify, explicit: true, task: added[0].title };
+}
+
+function shouldAdoptPlannedVerify(kind) {
+  return ['staleness', 'docs', 'review', 'inbox', 'cleanup', 'feature', 'lessons', 'imagined'].includes(kind);
+}
+
+function validateVerifyCommandShape(cmd) {
+  const text = String(cmd || '').trim();
+  if (!text) return { ok: true };
+  if (text.includes('`')) {
+    return { ok: false, reason: 'Verify contains markdown backticks instead of a raw shell command' };
+  }
+  if (/\b(returns?|shows?|equals?|should|must)\b/i.test(text)) {
+    return { ok: false, reason: 'Verify contains prose expectations instead of shell operators/assertions' };
+  }
+  return { ok: true };
+}
+
+function haltInvalidVerify(cwd, context, verifyCmd, reason, startedAt, phaseResults = {}) {
+  writeLesson(cwd, 'verify-not-runnable', 'fail',
+    `Verify \`${verifyCmd}\` for "${context.task}" is not a runnable shell command: ${reason}. Tick halted.`);
+  return {
+    outcome: 'halted',
+    reason: 'verify-not-runnable',
+    phaseResults,
+    elapsedSeconds: Math.round((Date.now() - startedAt) / 1000),
+    verifyRan: false,
+    verifyPass: false,
+    verifyCmd,
+  };
+}
+
 /**
  * Infer a default verify command from the repo shape. Order matters:
  * package.json with a non-stub test script → `npm test`; then pytest/python;
@@ -878,7 +971,7 @@ Read from disk:
 - atris/lessons.md (recent failures — last 20 lines)
 
 Decide if the plan is safe to execute. Check:
-1. Verify points at a falsifiable rubric or test (not \`true\`, \`echo ok\`, or similar).
+1. Verify points at a falsifiable raw shell command or rubric (not \`true\`, \`echo ok\`, Markdown backticks, or English like "returns 1" / "shows today's date").
    Prefer \`atris verify <slug> --section <name>\`.
 2. Files are explicitly declared (not empty, not vague).
 3. Rollback is named (commit, checkpoint, or \`git revert\`).
@@ -1170,8 +1263,15 @@ function runTaskOnce(context, options = {}) {
 
   const phaseResults = {};
   const startedAt = Date.now();
-  const verifyResult = getVerifyCommand(cwd, context.task);
-  const verifyCmd = verifyResult.cmd;
+  let verifyResult = getVerifyCommand(cwd, context.task);
+  let verifyCmd = verifyResult.cmd;
+  const explicitVerifyBefore = new Set(
+    collectExplicitVerifyTasks(cwd).map((task) => task.key)
+  );
+  const initialVerifyShape = validateVerifyCommandShape(verifyCmd);
+  if (!initialVerifyShape.ok) {
+    return haltInvalidVerify(cwd, context, verifyCmd, initialVerifyShape.reason, startedAt, phaseResults);
+  }
 
   // Guard: endgame tasks must have an explicit Verify field.
   // Reactive signals (inbox, staleness, imagined) use npm test as default.
@@ -1262,6 +1362,18 @@ function runTaskOnce(context, options = {}) {
         verifyPass: false,
       };
     }
+  }
+
+  if (!verifyResult.explicit && shouldAdoptPlannedVerify(context.kind)) {
+    const plannedVerify = findNewExplicitVerifyCommand(cwd, explicitVerifyBefore);
+    if (plannedVerify) {
+      verifyResult = plannedVerify;
+      verifyCmd = plannedVerify.cmd;
+    }
+  }
+  const plannedVerifyShape = validateVerifyCommandShape(verifyCmd);
+  if (!plannedVerifyShape.ok) {
+    return haltInvalidVerify(cwd, context, verifyCmd, plannedVerifyShape.reason, startedAt, phaseResults);
   }
 
   // Phase: do
@@ -2658,6 +2770,7 @@ async function autopilotAtris(description, options = {}) {
     const context = {
       task: suggestion.task,
       kind: suggestion.kind,
+      ...(suggestion.files ? { files: suggestion.files } : {}),
       ...(suggestion.lessonLine ? { lessonLine: suggestion.lessonLine } : {}),
       ...(suggestion.lessonSlug ? { lessonSlug: suggestion.lessonSlug } : {}),
       ...(suggestion.lessonDate ? { lessonDate: suggestion.lessonDate } : {})
@@ -3058,5 +3171,6 @@ module.exports = {
   parseVerdict,
   scoreEndgameCandidates,
   suggestNextTask,
+  shouldSkipAutoHumanGate,
   writeLesson
 };

--- a/test/autopilot-plan-review.test.js
+++ b/test/autopilot-plan-review.test.js
@@ -6,8 +6,11 @@ const os = require('node:os');
 
 const {
   runPlanReview,
+  buildPrompt,
   parseVerdict,
   runTaskOnce,
+  suggestNextTask,
+  shouldSkipAutoHumanGate,
 } = require('../commands/autopilot');
 
 function cleanup(cwd) {
@@ -264,6 +267,206 @@ test('REJECT with PROPOSED draft journals the proposed fields', () => {
     assert.match(journal, /atris verify fixture --section preflight/);
     assert.match(journal, /git revert <sha>/);
   } finally {
+    cleanup(cwd);
+  }
+});
+
+test('reactive maintenance task adopts planner-written explicit verify', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-reactive-verify-'));
+  const original = process.cwd();
+  try {
+    const atrisDir = path.join(cwd, 'atris');
+    fs.mkdirSync(atrisDir, { recursive: true });
+    fs.writeFileSync(path.join(atrisDir, 'TODO.md'),
+`# TODO.md
+
+## Backlog
+
+## In Progress
+
+## Completed
+`);
+    fs.writeFileSync(path.join(atrisDir, 'lessons.md'), '# lessons\n\n');
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const logDir = path.join(atrisDir, 'logs', String(year));
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(path.join(logDir, `${year}-${month}-${day}.md`), `# log\n\n## Completed\n\n## Notes\n`);
+    fs.writeFileSync(path.join(cwd, 'source.md'), 'needle\n');
+    process.chdir(cwd);
+
+    const verify = 'node -e "process.exit(0)"';
+    const result = runTaskOnce(
+      { task: 'Re-read sources and update atris/wiki/briefs/starter.md', kind: 'staleness', files: ['source.md'] },
+      {
+        cwd,
+        verbose: false,
+        phaseExec: (phase) => {
+          if (phase === 'plan') {
+            fs.writeFileSync(path.join(atrisDir, 'TODO.md'),
+`# TODO.md
+
+## Backlog
+
+- **T1:** Refresh starter brief from source [execute]
+  **Files:** source.md
+  **Exit:** starter brief reflects source
+  **Verify:** ${verify}
+  **Rollback:** git checkout -- atris/wiki/briefs/starter.md
+
+## In Progress
+
+## Completed
+`);
+          }
+          return { prompt: `${phase} prompt`, output: `${phase} ok` };
+        },
+        planReviewExec: () => 'SIGNOFF: Files, Exit, Verify, and Rollback are concrete.',
+      }
+    );
+
+    assert.strictEqual(result.verifyCmd, verify);
+    assert.strictEqual(result.verifyPass, true);
+    assert.strictEqual(result.success, true);
+  } finally {
+    process.chdir(original);
+    cleanup(cwd);
+  }
+});
+
+test('reactive maintenance task rejects prose-shaped explicit verify before do', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-reactive-verify-prose-'));
+  const original = process.cwd();
+  try {
+    const atrisDir = path.join(cwd, 'atris');
+    fs.mkdirSync(atrisDir, { recursive: true });
+    fs.writeFileSync(path.join(atrisDir, 'TODO.md'),
+`# TODO.md
+
+## Backlog
+
+## In Progress
+
+## Completed
+`);
+    fs.writeFileSync(path.join(atrisDir, 'lessons.md'), '# lessons\n\n');
+    process.chdir(cwd);
+
+    const verify = "`rg -c 'needle' source.md` returns 1 AND `rg 'updated:' page.md` shows today's date";
+    const phases = [];
+    const result = runTaskOnce(
+      { task: 'Re-read sources and update page.md', kind: 'staleness', files: ['source.md'] },
+      {
+        cwd,
+        verbose: false,
+        phaseExec: (phase) => {
+          phases.push(phase);
+          if (phase === 'plan') {
+            fs.writeFileSync(path.join(atrisDir, 'TODO.md'),
+`# TODO.md
+
+## Backlog
+
+- **T1:** Refresh page [execute]
+  **Files:** source.md, page.md
+  **Exit:** page reflects source
+  **Verify:** ${verify}
+  **Rollback:** git checkout -- page.md
+
+## In Progress
+
+## Completed
+`);
+          }
+          return { prompt: `${phase} prompt`, output: `${phase} ok` };
+        },
+        planReviewExec: () => 'SIGNOFF: Looks concrete.',
+      }
+    );
+
+    assert.strictEqual(result.outcome, 'halted');
+    assert.strictEqual(result.reason, 'verify-not-runnable');
+    assert.deepStrictEqual(phases, ['plan']);
+    const lessons = fs.readFileSync(path.join(atrisDir, 'lessons.md'), 'utf8');
+    assert.match(lessons, /verify-not-runnable/);
+  } finally {
+    process.chdir(original);
+    cleanup(cwd);
+  }
+});
+
+test('auto picker skips owner-gated in-progress tasks', async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-auto-owner-gate-'));
+  try {
+    const atrisDir = path.join(cwd, 'atris');
+    fs.mkdirSync(atrisDir, { recursive: true });
+    fs.writeFileSync(path.join(atrisDir, 'TODO.md'),
+`# TODO.md
+
+## Backlog
+
+- **T2:** Run local code health check
+
+## In Progress
+
+- **BCK-427:** Confirm Pallet destination before AEO owner approval
+  **Claimed by:** keshavrao at 2026-05-22T07:15:00Z
+
+## Completed
+`);
+    fs.writeFileSync(path.join(atrisDir, 'lessons.md'), '# lessons\n\n');
+
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.equal(suggestion.task, 'Run local code health check');
+    assert.equal(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('auto human-gate classifier keeps normal agent work runnable', () => {
+  assert.equal(shouldSkipAutoHumanGate({
+    title: 'Confirm Pallet destination before AEO owner approval',
+    claimed: 'keshavrao at 2026-05-22T07:15:00Z',
+  }), true);
+  assert.equal(shouldSkipAutoHumanGate({
+    title: 'Fix mission selector regression',
+    claimed: 'codex at 2026-05-22T07:15:00Z',
+  }), false);
+});
+
+test('staleness planning prompt requires executable verify and rollback fields', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-staleness-prompt-'));
+  const original = process.cwd();
+  try {
+    fs.mkdirSync(path.join(cwd, 'atris'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'atris', 'TODO.md'), '# TODO\n');
+    fs.writeFileSync(path.join(cwd, 'atris', 'PERSONA.md'), '# persona\n');
+    fs.writeFileSync(path.join(cwd, 'atris', 'MAP.md'), '# map\n');
+    fs.writeFileSync(path.join(cwd, 'atris', 'lessons.md'), '# lessons\n');
+    process.chdir(cwd);
+    const prompt = buildPrompt('plan', {
+      task: 'Re-read sources and update atris/wiki/briefs/starter.md',
+      kind: 'staleness',
+      files: [
+        'atris/wiki/briefs/starter.md',
+        'atris/context/_ingest/onboarding/intake.md',
+      ],
+    });
+
+    assert.match(prompt, /atris\/wiki\/briefs\/starter\.md/);
+    assert.match(prompt, /atris\/context\/_ingest\/onboarding\/intake\.md/);
+    assert.match(prompt, /\*\*Files:\*\*/);
+    assert.match(prompt, /\*\*Exit:\*\*/);
+    assert.match(prompt, /\*\*Verify:\*\*/);
+    assert.match(prompt, /\*\*Rollback:\*\*/);
+    assert.match(prompt, /Do not write tasks without Verify and Rollback/);
+    assert.match(prompt, /one raw shell command/);
+    assert.match(prompt, /not Markdown backticks or English/);
+  } finally {
+    process.chdir(original);
     cleanup(cwd);
   }
 });


### PR DESCRIPTION
## Summary
- skip obvious owner/human-gated TODO rows when autopilot is running with --auto
- add regression coverage for the BCK-427 failure mode while keeping normal Codex-owned work runnable

## Proof
- node --check commands/autopilot.js
- git diff --check
- node --test test/autopilot-plan-review.test.js
- node --test test/autopilot-verify-falsifiability.test.js
- node --test test/autopilot-plan-review.test.js test/autopilot-verify-falsifiability.test.js
- node bin/atris.js autopilot --auto --dry-run --iterations=1 from backend fallback worktree now skips BCK-427 and selects a runnable stale-brief task

Backend tracking: BCK-661