### PR TITLE
Trust clean MAP audit in autopilot picker

### DIFF
--- a/commands/autopilot.js
+++ b/commands/autopilot.js
@@ -48,6 +48,23 @@ function shouldSkipAutoHumanGate(task) {
   return looksOwnerClaimed(task.claimed) || looksOwnerGatedTitle(task.title || task.task);
 }
 
+function repoMapAuditReportsClean(cwd) {
+  const auditPath = path.join(cwd, 'scripts', 'audit_map_refs.py');
+  if (!fs.existsSync(auditPath)) return false;
+
+  const result = spawnSync('python3', [auditPath], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 120000,
+    maxBuffer: 1024 * 1024
+  });
+  if (result.status !== 0) return false;
+
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+  const match = output.match(/Total broken references:\s*(\d+)/i);
+  return Boolean(match && Number(match[1]) === 0);
+}
+
 /**
  * Scan workspace for the next thing worth doing.
  * Returns { task, why, kind } or null.
@@ -119,7 +136,9 @@ async function suggestNextTask(cwd, skipped = new Set(), { auto = false } = {}) 
   }
 
   // --- Broken MAP.md references ---
-  const { unhealable } = healBrokenMapRefs(cwd, atrisDir, true); // dry-run
+  const { unhealable } = repoMapAuditReportsClean(cwd)
+    ? { unhealable: [] }
+    : healBrokenMapRefs(cwd, atrisDir, true); // dry-run
   if (unhealable.length > 0 && !skipped.has('fix-map-refs')) {
     const sample = unhealable.slice(0, 3).map(r => `${r.file}:${r.line}`).join(', ');
     suggestions.push({
@@ -3165,6 +3184,7 @@ module.exports = {
   proposeCandidateHorizons,
   recordTickCommit,
   regressionCheck,
+  repoMapAuditReportsClean,
   runPlanReview,
   runTaskOnce,
   buildPlanReviewPrompt,

--- a/test/autopilot-plan-review.test.js
+++ b/test/autopilot-plan-review.test.js
@@ -426,6 +426,45 @@ test('auto picker skips owner-gated in-progress tasks', async () => {
   }
 });
 
+test('auto picker trusts clean repo MAP audit over healer false positives', async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-auto-map-audit-'));
+  try {
+    const atrisDir = path.join(cwd, 'atris');
+    fs.mkdirSync(atrisDir, { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(atrisDir, 'TODO.md'),
+`# TODO.md
+
+## Backlog
+
+- **T2:** Run local code health check
+
+## In Progress
+
+## Completed
+`);
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'),
+`# MAP
+
+\`\`\`
+RL Stack (backend/rl/)
+  core.py:17    TaskType enum
+\`\`\`
+`);
+    fs.writeFileSync(path.join(cwd, 'scripts', 'audit_map_refs.py'),
+`#!/usr/bin/env python3
+print("Total broken references: 0")
+`);
+    fs.writeFileSync(path.join(atrisDir, 'lessons.md'), '# lessons\n\n');
+
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.equal(suggestion.task, 'Run local code health check');
+    assert.equal(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
 test('auto human-gate classifier keeps normal agent work runnable', () => {
   assert.equal(shouldSkipAutoHumanGate({
     title: 'Confirm Pallet destination before AEO owner approval',


### PR DESCRIPTION
## Summary
- make autopilot suppress broken-MAP suggestions when a workspace's own scripts/audit_map_refs.py reports zero broken references
- add regression coverage for healer false positives like core.py:17 inside a contextual MAP block

## Verification
- git diff --check
- node --test test/autopilot-plan-review.test.js
- node --test test/autopilot-plan-review.test.js test/clean-heal.test.js
- backend reproduction with patched suggestNextTask no longer selects stale Fix 142 broken references in MAP.md