### PR TITLE
Skip stale verifier lessons in autopilot self-heal

### DIFF
--- a/commands/autopilot.js
+++ b/commands/autopilot.js
@@ -2291,14 +2291,45 @@ function isLessonResolved(lessonLine, cwd, options = {}) {
   if (!slugMatch) return false;
   const slug = slugMatch[1];
 
+  if (isCleanMapBrokenRefFailLesson(lessonLine, cwd)) return true;
+
   // Detector-backed check (typed lesson sidecar)
   const meta = options.meta || loadLessonMetadata(cwd)[slug];
   if (meta && meta.detector) {
     return runLessonDetector(meta.detector, cwd, options.detectorTimeout);
   }
 
+  if (inlinePythonVerifyFailureNowPasses(lessonLine, cwd, options.detectorTimeout)) return true;
+
   // Legacy fallback: keyword grep against referenced files.
   return isLessonResolvedLegacy(lessonLine, cwd);
+}
+
+function isCleanMapBrokenRefFailLesson(lessonLine, cwd) {
+  const text = String(lessonLine || '').toLowerCase();
+  if (!/fix \d+ broken references? in map\.md/.test(text)) return false;
+  return repoMapAuditReportsClean(cwd);
+}
+
+function extractInlinePythonVerifyFailure(lessonLine) {
+  const match = String(lessonLine || '').match(/Verify command\s+``(python3?)\s+-c\s+(["'])([\s\S]*?)\2``\s+failed/i);
+  if (!match) return null;
+  return {
+    executable: match[1],
+    code: match[3].replace(/\\"/g, '"').replace(/\\'/g, "'")
+  };
+}
+
+function inlinePythonVerifyFailureNowPasses(lessonLine, cwd, timeout = 10000) {
+  const parsed = extractInlinePythonVerifyFailure(lessonLine);
+  if (!parsed) return false;
+  const result = spawnSync(parsed.executable, ['-c', parsed.code], {
+    cwd,
+    encoding: 'utf8',
+    timeout,
+    stdio: ['ignore', 'ignore', 'ignore']
+  });
+  return result.status === 0;
 }
 
 /**
@@ -2405,6 +2436,8 @@ function pickUnresolvedFailLesson(cwd) {
   const candidates = [];
   for (const lesson of lessons) {
     if (lesson.verdict !== 'fail') continue;
+    if (lesson.id === 'verify-not-falsifiable') continue;
+    if (lesson.id === 'verify-failed' && lesson.legacy) continue;
     if (lesson.resolvedTag) continue;
     // Typed lesson with explicit status wins — respect the sidecar.
     // `resolved` = done. `observed` = process rule, not a fixable code state.
@@ -3185,6 +3218,8 @@ module.exports = {
   recordTickCommit,
   regressionCheck,
   repoMapAuditReportsClean,
+  isCleanMapBrokenRefFailLesson,
+  inlinePythonVerifyFailureNowPasses,
   runPlanReview,
   runTaskOnce,
   buildPlanReviewPrompt,

--- a/test/autopilot-verify-falsifiability.test.js
+++ b/test/autopilot-verify-falsifiability.test.js
@@ -185,6 +185,70 @@ test('picker does not downgrade recently pre-passed endgame tasks into backlog',
   }
 });
 
+test('picker skips stale MAP verify-failed lesson when repo audit is clean', async () => {
+  const cwd = setupPickerFixture({
+    lesson: '# lessons\n\n---\n\n- **[2026-04-29] verify-failed** — fail — Task "Fix 118 broken references in MAP.md" passed review but failed verify command.\n',
+  });
+  try {
+    fs.mkdirSync(path.join(cwd, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'scripts', 'audit_map_refs.py'),
+`#!/usr/bin/env python3
+print("Total broken references: 0")
+`);
+
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.strictEqual(suggestion.task, 'Safe generic task');
+    assert.strictEqual(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('picker does not promote verify-not-falsifiable lessons to self-heal work', async () => {
+  const cwd = setupPickerFixture({
+    lesson: '# lessons\n\n---\n\n- **[2026-04-29] verify-not-falsifiable** — fail — Verify `true` passed before work started on "Old shipped task". Either the rubric is trivial or the task is already done. Tick halted.\n',
+  });
+  try {
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.strictEqual(suggestion.task, 'Safe generic task');
+    assert.strictEqual(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('picker does not promote legacy verify-failed receipts to self-heal work', async () => {
+  const cwd = setupPickerFixture({
+    lesson: '# lessons\n\n---\n\n- **[2026-04-29] verify-failed** — fail — Task "Capture rejection path". Touch `backend/rl/etl/action_queue_to_trajectories.py`. Verify command failed.\n',
+  });
+  try {
+    const sourcePath = path.join(cwd, 'backend', 'rl', 'etl', 'action_queue_to_trajectories.py');
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(sourcePath, '# failed verify wording in an unrelated comment\n');
+
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.strictEqual(suggestion.task, 'Safe generic task');
+    assert.strictEqual(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('picker replays passing inline python verify failures before self-heal', async () => {
+  const cwd = setupPickerFixture({
+    lesson: "# lessons\n\n---\n\n- **[2026-04-29] verify-fail-doc-edit-attribution** — fail — Verify command ``python3 -c \"open('proof.txt').read(); assert True\"`` failed: Command failed.\n",
+  });
+  try {
+    fs.writeFileSync(path.join(cwd, 'proof.txt'), 'now present\n');
+
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.strictEqual(suggestion.task, 'Safe generic task');
+    assert.strictEqual(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
 // verifyRubric command tests: the new machine-checkable Verify shape.
 test('verifyRubric extracts and runs a passing fenced bash block', () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-rubric-test-'));


### PR DESCRIPTION
## Summary
- resolve old broken-MAP verify-failed lessons when the repo MAP audit is clean
- skip verifier-gate tombstones like verify-not-falsifiable and legacy generic verify-failed receipts as self-heal work
- replay cheap inline Python verify-fail commands before treating them as unresolved

## Verification
- git diff --check
- node --test test/autopilot-verify-falsifiability.test.js test/autopilot-plan-review.test.js test/clean-heal.test.js
- backend reproduction with patched suggestNextTask skips stale MAP and generic verifier tombstones and reaches the next specific self-heal candidate