### PR TITLE
Replay embedded verifier assertions in autopilot

### DIFF
--- a/commands/autopilot.js
+++ b/commands/autopilot.js
@@ -2312,7 +2312,10 @@ function isCleanMapBrokenRefFailLesson(lessonLine, cwd) {
 }
 
 function extractInlinePythonVerifyFailure(lessonLine) {
-  const match = String(lessonLine || '').match(/Verify command\s+``(python3?)\s+-c\s+(["'])([\s\S]*?)\2``\s+failed/i);
+  const commandMatch = String(lessonLine || '').match(/Verify command\s+``([\s\S]*?)``\s+failed/i);
+  if (!commandMatch) return null;
+  const matches = [...commandMatch[1].matchAll(/\b(python3?)\s+-c\s+(["'])([\s\S]*?)\2/g)];
+  const match = matches[matches.length - 1];
   if (!match) return null;
   return {
     executable: match[1],
@@ -2355,11 +2358,11 @@ function isLessonResolvedLegacy(lessonLine, cwd) {
     }
   }
 
-  if (fileRefs.length === 0) return false;
+  if (fileRefs.length === 0) return true;
 
   // Derive keywords from slug (split on dashes, drop short words)
   const keywords = slug.split('-').filter(w => w.length > 2);
-  if (keywords.length === 0) return false;
+  if (keywords.length === 0) return true;
 
   // Grep each named file for any keyword. If at least one file still matches → not resolved.
   for (const ref of fileRefs) {
@@ -2437,6 +2440,7 @@ function pickUnresolvedFailLesson(cwd) {
   for (const lesson of lessons) {
     if (lesson.verdict !== 'fail') continue;
     if (lesson.id === 'verify-not-falsifiable') continue;
+    if (lesson.id === 'no-verify-field') continue;
     if (lesson.id === 'verify-failed' && lesson.legacy) continue;
     if (lesson.resolvedTag) continue;
     // Typed lesson with explicit status wins — respect the sidecar.

--- a/test/autopilot-verify-falsifiability.test.js
+++ b/test/autopilot-verify-falsifiability.test.js
@@ -217,6 +217,32 @@ test('picker does not promote verify-not-falsifiable lessons to self-heal work',
   }
 });
 
+test('picker does not promote no-verify-field lessons to self-heal work', async () => {
+  const cwd = setupPickerFixture({
+    lesson: '# lessons\n\n---\n\n- **[2026-05-04] no-verify-field** — fail — Task "Old shipped task" has no explicit **Verify:** field in TODO.md. Tick halted.\n',
+  });
+  try {
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.strictEqual(suggestion.task, 'Safe generic task');
+    assert.strictEqual(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('picker does not promote ungrounded legacy fail lessons to self-heal work', async () => {
+  const cwd = setupPickerFixture({
+    lesson: '# lessons\n\n---\n\n- **[2026-05-04] codex-cli-hangs-on-substantive-prompts** — fail — codex exec hangs on substantive prompts; cause unknown.\n',
+  });
+  try {
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.strictEqual(suggestion.task, 'Safe generic task');
+    assert.strictEqual(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
 test('picker does not promote legacy verify-failed receipts to self-heal work', async () => {
   const cwd = setupPickerFixture({
     lesson: '# lessons\n\n---\n\n- **[2026-04-29] verify-failed** — fail — Task "Capture rejection path". Touch `backend/rl/etl/action_queue_to_trajectories.py`. Verify command failed.\n',
@@ -237,6 +263,21 @@ test('picker does not promote legacy verify-failed receipts to self-heal work', 
 test('picker replays passing inline python verify failures before self-heal', async () => {
   const cwd = setupPickerFixture({
     lesson: "# lessons\n\n---\n\n- **[2026-04-29] verify-fail-doc-edit-attribution** — fail — Verify command ``python3 -c \"open('proof.txt').read(); assert True\"`` failed: Command failed.\n",
+  });
+  try {
+    fs.writeFileSync(path.join(cwd, 'proof.txt'), 'now present\n');
+
+    const suggestion = await suggestNextTask(cwd, new Set(), { auto: true });
+    assert.strictEqual(suggestion.task, 'Safe generic task');
+    assert.strictEqual(suggestion.kind, 'backlog');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('picker replays embedded inline python assertion in compound verify failure', async () => {
+  const cwd = setupPickerFixture({
+    lesson: "# lessons\n\n---\n\n- **[2026-04-29] verify-fail-doc-edit-attribution-compound** — fail — Verify command ``echo preflight && python3 -c \"open('proof.txt').read(); assert True\" && echo done`` failed: Command failed.\n",
   });
   try {
     fs.writeFileSync(path.join(cwd, 'proof.txt'), 'now present\n');


### PR DESCRIPTION
## Summary
- make legacy lesson resolution treat no-file-reference fail lessons as non-actionable
- replay the last embedded python3 -c verifier assertion inside compound verify-fail commands before selecting self-heal work
- skip no-verify-field gate tombstones as self-heal candidates

## Verification
- git diff --check
- node --test test/autopilot-verify-falsifiability.test.js test/autopilot-plan-review.test.js test/clean-heal.test.js
- backend reproduction with patched suggestNextTask now reaches concrete orphan TODO work instead of stale MAP/verifier lesson noise