### PR TITLE
Ignore archived TODOs in autopilot scan

### DIFF
--- a/commands/autopilot.js
+++ b/commands/autopilot.js
@@ -2106,12 +2106,13 @@ function findCodeTodos(cwd) {
   try {
     const out = execFileSync('git', [
       'grep', '-n', '-I', '-E', '(TODO|FIXME)',
-      '--', ':!test/', ':!node_modules/', ':!atris/', ':!**/*.md'
+      '--', ':!test/', ':!node_modules/', ':!atris/', ':!**/_archive/**', ':!**/*.md'
     ], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
     const results = [];
     for (const raw of out.split('\n').filter(Boolean)) {
       const m = raw.match(/^([^:]+):(\d+):(.*)$/);
       if (!m) continue;
+      if (m[1].split(/[\\/]/).includes('_archive')) continue;
       const line = m[3];
       // A real TODO is a comment marker at the start of the line (allowing
       // leading indent) followed by TODO/FIXME and at least one word. This

--- a/test/scan-anomalies.test.js
+++ b/test/scan-anomalies.test.js
@@ -63,17 +63,18 @@ test('findCodeTodos finds // TODO in JS source', () => {
   }
 });
 
-test('findCodeTodos skips test/ and atris/ directories', () => {
+test('findCodeTodos skips test/, atris/, and _archive directories', () => {
   const dir = makeGitRepo();
   try {
     fs.mkdirSync(path.join(dir, 'test'), { recursive: true });
     commit(dir, 'init', {
       'commands/foo.js': 'const x = 1;\n',
       'test/foo.test.js': '// TODO: add more tests\n',
-      'atris/MAP.md': '# TODO: refresh MAP\n'
+      'atris/MAP.md': '# TODO: refresh MAP\n',
+      'backend/_archive/dead_code.py': '# TODO: delete later\n'
     });
     const todos = findCodeTodos(dir);
-    assert.equal(todos.length, 0, 'test/ and atris/ should be skipped');
+    assert.equal(todos.length, 0, 'test/, atris/, and _archive should be skipped');
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- exclude _archive paths from autopilot's orphan TODO scanner
- keep a defensive path-component filter so archived TODOs do not outrank live code work

## Verification
- git diff --check
- node --test test/scan-anomalies.test.js test/autopilot-verify-falsifiability.test.js
- backend reproduction: findCodeTodos count 16, archiveCount 0; suggestNextTask now starts with live backend/clients/chatgpt.py TODOs