### PR TITLE
Use task DB counts in Atris boot card

### DIFF
--- a/lib/state-detection.js
+++ b/lib/state-detection.js
@@ -1,6 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 
+const TASK_STATUS_BUCKETS = {
+  backlog: new Set(['open']),
+  inProgress: new Set(['claimed']),
+  completed: new Set(['done', 'failed'])
+};
+
 function isFeatureInProgress(ideaContent) {
   if (!ideaContent || typeof ideaContent !== 'string') return false;
   return /\*\*Status:\*\*\s*in-progress\b/i.test(ideaContent) || /\bstatus:\s*in-progress\b/i.test(ideaContent);
@@ -36,6 +42,9 @@ function getInProgressFeatures(featuresDir) {
 }
 
 function getBacklogTasks(atrisDir) {
+  const dbTasks = getTasksFromDbBucket(atrisDir, 'backlog');
+  if (dbTasks) return dbTasks;
+
   const todoFile = path.join(atrisDir, 'TODO.md');
   const legacyTaskContextFile = path.join(atrisDir, 'TASK_CONTEXTS.md');
   const taskFilePath = fs.existsSync(todoFile)
@@ -60,6 +69,9 @@ function getBacklogTasks(atrisDir) {
 }
 
 function getInProgressTasks(atrisDir) {
+  const dbTasks = getTasksFromDbBucket(atrisDir, 'inProgress');
+  if (dbTasks) return dbTasks;
+
   const todoFile = path.join(atrisDir, 'TODO.md');
   const legacyTaskContextFile = path.join(atrisDir, 'TASK_CONTEXTS.md');
   const taskFilePath = fs.existsSync(todoFile)
@@ -73,6 +85,9 @@ function getInProgressTasks(atrisDir) {
 }
 
 function getCompletedTasks(atrisDir) {
+  const dbTasks = getTasksFromDbBucket(atrisDir, 'completed');
+  if (dbTasks) return dbTasks;
+
   const todoFile = path.join(atrisDir, 'TODO.md');
   const legacyTaskContextFile = path.join(atrisDir, 'TASK_CONTEXTS.md');
   const taskFilePath = fs.existsSync(todoFile)
@@ -109,6 +124,25 @@ function getTasksFromTodoSection(content, sectionName) {
     .map((line) => line.trim())
     .filter((line) => /^-\s+/.test(line) && !/\(empty/i.test(line))
     .map((line) => line.replace(/^-+\s*/, '').trim());
+}
+
+function getTasksFromDbBucket(atrisDir, bucketName) {
+  const statuses = TASK_STATUS_BUCKETS[bucketName];
+  if (!statuses) return null;
+  try {
+    const taskDb = require('./task-db');
+    if (!fs.existsSync(taskDb.getDbPath())) return null;
+    const workspaceRoot = taskDb.workspaceRoot(path.dirname(path.resolve(atrisDir)));
+    const rows = taskDb.listTasks(taskDb.open(), { workspaceRoot, limit: 500 });
+    if (!rows.length) return null;
+    return rows
+      .filter(row => statuses.has(String(row.status || '').toLowerCase()))
+      .map(row => row.title)
+      .filter(Boolean);
+  } catch (e) {
+    if (process.env.ATRIS_DEBUG) console.error('[state-detection] db task read failed:', e.message);
+    return null;
+  }
 }
 
 function escapeRegExp(value) {

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -7,6 +7,7 @@ const { spawnSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
 const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+const taskDb = require('../lib/task-db');
 
 function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-cli-test-'));
@@ -16,13 +17,14 @@ function cleanupTempDir(dir) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-function runCli(args, { cwd, input } = {}) {
+function runCli(args, { cwd, input, env } = {}) {
   const result = spawnSync(process.execPath, [cliPath, ...args], {
     cwd,
     input,
     encoding: 'utf8',
     env: {
       ...process.env,
+      ...(env || {}),
       ATRIS_SKIP_UPDATE_CHECK: '1',
     },
   });
@@ -132,6 +134,66 @@ test('atris.md boot visualization does not create an empty daily journal', () =>
     assert.match(res.stdout, /WORKSPACE DETECTED/);
     assert.equal(fs.existsSync(path.join(atrisDir, 'logs')), false);
   } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('atris.md boot visualization does not create a task DB just to count tasks', () => {
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, '.atris-test', 'tasks.db');
+  try {
+    const atrisDir = path.join(dir, 'atris');
+    fs.mkdirSync(atrisDir, { recursive: true });
+    fs.writeFileSync(path.join(atrisDir, 'atris.md'), '# atris.md\n', 'utf8');
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'), '# MAP.md\n\n- `bin/atris.js`\n', 'utf8');
+    fs.writeFileSync(
+      path.join(atrisDir, 'TODO.md'),
+      ['# TODO.md', '', '## Backlog', '', '- markdown fallback task', '', '## In Progress', '', '## Completed', ''].join('\n'),
+      'utf8'
+    );
+
+    const res = runCli(['atris.md'], { cwd: dir, env: { ATRIS_TASKS_DB: dbPath } });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Tasks:\s+1 backlog, 0 active/);
+    assert.equal(fs.existsSync(dbPath), false);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('atris.md boot visualization prefers task DB counts over stale TODO rows', () => {
+  const dir = makeTempDir();
+  const oldDb = process.env.ATRIS_TASKS_DB;
+  const dbPath = path.join(dir, '.atris-test', 'tasks.db');
+  try {
+    const atrisDir = path.join(dir, 'atris');
+    fs.mkdirSync(atrisDir, { recursive: true });
+    fs.writeFileSync(path.join(atrisDir, 'atris.md'), '# atris.md\n', 'utf8');
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'), '# MAP.md\n\n- `bin/atris.js`\n', 'utf8');
+    fs.writeFileSync(
+      path.join(atrisDir, 'TODO.md'),
+      ['# TODO.md', '', '## Backlog', '', '- stale markdown task', '', '## In Progress', '', '## Completed', ''].join('\n'),
+      'utf8'
+    );
+
+    process.env.ATRIS_TASKS_DB = dbPath;
+    const db = taskDb.open(dbPath);
+    taskDb.addTask(db, {
+      title: 'Authoritative claimed task',
+      workspaceRoot: taskDb.workspaceRoot(dir),
+      status: 'claimed',
+      claimedBy: 'codex'
+    });
+    taskDb.close();
+
+    const res = runCli(['atris.md'], { cwd: dir, env: { ATRIS_TASKS_DB: dbPath } });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Tasks:\s+0 backlog, 1 active/);
+    assert.match(res.stdout, /TODO\.md ←── 0 tasks waiting/);
+  } finally {
+    taskDb.close();
+    if (oldDb === undefined) delete process.env.ATRIS_TASKS_DB;
+    else process.env.ATRIS_TASKS_DB = oldDb;
     cleanupTempDir(dir);
   }
 });


### PR DESCRIPTION
## Summary
- Prefer SQLite task-plane rows for boot/activation task counters when an existing task DB has rows for the workspace
- Keep TODO.md and journal parsing as fallback for workspaces without task DB state
- Preserve read-only boot behavior by not creating a missing task DB just to draw the boot card
- Add smoke regressions for stale TODO rows losing to authoritative DB state and for missing DB fallback staying non-mutating

## Verification
- node --test test/cli-smoke.test.js
- node --test test/commands.test.js
- node --check lib/state-detection.js && node --check test/cli-smoke.test.js
- git diff --check
- node /Users/keshavrao/arena/atris-cli-worktrees/codex-cli-187-boot-task-db-counts-20260524/bin/atris.js atris.md from /Users/keshavrao/arena/atrisos-backend shows 0 backlog, 2 active
