### PR TITLE
[codex] Surface GitHub Actions risk receipts in task reviews

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -347,6 +347,32 @@ function reviewSummary(task, payload = {}) {
   return `This explains what accepting ${plainTitle} would make real.`;
 }
 
+function githubActionsRiskReceiptFromProof(proof) {
+  const text = String(proof || '').replace(/\s+/g, ' ').trim();
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  const mentionsActions = lower.includes('github actions')
+    || lower.includes('github_actions')
+    || lower.includes('actions owner gate');
+  if (!mentionsActions) return null;
+
+  const reviewProofMatch = text.match(/review proof:\s*(.+)$/i);
+  const sentenceMatch = text.match(/[^.]*github[_ ]actions[^.]*\.?/i);
+  const summary = clipStatusText(
+    (reviewProofMatch && reviewProofMatch[1]) || (sentenceMatch && sentenceMatch[0]) || text,
+    240,
+  );
+  const status = lower.includes('not_applicable') || lower.includes('not applicable')
+    ? 'not_applicable'
+    : lower.includes('risk receipt')
+      || lower.includes('owner gate')
+      || lower.includes('billing')
+      || lower.includes('spend')
+        ? 'receipt_present'
+        : 'mentioned';
+  return { status, summary };
+}
+
 function taskReviewSummary(task) {
   const reviewed = (task.events || []).slice().reverse().find(e => e.event_type === 'reviewed' || e.event_type === 'proof_ready' || e.event_type === 'revision_requested');
   const payload = reviewed && reviewed.payload || {};
@@ -382,10 +408,12 @@ function taskReviewSummary(task) {
     }
     return payload[key] || metadata[metadataKey] || null;
   };
-  return {
+  const proof = readyField('proof', 'latest_agent_proof');
+  const githubActionsRiskReceipt = githubActionsRiskReceiptFromProof(proof);
+  const review = {
     summary: reviewSummary(task, payload),
     reward: reviewed && reviewed.event_type === 'reviewed' && payload.reward !== undefined ? payload.reward : null,
-    proof: readyField('proof', 'latest_agent_proof'),
+    proof,
     lesson: readyField('lesson', 'latest_agent_lesson'),
     next_task: readyField('next_task', 'latest_agent_next_task'),
     approval_status: metadata.approval_status || (task.status === 'review' ? 'pending' : null),
@@ -396,6 +424,8 @@ function taskReviewSummary(task) {
       || (agentCertified ? `${AGENT_CERTIFICATION_REVIEW_PASSES}_agent_review_passes` : null),
     human_revision_count: metadata.human_revision_count || null,
   };
+  if (githubActionsRiskReceipt) review.github_actions_risk_receipt = githubActionsRiskReceipt;
+  return review;
 }
 
 function taskAssignee(task) {
@@ -725,6 +755,7 @@ function compactTaskForStatus(task) {
     else if (task.review.reward === null) review.reward = null;
     if (task.review.summary) review.summary = clipStatusText(task.review.summary, 240);
     if (task.review.proof) review.proof = clipStatusText(task.review.proof, 180);
+    if (task.review.github_actions_risk_receipt) review.github_actions_risk_receipt = task.review.github_actions_risk_receipt;
     if (task.review.lesson) review.lesson = clipStatusText(task.review.lesson, 180);
     if (task.review.next_task) review.next_task = clipStatusText(task.review.next_task, 140);
     if (task.review.approval_status) review.approval_status = task.review.approval_status;
@@ -889,7 +920,7 @@ function reviewQueueLimit(args, total) {
 
 function reviewQueueItem(task) {
   const ref = taskRef(task);
-  return {
+  const item = {
     id: task.id,
     display_id: task.display_id || null,
     title: task.title,
@@ -900,6 +931,10 @@ function reviewQueueItem(task) {
     accept_command: `atris task accept ${ref}`,
     revise_command: `atris task revise ${ref} --note "<what must change>"`,
   };
+  if (task.review?.github_actions_risk_receipt) {
+    item.github_actions_risk_receipt = task.review.github_actions_risk_receipt;
+  }
+  return item;
 }
 
 function taskReviewQueue(projection, args = []) {
@@ -951,6 +986,10 @@ function cmdReviews(args) {
     console.log('');
     console.log(`${index + 1}. ${item.display_id || taskRef(item.id)}${tag}${passes}: ${item.title}`);
     if (item.proof) console.log(`   proof: ${item.proof}`);
+    if (item.github_actions_risk_receipt) {
+      const receipt = item.github_actions_risk_receipt;
+      console.log(`   github actions risk: ${receipt.status} - ${receipt.summary}`);
+    }
     console.log(`   accept: ${item.accept_command}`);
     console.log(`   revise: ${item.revise_command}`);
   });
@@ -1566,6 +1605,10 @@ function cmdShow(args) {
     console.log('');
     if (task.review.summary) console.log(`Summary: ${task.review.summary}`);
     if (task.review.proof) console.log(`Proof: ${task.review.proof}`);
+    if (task.review.github_actions_risk_receipt) {
+      const receipt = task.review.github_actions_risk_receipt;
+      console.log(`GitHub Actions risk: ${receipt.status} - ${receipt.summary}`);
+    }
     if (task.review.lesson) console.log(`Lesson: ${task.review.lesson}`);
     if (task.review.next_task) console.log(`Next: ${task.review.next_task}`);
     if (task.review.approval_status) console.log(`Approval: ${task.review.approval_status}`);

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -5558,6 +5558,46 @@ test('task reviews gives a compact certified accept queue', () => {
   }
 });
 
+test('task review surfaces GitHub Actions risk receipt from proof', () => {
+  if (!hasNodeSqlite()) return;
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, 'tasks.db');
+  const env = { ATRIS_TASKS_DB: dbPath, NODE_NO_WARNINGS: '1' };
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const created = runCli(['task', 'new', 'Surface backend Actions risk', '--tag', 'reliability', '--json'], { cwd: dir, env });
+    assert.equal(created.status, 0, created.stderr);
+    const task = JSON.parse(created.stdout).task;
+    const proof = 'Focused tests passed. REVIEW PROOF: not_applicable for GitHub Actions risk receipt because this is a docs-only artifact with no runtime or deploy code.';
+
+    assert.equal(runCli(['task', 'claim', task.display_id, '--as', 'codex'], { cwd: dir, env }).status, 0);
+    assert.equal(runCli(['task', 'ready', task.display_id, '--proof', proof, '--as', 'codex'], { cwd: dir, env }).status, 0);
+    assert.equal(runCli(['task', 'review', task.display_id, '--reward', '0', '--as', 'validator'], { cwd: dir, env }).status, 0);
+
+    const queue = runCli(['task', 'reviews', '--json'], { cwd: dir, env });
+    assert.equal(queue.status, 0, queue.stderr);
+    const queuePayload = JSON.parse(queue.stdout);
+    assert.equal(queuePayload.queue.items[0].github_actions_risk_receipt.status, 'not_applicable');
+    assert.match(queuePayload.queue.items[0].github_actions_risk_receipt.summary, /docs-only artifact/);
+
+    const status = runCli(['task', 'status', '--json'], { cwd: dir, env });
+    assert.equal(status.status, 0, status.stderr);
+    const statusPayload = JSON.parse(status.stdout);
+    assert.equal(statusPayload.status.needs_review[0].review.github_actions_risk_receipt.status, 'not_applicable');
+
+    const show = runCli(['task', 'show', task.display_id], { cwd: dir, env });
+    assert.equal(show.status, 0, show.stderr);
+    assert.match(show.stdout, /GitHub Actions risk: not_applicable - .*docs-only artifact/);
+
+    const textQueue = runCli(['task', 'reviews'], { cwd: dir, env });
+    assert.equal(textQueue.status, 0, textQueue.stderr);
+    assert.match(textQueue.stdout, /github actions risk: not_applicable - .*docs-only artifact/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('task status resolves goal_id display refs to parent task objectives', () => {
   if (!hasNodeSqlite()) return;
   const dir = makeTempDir();


### PR DESCRIPTION
## What changed

- Derive a structured `github_actions_risk_receipt` from task review proof text when the proof mentions GitHub Actions, Actions owner gate, billing/spend limits, or an explicit non-applicability boundary.
- Surface that receipt in `atris task show`, `atris task status --json`, and `atris task reviews` / `--json`.
- Add regression coverage for certified review queue/status/show output.

## Why

Backend review proof now requires either a GitHub Actions risk receipt or an explicit non-applicability reason. Reviewers should not have to scrape a long proof blob to see whether that boundary exists.

## Validation

- `node --test --test-name-pattern "task review surfaces GitHub Actions risk receipt|task reviews gives a compact certified accept queue|task ready holds work in review until human accept" test/commands.test.js`
- `node --check commands/task.js`
- `git diff --check`

## Risk

Low runtime risk: this only derives display/projection metadata from existing proof text and omits the field when no GitHub Actions proof is present. Residual risk is parser looseness because old proof text is unstructured; the fallback status is intentionally `mentioned` unless the proof clearly says `not_applicable` or includes receipt/owner-gate/billing language.