### PR TITLE
Report inherited GitHub Actions receipt in review output

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -2015,7 +2015,7 @@ function cmdReview(args) {
   const nextCreated = createNextTaskIfRequested(taskDb, db, args, currentTask, result.episode.next_task_suggestion);
   const xpProjection = refreshCareerXpAfterReview(result);
   const { projection, outPath } = writeDefaultProjection(taskDb, db);
-  const githubActionsReceipt = githubActionsRiskReceipt(result.episode.proof, taskDb);
+  const githubActionsReceipt = githubActionsRiskReceipt(effectiveProof, taskDb);
   if (wantsJson(args)) {
     printJson({
       ok: true,

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4801,7 +4801,9 @@ test('task ready surfaces backend GitHub Actions risk receipt state', () => {
     assert.equal(receiptState.has_deploy_fallback, true);
     const validatorReview = runCli(['task', 'review', refWithReceipt, '--reward', '1', '--as', 'validator', '--json'], { cwd: dir, env });
     assert.equal(validatorReview.status, 0, validatorReview.stderr);
-    assert.equal(JSON.parse(validatorReview.stdout).task.review.agent_certified, true);
+    const validatorPayload = JSON.parse(validatorReview.stdout);
+    assert.equal(validatorPayload.github_actions_risk_receipt.status, 'present');
+    assert.equal(validatorPayload.task.review.agent_certified, true);
   } finally {
     cleanupTempDir(root);
   }


### PR DESCRIPTION
## Summary
- make backend task review JSON report the same effective GitHub Actions risk proof used by enforcement
- add regression coverage for validator review without a new --proof still returning receipt status=present

## Tests
- node --check commands/task.js
- node --test --test-name-pattern "GitHub Actions|task ready holds work" test/commands.test.js
- node --test test/commands.test.js
- git diff --check