### PR TITLE
fix(task): surface strict auto-accept recovery

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -5789,7 +5789,9 @@ function cmdAutoAcceptCertified(args) {
   console.log(`AUTO-ACCEPT CERTIFIED (${dryRun ? 'dry-run' : 'execute'})`);
   console.log(`${summary.accepted || summary.would_accept} accepted / ${summary.skipped} skipped / ${summary.failed} failed / ${summary.scanned} scanned`);
   for (const row of results) {
-    console.log(`${row.action.toUpperCase()} ${row.ref}: ${row.reason}${row.reward ? ` reward=${row.reward}` : ''}`);
+    const nextAction = row.next_action ? ` next_action=${row.next_action}` : '';
+    const reviewChat = row.review_chat_command ? ` review_chat=${row.review_chat_command}` : '';
+    console.log(`${row.action.toUpperCase()} ${row.ref}: ${row.reason}${row.reward ? ` reward=${row.reward}` : ''}${nextAction}${reviewChat}`);
   }
 }
 

--- a/lib/auto-accept-certified.js
+++ b/lib/auto-accept-certified.js
@@ -106,6 +106,16 @@ function runVerifyCommand(verify, workspaceRoot) {
   };
 }
 
+function strictVerifyMissingResult(ref) {
+  return {
+    eligible: false,
+    ref,
+    reason: 'strict_verify_missing',
+    next_action: 'rerun the review verifier and record a safe metadata.verify command before strict auto-accept',
+    review_chat_command: `atris task review-chat ${ref} --as codex-review`,
+  };
+}
+
 function evaluateAutoAccept(task, options = {}) {
   const { strictVerify = false, minPasses = AGENT_CERTIFICATION_REVIEW_PASSES } = options;
   const ref = task.display_id || task.legacy_ref || task.id;
@@ -145,7 +155,7 @@ function evaluateAutoAccept(task, options = {}) {
 
   if (strictVerify) {
     const verify = metadata.verify;
-    if (!verify) return { eligible: false, ref, reason: 'strict_verify_missing' };
+    if (!verify) return strictVerifyMissingResult(ref);
     const workspaceRoot = task.workspace_root || process.cwd();
     const verifyResult = runVerifyCommand(verify, workspaceRoot);
     if (!verifyResult.ok) {

--- a/test/auto-accept-certified.test.js
+++ b/test/auto-accept-certified.test.js
@@ -43,6 +43,16 @@ test('accepts certified review with two actors and meaningful proof', () => {
   assert.equal(result.policy, '2_actors_2_passes');
 });
 
+test('strict verify missing points agents back to review chat', () => {
+  const result = evaluateAutoAccept(reviewTask({
+    metadata: { verify: '' },
+  }), { strictVerify: true });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, 'strict_verify_missing');
+  assert.match(result.next_action, /metadata\.verify/);
+  assert.equal(result.review_chat_command, 'atris task review-chat OBL-TEST --as codex-review');
+});
+
 test('accepts third pass even with one actor', () => {
   const base = reviewTask();
   const result = evaluateAutoAccept({

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -8531,6 +8531,21 @@ test('task auto-accept-certified requires explicit human confirmation', () => {
     assert.equal(previewPayload.results[0].action, 'would_accept');
     assert.equal(JSON.parse(runCli(['task', 'show', ref, '--json'], { cwd: dir, env }).stdout).status, 'review');
 
+    const strictPreview = runCli(['task', 'auto-accept-certified', '--dry-run', '--strict-verify', '--json'], { cwd: dir, env });
+    assert.equal(strictPreview.status, 0, strictPreview.stderr);
+    const strictPayload = JSON.parse(strictPreview.stdout);
+    assert.equal(strictPayload.summary.would_accept, 0);
+    assert.equal(strictPayload.summary.skipped, 1);
+    assert.equal(strictPayload.results[0].reason, 'strict_verify_missing');
+    assert.match(strictPayload.results[0].next_action, /metadata\.verify/);
+    assert.equal(strictPayload.results[0].review_chat_command, `atris task review-chat ${ref} --as codex-review`);
+
+    const strictText = runCli(['task', 'auto-accept-certified', '--dry-run', '--strict-verify'], { cwd: dir, env });
+    assert.equal(strictText.status, 0, strictText.stderr);
+    assert.match(strictText.stdout, /SKIPPED .*strict_verify_missing/);
+    assert.match(strictText.stdout, /next_action=.*metadata\.verify/);
+    assert.match(strictText.stdout, new RegExp(`review_chat=atris task review-chat ${ref} --as codex-review`));
+
     const confirmed = runCli([
       'task', 'auto-accept-certified',
       '--confirm-human-accept',


### PR DESCRIPTION
## Summary\n- add structured recovery guidance when strict auto-accept skips certified review rows missing metadata.verify\n- print next_action and review_chat recovery details in text output\n- cover JSON/text behavior plus evaluator output in tests\n\n## Verification\n- node --check lib/auto-accept-certified.js\n- node --check commands/task.js\n- node --test test/auto-accept-certified.test.js\n- node --test test/commands.test.js\n- npm test\n- git diff --check\n\n## Safety\n- does not weaken human accept confirmation\n- does not change strict verifier execution or acceptance eligibility\n- no prod/live tick