### PR TITLE
Let task reviews record verify metadata

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -8,7 +8,7 @@ const http = require('http');
 const path = require('path');
 const os = require('os');
 const { taskProofState } = require('../lib/task-proof');
-const { evaluateAutoAccept } = require('../lib/auto-accept-certified');
+const { evaluateAutoAccept, parseVerifyCommand } = require('../lib/auto-accept-certified');
 
 const DEFAULT_OWNER = process.env.ATRIS_AGENT_ID
   || process.env.USER
@@ -128,7 +128,8 @@ atris task - durable local task state (SQLite, gitignored)
   atris task done <id> --proof "..."       Mark complete with proof
   atris task done <id> --failed [--proof "..."]  Mark failed, optionally reviewed
   atris task finish <id> --proof "..."     Legacy alias for done with proof
-  atris task review <id> --reward <n>      Write review event + RSI episode
+  atris task review <id> --reward <n> [--verify "<cmd>"]
+                                           Write review event + RSI episode
   atris task reviews [--limit <n>]         Show certified Review items for human accept/revise
   atris task status [--json] [--history]   Compact live status for web/Swarlo
   atris task setup [--import-todo]         Create/refresh task projection
@@ -1154,7 +1155,7 @@ function taskReviewSpecificCodexPrompt(task, focus, actor) {
   const files = focus && focus.files_to_inspect && focus.files_to_inspect.length
     ? ` Files/artifacts: ${focus.files_to_inspect.join(', ')}.`
     : '';
-  return `/codex review ${ref}: verify "${title}".${proof}${commands}${files} Inspect the task thread, then run ${`atris task review ${ref} --reward 0 --as ${actor} --proof "<specific verifier commands passed and diff/proof inspected>"`} or revise with the exact missing proof. Do not accept XP.`;
+  return `/codex review ${ref}: verify "${title}".${proof}${commands}${files} Inspect the task thread, then run ${`atris task review ${ref} --reward 0 --as ${actor} --proof "<specific verifier commands passed and diff/proof inspected>" --verify "<safe verifier command>"`} or revise with the exact missing proof. Do not accept XP.`;
 }
 
 function taskReviewChatHandoff(task, { reviewer = 'codex-review', allowCertified = false } = {}) {
@@ -1167,7 +1168,7 @@ function taskReviewChatHandoff(task, { reviewer = 'codex-review', allowCertified
     schema: 'atris.task_review_chat.v1',
     command: `atris task review-chat ${ref} --as ${actor}`,
     codex_prompt: taskReviewSpecificCodexPrompt(task, verificationFocus, actor),
-    pass_command: `atris task review ${ref} --reward 0 --as ${actor} --proof "<specific verifier commands passed and diff/proof inspected>"`,
+    pass_command: `atris task review ${ref} --reward 0 --as ${actor} --proof "<specific verifier commands passed and diff/proof inspected>" --verify "<safe verifier command>"`,
     revise_command: `atris task revise ${ref} --as ${actor} --note "<specific missing proof or required change>"`,
     human_accept_command: `atris task accept ${ref}`,
     verification_focus: {
@@ -4628,7 +4629,7 @@ function taskPageActions(task, { reviewer = 'codex-review', hasExistingReviewFol
     plan_command: `atris task plan ${ref} --goal ${taskCommandQuote(goal)} --exit "<exit condition>" --proof-needed "<verification command>" --first-move "<first move>"`,
     do_command: `atris task do ${ref} --as ${owner} --first-move "<first move>"`,
     ready_command: `atris task ready ${ref} --as ${owner} --proof "<specific proof command/result>"`,
-    review_command: `atris task review ${ref} --reward 0 --as ${actor} --proof "<specific proof command/result>"`,
+    review_command: `atris task review ${ref} --reward 0 --as ${actor} --proof "<specific proof command/result>" --verify "<safe verifier command>"`,
   };
   if (task && task.status === 'review') {
     actions.revise_command = `atris task revise ${ref} --as ${actor} --note "<specific missing proof or required change>"`;
@@ -5860,6 +5861,7 @@ function cmdReview(args) {
   if (clearLesson || (typeof lessonFlag === 'string' && !String(lessonFlag).trim())) clearedFields.push('lesson');
   if (clearNextTask || (typeof nextTaskFlag === 'string' && !String(nextTaskFlag).trim())) clearedFields.push('next_task');
   const proof = proofFlagValue(args);
+  const verify = textFlag(args, ['--verify']);
   const actor = flag(args, '--as') || DEFAULT_OWNER;
   const rewardValue = reward === true || reward === null ? 0 : reward;
   if (agentProofOnlyMode() && Number(rewardValue) > 0) {
@@ -5870,6 +5872,16 @@ function cmdReview(args) {
   }
   if (Number(rewardValue) > 0 || proof) {
     requireMeaningfulTaskProof('atris task review', proof);
+  }
+  if (verify) {
+    const parsedVerify = parseVerifyCommand(verify);
+    if (!parsedVerify.ok) {
+      failTask(
+        'atris task review',
+        parsedVerify.reason || 'invalid_verify_command',
+        'Verify command must be a safe simple command accepted by strict auto-accept.',
+      );
+    }
   }
   const taskDb = getTaskDb();
   const db = taskDb.open();
@@ -5882,6 +5894,7 @@ function cmdReview(args) {
     lesson: typeof lesson === 'string' ? lesson : '',
     nextTask: nextTaskInput.nextTask,
     proof,
+    verify,
     careerXpEligible: false,
     clearedFields,
   });

--- a/lib/task-db.js
+++ b/lib/task-db.js
@@ -1073,7 +1073,7 @@ function chatTask(db, { id, actor, content, goal, summary }) {
   };
 }
 
-function reviewTask(db, { id, actor, reward, lesson, nextTask, proof, careerXpEligible = false, clearedFields = [] }) {
+function reviewTask(db, { id, actor, reward, lesson, nextTask, proof, verify, careerXpEligible = false, clearedFields = [] }) {
   if (!id) throw new Error('id required');
   const row = getTask(db, id);
   if (!row) return { reviewed: false, reason: 'not_found' };
@@ -1082,6 +1082,7 @@ function reviewTask(db, { id, actor, reward, lesson, nextTask, proof, careerXpEl
   const reviewer = actor || process.env.ATRIS_AGENT_ID || process.env.USER || null;
   const metadata = row.metadata && typeof row.metadata === 'object' ? { ...row.metadata } : {};
   const proofText = String(proof || '').trim();
+  const verifyText = cleanStageText(verify);
   const lessonText = String(lesson || '').trim();
   const nextTaskText = String(nextTask || '').trim();
   const clearedReviewFields = Array.isArray(clearedFields)
@@ -1094,12 +1095,16 @@ function reviewTask(db, { id, actor, reward, lesson, nextTask, proof, careerXpEl
   const updatingPendingReviewProof = row.status === 'review'
     && metadata.approval_status === 'pending'
     && numericReward <= 0
-    && Boolean(proofText || lessonText || nextTaskText || clearedReviewFields.length);
+    && Boolean(proofText || verifyText || lessonText || nextTaskText || clearedReviewFields.length);
   let reviewPassCount = Number(metadata.agent_review_pass_count || 0);
   if (reviewingPendingProof || updatingPendingReviewProof) {
     metadata.agent_reviewed_at = new Date(now).toISOString();
     metadata.agent_reviewed_by = reviewer;
     if (proofText) metadata.latest_agent_proof = proofText;
+    if (verifyText) {
+      metadata.verify = verifyText;
+      metadata.latest_agent_verify = verifyText;
+    }
     if (clearedReviewFields.includes('lesson')) metadata.latest_agent_lesson = null;
     else if (lessonText) metadata.latest_agent_lesson = lessonText;
     if (clearedReviewFields.includes('next_task')) metadata.latest_agent_next_task = null;
@@ -1133,6 +1138,7 @@ function reviewTask(db, { id, actor, reward, lesson, nextTask, proof, careerXpEl
     lesson: lessonText,
     next_task: nextTaskText || null,
     proof: proofText || null,
+    verify: verifyText || null,
     career_xp_eligible: Boolean(careerXpEligible),
   };
   if (reviewingPendingProof) {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -6538,7 +6538,7 @@ test('task page exposes one-task goal chat stage and review actions', () => {
     const customReviewerContract = JSON.parse(customReviewerPage.stdout).page;
     assert.equal(customReviewerContract.stage.next_action.command, `atris task review-chat ${ref} --as alice-review`);
     assert.equal(customReviewerContract.review.verification_chat.command, `atris task review-chat ${ref} --as alice-review`);
-    assert.equal(customReviewerContract.review.verification_chat.pass_command, `atris task review ${ref} --reward 0 --as alice-review --proof "<specific verifier commands passed and diff/proof inspected>"`);
+    assert.equal(customReviewerContract.review.verification_chat.pass_command, `atris task review ${ref} --reward 0 --as alice-review --proof "<specific verifier commands passed and diff/proof inspected>" --verify "<safe verifier command>"`);
 
     const certify = runCli([
       'task', 'review', ref,
@@ -7481,7 +7481,7 @@ test('task ready holds work in review until human accept', () => {
     assert.equal(reviewChatPayload.contract.verification_focus.proof_claim, 'typecheck passed and diff reviewed');
     assert.match(reviewChatPayload.contract.required_checks.join('\n'), /Find the concrete verifier command/);
     assert.match(reviewChatPayload.contract.required_checks.join('\n'), /Do not run task accept/);
-    assert.equal(reviewChatPayload.contract.pass_command, `atris task review ${ref} --reward 0 --as codex-review --proof "<specific verifier commands passed and diff/proof inspected>"`);
+    assert.equal(reviewChatPayload.contract.pass_command, `atris task review ${ref} --reward 0 --as codex-review --proof "<specific verifier commands passed and diff/proof inspected>" --verify "<safe verifier command>"`);
     assert.equal(reviewChatPayload.contract.revise_command, `atris task revise ${ref} --as codex-review --note "<specific missing proof or required change>"`);
     assert.match(reviewChatPayload.task.messages.at(-1).content, /TASK_REVIEW_CHAT/);
     assert.match(reviewChatPayload.task.messages.at(-1).content, /proof_claim: typecheck passed and diff reviewed/);
@@ -7489,10 +7489,12 @@ test('task ready holds work in review until human accept', () => {
     assert.match(reviewChatPayload.task.messages.at(-1).content, /files_to_inspect:/);
     assert.match(reviewChatPayload.task.messages.at(-1).content, /human_accept_xp: atris task accept/);
 
+    fs.writeFileSync(path.join(dir, 'review-verify.js'), 'const ok = true;\n', 'utf8');
     const prooflessReview = runCli([
       'task', 'review', ref,
       '--reward', '0',
       '--as', 'validator',
+      '--verify', 'node --check review-verify.js',
       '--json',
     ], { cwd: dir, env });
     assert.equal(prooflessReview.status, 0, prooflessReview.stderr);
@@ -7500,6 +7502,7 @@ test('task ready holds work in review until human accept', () => {
     assert.equal(JSON.parse(prooflessReview.stdout).task.review.agent_review_pass_count, 2);
     assert.equal(JSON.parse(prooflessReview.stdout).task.review.agent_certified, true);
     assert.equal(JSON.parse(prooflessReview.stdout).task.metadata.agent_certified, true);
+    assert.equal(JSON.parse(prooflessReview.stdout).task.metadata.verify, 'node --check review-verify.js');
 
     const nextAfterReviewCertification = runCli(['task', 'next', '--as', 'codex', '--json'], { cwd: dir, env });
     assert.equal(nextAfterReviewCertification.status, 0, nextAfterReviewCertification.stderr);
@@ -8545,6 +8548,26 @@ test('task auto-accept-certified requires explicit human confirmation', () => {
     assert.match(strictText.stdout, /SKIPPED .*strict_verify_missing/);
     assert.match(strictText.stdout, /next_action=.*metadata\.verify/);
     assert.match(strictText.stdout, new RegExp(`review_chat=atris task review-chat ${ref} --as codex-review`));
+
+    fs.writeFileSync(path.join(dir, 'verify.js'), 'const ok = true;\n', 'utf8');
+    const verifyReview = runCli([
+      'task', 'review', ref,
+      '--reward', '0',
+      '--as', 'codex-review',
+      '--proof', 'node --check verify.js passed and diff inspected',
+      '--verify', 'node --check verify.js',
+      '--json',
+    ], { cwd: dir, env });
+    assert.equal(verifyReview.status, 0, verifyReview.stderr);
+    assert.equal(JSON.parse(verifyReview.stdout).task.metadata.verify, 'node --check verify.js');
+
+    const strictVerifiedPreview = runCli(['task', 'auto-accept-certified', '--dry-run', '--strict-verify', '--json'], { cwd: dir, env });
+    assert.equal(strictVerifiedPreview.status, 0, strictVerifiedPreview.stderr);
+    const strictVerifiedPayload = JSON.parse(strictVerifiedPreview.stdout);
+    assert.equal(strictVerifiedPayload.summary.would_accept, 1);
+    assert.equal(strictVerifiedPayload.summary.skipped, 0);
+    assert.equal(strictVerifiedPayload.results[0].action, 'would_accept');
+    assert.equal(strictVerifiedPayload.results[0].reason, 'certified_strict_verify');
 
     const confirmed = runCli([
       'task', 'auto-accept-certified',


### PR DESCRIPTION
## Summary
- add explicit `atris task review --verify "<cmd>"` support for pending review metadata
- validate review verify commands with the strict auto-accept parser before storing them
- update review-chat handoffs to tell reviewers to include a safe verifier command
- cover the strict auto-accept transition from `strict_verify_missing` to `would_accept` after `metadata.verify` is recorded

## Verification
- `node --check lib/task-db.js`
- `node --check commands/task.js`
- `node --test test/auto-accept-certified.test.js`
- `node --test test/commands.test.js`
- `git diff --check`
- `npm test`
