### PR TITLE
fix(task): allow bounded git worktree verify commands

### DIFF
--- a/lib/auto-accept-certified.js
+++ b/lib/auto-accept-certified.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 const { taskProofState } = require('./task-proof');
 
 const AGENT_CERTIFICATION_REVIEW_PASSES = 2;
@@ -8,6 +10,8 @@ const AUTO_ACCEPT_HIGH_CONFIDENCE_PASSES = 3;
 const DENIED_TAGS = new Set(['billing', 'deploy', 'feedback', 'voice', 'security', 'customer', 'external']);
 
 const SIMPLE_VERIFY_TOKEN_RE = /^[a-zA-Z0-9_./:@=+-]+$/;
+const GIT_WORKTREE_PATH_RE = /^[a-zA-Z0-9_./@=+-]+$/;
+const GIT_REV_TOKEN_RE = /^[a-zA-Z0-9_./@=+~^-]+$/;
 
 function hasUnsafePathSegment(token) {
   const text = String(token || '');
@@ -28,8 +32,59 @@ function safeRelativePathToken(token) {
     && safeVerifyToken(text);
 }
 
+function safeGitWorktreePathToken(token) {
+  const text = String(token || '');
+  return Boolean(text)
+    && !text.startsWith('-')
+    && !text.includes(':')
+    && GIT_WORKTREE_PATH_RE.test(text)
+    && !text.split(/[\\/]+/).includes('..');
+}
+
+function safeGitRevToken(token) {
+  const text = String(token || '');
+  return Boolean(text)
+    && !text.startsWith('-')
+    && !text.includes(':')
+    && GIT_REV_TOKEN_RE.test(text)
+    && !text.split(/[\\/]+/).includes('..');
+}
+
 function safeNodePathArgs(args) {
   return args.every(token => safeRelativePathToken(token));
+}
+
+function safeGitDiffCheckArgs(args) {
+  return args.length === 0 || (args.length <= 2 && args.every(safeGitRevToken));
+}
+
+function isAllowedGitDiffCheck(argv) {
+  const [bin, first, second, third, fourth] = argv;
+  if (bin !== 'git') return false;
+  if (first === 'diff' && second === '--check') {
+    return safeGitDiffCheckArgs(argv.slice(3));
+  }
+  if (first === '-C' && safeGitWorktreePathToken(second) && third === 'diff' && fourth === '--check') {
+    return safeGitDiffCheckArgs(argv.slice(5));
+  }
+  return false;
+}
+
+function isInsidePath(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function validateGitWorktreePath(argv, workspaceRoot) {
+  if (!(argv[0] === 'git' && argv[1] === '-C')) return { ok: true };
+  const workspace = path.resolve(workspaceRoot || process.cwd());
+  const target = path.resolve(workspace, argv[2]);
+  const allowedRoot = path.dirname(workspace);
+  if (!isInsidePath(target, workspace) && !isInsidePath(target, allowedRoot)) {
+    return { ok: false, reason: 'verify_command_not_allowed' };
+  }
+  if (!fs.existsSync(target)) return { ok: false, reason: 'verify_worktree_missing' };
+  return { ok: true };
 }
 
 function reviewPassCount(task) {
@@ -70,7 +125,15 @@ function parseVerifyCommand(verify) {
   if (!cmd) return { ok: false, reason: 'no_verify_command' };
   if (/[;&|`$<>\n\r]/.test(cmd)) return { ok: false, reason: 'verify_command_not_allowed' };
   const argv = cmd.split(/\s+/).filter(Boolean);
-  if (!argv.length || argv.some(token => !safeVerifyToken(token))) {
+  if (!argv.length || argv.some((token, index) => {
+    if (argv[0] === 'git' && argv[1] === '-C' && index === 2) {
+      return !safeGitWorktreePathToken(token);
+    }
+    if (argv[0] === 'git' && ['diff', '-C'].includes(argv[1]) && index >= (argv[1] === '-C' ? 5 : 3)) {
+      return !safeGitRevToken(token);
+    }
+    return !safeVerifyToken(token);
+  })) {
     return { ok: false, reason: 'verify_command_not_allowed' };
   }
   const [bin, first, second] = argv;
@@ -84,7 +147,7 @@ function parseVerifyCommand(verify) {
       || (/^scripts\/[a-zA-Z0-9_./-]+$/.test(first || '') && safeNodePathArgs(argv.slice(1)))
     ))
     || (bin === 'tsc' && argv.length === 1)
-    || (bin === 'git' && first === 'diff' && second === '--check' && argv.length === 3);
+    || isAllowedGitDiffCheck(argv);
   if (!allowed) return { ok: false, reason: 'verify_command_not_allowed' };
   return { ok: true, argv };
 }
@@ -92,6 +155,8 @@ function parseVerifyCommand(verify) {
 function runVerifyCommand(verify, workspaceRoot) {
   const parsed = parseVerifyCommand(verify);
   if (!parsed.ok) return parsed;
+  const gitPathCheck = validateGitWorktreePath(parsed.argv, workspaceRoot);
+  if (!gitPathCheck.ok) return gitPathCheck;
   const result = spawnSync(parsed.argv[0], parsed.argv.slice(1), {
     cwd: workspaceRoot,
     shell: false,

--- a/test/auto-accept-certified.test.js
+++ b/test/auto-accept-certified.test.js
@@ -106,3 +106,34 @@ test('strict verify parser rejects path and npm config escapes', () => {
   assert.equal(parseVerifyCommand('node --check --require=/tmp/pwn.js').ok, false);
   assert.equal(parseVerifyCommand('node --check file:///tmp/pwn.js').ok, false);
 });
+
+test('strict verify parser allows bounded git worktree diff checks', () => {
+  const sibling = path.join(os.tmpdir(), 'sibling-worktree');
+  const parsed = parseVerifyCommand(`git -C ${sibling} diff --check origin/master^ origin/master`);
+  assert.deepEqual(parsed, {
+    ok: true,
+    argv: ['git', '-C', sibling, 'diff', '--check', 'origin/master^', 'origin/master'],
+  });
+  assert.deepEqual(parseVerifyCommand('git diff --check HEAD~1 HEAD'), {
+    ok: true,
+    argv: ['git', 'diff', '--check', 'HEAD~1', 'HEAD'],
+  });
+  assert.equal(parseVerifyCommand('git -C ../../outside diff --check').ok, false);
+  assert.equal(parseVerifyCommand('git -C /tmp/evil diff --check --output=/tmp/x').ok, false);
+});
+
+test('strict verify runtime blocks git -C outside the workspace parent', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-verify-parent-'));
+  const workspace = path.join(parent, 'workspace');
+  const sibling = path.join(parent, 'sibling');
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-verify-outside-'));
+  fs.mkdirSync(workspace);
+  fs.mkdirSync(sibling);
+
+  const allowed = runVerifyCommand(`git -C ${sibling} diff --check`, workspace);
+  assert.notEqual(allowed.reason, 'verify_command_not_allowed');
+
+  const denied = runVerifyCommand(`git -C ${outside} diff --check`, workspace);
+  assert.equal(denied.ok, false);
+  assert.equal(denied.reason, 'verify_command_not_allowed');
+});


### PR DESCRIPTION
## Summary
- Allow strict review metadata to use bounded git -C verifier worktrees for diff checks.
- Runtime validation keeps the git -C target inside the current workspace or its parent directory.
- Shell separators, npm config escapes, traversal paths, and git output flags remain rejected.

## Proof
- node --check lib/auto-accept-certified.js
- node --test test/auto-accept-certified.test.js passed 9/9
- node --test test/commands.test.js --test-name-pattern "auto-accept|review metadata|review-chat|task review" passed 328/328
- git diff --check
- real BCK-656 replay command returned verify_passed from the backend workspace root

## Boundary
No human accept, no XP grant, no backend live RSI tick, no producer revive.