### PR TITLE
fix(task): block auto-accept on unmerged PR proof

### DIFF
--- a/lib/auto-accept-certified.js
+++ b/lib/auto-accept-certified.js
@@ -110,6 +110,28 @@ function latestProof(task) {
   return String(metadata.latest_agent_proof || review.proof || '').trim();
 }
 
+function proofHasUnmergedPullRequestBoundary(proof) {
+  const text = String(proof || '');
+  if (!text) return false;
+  return /\bopen\s+draft\b/i.test(text)
+    || /\bopen\/draft\b/i.test(text)
+    || /\bopen\s+and\s+draft\s*=\s*true\b/i.test(text)
+    || /\bdraft\s*=\s*true\b/i.test(text)
+    || /\bisDraft\s*[:=]\s*true\b/i.test(text)
+    || /\bmergedAt\s*[:=]\s*null\b/i.test(text)
+    || /\bclosed\s+(?:with\s+)?mergedAt\s*[:=]\s*null\b/i.test(text);
+}
+
+function unmergedPullRequestBoundaryResult(ref, proof) {
+  return {
+    eligible: false,
+    ref,
+    reason: 'proof_unmerged_or_draft_pr_boundary',
+    next_action: 'revise the task out of Review or narrow the proof to draft/local-proof only before auto-accept',
+    proof,
+  };
+}
+
 function distinctReviewActors(task) {
   const actors = new Set();
   for (const event of task.events || []) {
@@ -204,6 +226,9 @@ function evaluateAutoAccept(task, options = {}) {
   const proof = latestProof(task);
   const proofCheck = taskProofState(proof);
   if (!proofCheck.ok) return { eligible: false, ref, reason: proofCheck.reason, proof };
+  if (proofHasUnmergedPullRequestBoundary(proof)) {
+    return unmergedPullRequestBoundaryResult(ref, proof);
+  }
 
   const actors = distinctReviewActors(task);
   const multiActor = actors.size >= 2;

--- a/test/auto-accept-certified.test.js
+++ b/test/auto-accept-certified.test.js
@@ -73,6 +73,28 @@ test('rejects denied tags and weak proof', () => {
   })).eligible, false);
 });
 
+test('rejects proof that names an open draft PR boundary', () => {
+  const proof = 'PR #1611 is still OPEN and draft=true, mergedAt=null. git diff --check passed.';
+  const result = evaluateAutoAccept(reviewTask({
+    metadata: { latest_agent_proof: proof },
+    review: { proof },
+  }));
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, 'proof_unmerged_or_draft_pr_boundary');
+  assert.match(result.next_action, /revise/);
+});
+
+test('rejects proof that names a closed unmerged PR boundary', () => {
+  const proof = 'PR #1585 is CLOSED with mergedAt=null after json.tool passed and git diff --check passed.';
+  const result = evaluateAutoAccept(reviewTask({
+    metadata: { latest_agent_proof: proof, agent_review_pass_count: 3 },
+    review: { proof, agent_review_pass_count: 3 },
+    events: [{ event_type: 'proof_ready', actor: 'codex' }],
+  }));
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, 'proof_unmerged_or_draft_pr_boundary');
+});
+
 test('rejects single actor with only two passes', () => {
   const result = evaluateAutoAccept(reviewTask({
     events: [{ event_type: 'proof_ready', actor: 'codex' }],


### PR DESCRIPTION
## What changed
- Add a strict auto-accept guard for proof text that names open draft, draft=true, isDraft=true, mergedAt=null, or closed-unmerged PR boundaries.
- Add focused regression coverage for open draft and closed-unmerged PR proof.

## Why
Manual review-lane cleanup found certified Review rows that looked auto-acceptable while their proof depended on open draft, stack-dependent, or closed-unmerged PR state. The CLI should fail closed before human-accept-ready automation can overclaim those rows.

## Verification
- node --check lib/auto-accept-certified.js
- node --test test/auto-accept-certified.test.js
- node --test test/commands.test.js --test-name-pattern 'auto-accept|review metadata|review-chat|task review'
- git diff --check

Task: BCK-982