### PR TITLE
fix(task): narrow unmerged PR proof guard

### DIFF
--- a/lib/auto-accept-certified.js
+++ b/lib/auto-accept-certified.js
@@ -110,16 +110,33 @@ function latestProof(task) {
   return String(metadata.latest_agent_proof || review.proof || '').trim();
 }
 
+function proofSentences(proof) {
+  return String(proof || '')
+    .replace(/([.!?])\s+/g, '$1\n')
+    .split(/[\n\r]+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+}
+
+function sentenceHasPullRequestReference(sentence) {
+  return /\bPR\s*#?\d+\b/i.test(sentence)
+    || /\bpull request\s*#?\d+\b/i.test(sentence)
+    || /\bgithub\.com\/\S+\/pull\/\d+\b/i.test(sentence);
+}
+
+function sentenceHasUnmergedPullRequestBoundary(sentence) {
+  return sentenceHasPullRequestReference(sentence)
+    && (/\bopen\s+draft\b/i.test(sentence)
+      || /\bopen\/draft\b/i.test(sentence)
+      || /\bopen\s+and\s+draft\s*=\s*true\b/i.test(sentence)
+      || /\bdraft\s*=\s*true\b/i.test(sentence)
+      || /\bisDraft\s*[:=]\s*true\b/i.test(sentence)
+      || /\bmergedAt\s*[:=]\s*null\b/i.test(sentence)
+      || /\bclosed\s+(?:with\s+)?mergedAt\s*[:=]\s*null\b/i.test(sentence));
+}
+
 function proofHasUnmergedPullRequestBoundary(proof) {
-  const text = String(proof || '');
-  if (!text) return false;
-  return /\bopen\s+draft\b/i.test(text)
-    || /\bopen\/draft\b/i.test(text)
-    || /\bopen\s+and\s+draft\s*=\s*true\b/i.test(text)
-    || /\bdraft\s*=\s*true\b/i.test(text)
-    || /\bisDraft\s*[:=]\s*true\b/i.test(text)
-    || /\bmergedAt\s*[:=]\s*null\b/i.test(text)
-    || /\bclosed\s+(?:with\s+)?mergedAt\s*[:=]\s*null\b/i.test(text);
+  return proofSentences(proof).some(sentenceHasUnmergedPullRequestBoundary);
 }
 
 function unmergedPullRequestBoundaryResult(ref, proof) {

--- a/test/auto-accept-certified.test.js
+++ b/test/auto-accept-certified.test.js
@@ -95,6 +95,21 @@ test('rejects proof that names a closed unmerged PR boundary', () => {
   assert.equal(result.reason, 'proof_unmerged_or_draft_pr_boundary');
 });
 
+test('allows merged proof that explains the rejected PR boundary terms', () => {
+  const proof = [
+    'Merged PR #78 at origin/master commit 7944f271.',
+    'Changed evaluator tests to reject proof text that names open draft, draft=true, isDraft=true, mergedAt=null, or closed-unmerged PR boundaries.',
+    'git diff --check passed.',
+  ].join(' ');
+  const result = evaluateAutoAccept(reviewTask({
+    metadata: { latest_agent_proof: proof, agent_review_pass_count: 3 },
+    review: { proof, agent_review_pass_count: 3 },
+    events: [{ event_type: 'proof_ready', actor: 'codex' }],
+  }));
+  assert.equal(result.eligible, true);
+  assert.equal(result.policy, '3_passes');
+});
+
 test('rejects single actor with only two passes', () => {
   const result = evaluateAutoAccept(reviewTask({
     events: [{ event_type: 'proof_ready', actor: 'codex' }],


### PR DESCRIPTION
## What changed
- Narrow the auto-accept PR-boundary guard to inspect proof sentence by sentence.
- Require a PR reference in the same sentence as open draft, draft=true, isDraft=true, mergedAt=null, or closed-unmerged state before rejecting.
- Add a regression proving merged PR proof can explain those rejected terms without being blocked.

## Why
PR #78 fixed the stale Review overclaim hole, but direct smoke testing showed the global token scan could false-positive on explanatory proof text. This keeps the fail-closed behavior for real stale PR state evidence while avoiding abstract keyword traps.

## Verification
- node --check lib/auto-accept-certified.js
- node --test test/auto-accept-certified.test.js
- node --test test/commands.test.js --test-name-pattern 'auto-accept|review metadata|review-chat|task review'
- node -e direct stale/explanatory evaluator smoke
- git diff --check

Task: BCK-983