### PR TITLE
fix(task): catch bare PR stale proof boundaries

### DIFF
--- a/lib/auto-accept-certified.js
+++ b/lib/auto-accept-certified.js
@@ -121,7 +121,8 @@ function proofSentences(proof) {
 function sentenceHasPullRequestReference(sentence) {
   return /\bPR\s*#?\d+\b/i.test(sentence)
     || /\bpull request\s*#?\d+\b/i.test(sentence)
-    || /\bgithub\.com\/\S+\/pull\/\d+\b/i.test(sentence);
+    || /\bgithub\.com\/\S+\/pull\/\d+\b/i.test(sentence)
+    || /#\d+\b/.test(sentence);
 }
 
 function sentenceHasUnmergedPullRequestBoundary(sentence) {
@@ -241,11 +242,11 @@ function evaluateAutoAccept(task, options = {}) {
   if (passes < minPasses) return { eligible: false, ref, reason: 'insufficient_review_passes', passes };
 
   const proof = latestProof(task);
-  const proofCheck = taskProofState(proof);
-  if (!proofCheck.ok) return { eligible: false, ref, reason: proofCheck.reason, proof };
   if (proofHasUnmergedPullRequestBoundary(proof)) {
     return unmergedPullRequestBoundaryResult(ref, proof);
   }
+  const proofCheck = taskProofState(proof);
+  if (!proofCheck.ok) return { eligible: false, ref, reason: proofCheck.reason, proof };
 
   const actors = distinctReviewActors(task);
   const multiActor = actors.size >= 2;

--- a/test/auto-accept-certified.test.js
+++ b/test/auto-accept-certified.test.js
@@ -95,6 +95,26 @@ test('rejects proof that names a closed unmerged PR boundary', () => {
   assert.equal(result.reason, 'proof_unmerged_or_draft_pr_boundary');
 });
 
+test('rejects stale proof that uses a bare PR number reference', () => {
+  const proof = 'Verified #1600 remains OPEN/draft/CLEAN at head be8797f. git diff --check passed.';
+  const result = evaluateAutoAccept(reviewTask({
+    metadata: { latest_agent_proof: proof },
+    review: { proof },
+  }));
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, 'proof_unmerged_or_draft_pr_boundary');
+});
+
+test('reports PR boundary before generic weak proof', () => {
+  const proof = 'Verified #1595 remains OPEN draft CLEAN for the canonical replacement.';
+  const result = evaluateAutoAccept(reviewTask({
+    metadata: { latest_agent_proof: proof },
+    review: { proof },
+  }));
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, 'proof_unmerged_or_draft_pr_boundary');
+});
+
 test('allows merged proof that explains the rejected PR boundary terms', () => {
   const proof = [
     'Merged PR #78 at origin/master commit 7944f271.',


### PR DESCRIPTION
## What changed
- Treat bare GitHub number references like #1600 as PR-state evidence when the same sentence contains stale/draft/unmerged boundary text.
- Run the PR-boundary guard before generic proof-strength checks so safety boundary reasons are not hidden by weak-proof reasons.
- Add regressions for BCK-966/BCK-961-style proof shapes.

## Why
The installed strict dry-run after PR #79 still showed rows where stale PR state used bare #number references. This promotes that observed failure into evaluator coverage, matching the regression-suite pattern from the RSI research sweep.

## Verification
- node --check lib/auto-accept-certified.js
- node --test test/auto-accept-certified.test.js
- node --test test/commands.test.js --test-name-pattern 'auto-accept|review metadata|review-chat|task review'
- node -e direct bare-number evaluator smoke
- git diff --check

Task: BCK-984