### PR TITLE
fix(task): suppress boundary review-chat accept command

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -1187,13 +1187,17 @@ function taskReviewChatHandoff(task, { reviewer = 'codex-review', allowCertified
   const ref = taskRef(task);
   const actor = reviewActor(reviewer);
   const verificationFocus = taskReviewVerificationFocus(task);
+  const reviewHandoff = reviewHandoffForTask(task, { suppressExistingFollowUp: true });
+  const humanAcceptCommand = reviewHandoff && reviewHandoff.next_action === PROOF_BOUNDARY_BLOCKED_ACTION
+    ? null
+    : `atris task accept ${ref}`;
   return {
     schema: 'atris.task_review_chat.v1',
     command: `atris task review-chat ${ref} --as ${actor}`,
     codex_prompt: taskReviewSpecificCodexPrompt(task, verificationFocus, actor),
     pass_command: `atris task review ${ref} --reward 0 --as ${actor} --proof "<specific verifier commands passed and diff/proof inspected>" --verify "<safe verifier command>"`,
     revise_command: `atris task revise ${ref} --as ${actor} --note "<specific missing proof or required change>"`,
-    human_accept_command: `atris task accept ${ref}`,
+    human_accept_command: humanAcceptCommand,
     verification_focus: {
       objective: verificationFocus.objective,
       proof_claim: verificationFocus.proof_claim,

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -9800,6 +9800,7 @@ test('task current exposes continue-work for certified review suggestions', () =
     assert.equal(currentPayload.current.next.key, 'continue_work');
     assert.equal(currentPayload.current.next.command, command);
     assert.equal(currentPayload.current.next.human_accept_command, `atris task accept ${ref}`);
+    assert.equal(currentPayload.page.review.verification_chat.human_accept_command, `atris task accept ${ref}`);
     assert.deepEqual(currentPayload.current.next.api, { method: 'POST', path: `/api/tasks/${parent.id}/continue-work` });
     assert.equal(currentPayload.page.stage.next_action.command, command);
     assert.equal(currentPayload.selected.continue_work_command, command);
@@ -10063,6 +10064,8 @@ test('task review lanes route stale PR proof out of human accept waiting', () =>
     assert.equal(currentPayload.current.review_state_actions.proof_boundary_blocked.human_accept.enabled, false);
     assert.equal(currentPayload.current.review_state_actions.proof_boundary_blocked.human_accept.command, null);
     assert.equal(currentPayload.selected.commands.human_accept, undefined);
+    assert.equal(currentPayload.page.review.verification_chat.human_accept_command, null);
+    assert.doesNotMatch(JSON.stringify(currentPayload.page.review.verification_chat), new RegExp(`atris task accept ${ref}`));
 
     const waiting = runCli([
       'task', 'current',


### PR DESCRIPTION
## Summary
- suppress nested review-chat human_accept_command for proof-boundary-blocked Review rows
- keep normal certified accept-ready rows exposing the human accept command
- add stale PR proof-boundary regression assertions

## Verification
- node --check commands/task.js
- node --check test/commands.test.js
- git diff --check
- node --test test/commands.test.js --test-name-pattern "task current exposes continue-work|task review lanes route stale PR proof"