### PR TITLE
fix(task): let current claimant start do

### DIFF
--- a/lib/task-db.js
+++ b/lib/task-db.js
@@ -720,13 +720,13 @@ function stageTask(db, {
   let proofText = requestedProof || cleanStageText(metadata.verify || metadata.proof_needed);
   let exitText = requestedExit || cleanStageText(metadata.exit_condition);
 
-  function recordedDoPlan(currentRow) {
+  function recordedDoPlan(currentRow, { claimedOwnerWins = false } = {}) {
     const currentMetadata = currentRow && currentRow.metadata && typeof currentRow.metadata === 'object'
       ? { ...currentRow.metadata }
       : {};
     const claimedOwner = cleanStageText(currentRow && currentRow.claimed_by);
     const planOwner = cleanStageText(currentMetadata.stage_owner || currentMetadata.assigned_to);
-    const recordedOwner = claimedOwner || planOwner;
+    const recordedOwner = claimedOwnerWins && claimedOwner ? claimedOwner : (claimedOwner || planOwner);
     const caller = actorText || requestedOwner || null;
     const recordedGoal = cleanStageText(currentMetadata.goal_objective || currentMetadata.objective || currentMetadata.stage_goal || currentMetadata.task_goal);
     const recordedProof = cleanStageText(currentMetadata.verify || currentMetadata.proof_needed);
@@ -743,7 +743,7 @@ function stageTask(db, {
     if (requestedGoal && requestedGoal !== recordedGoal) return { ok: false, reason: 'plan_goal_mismatch' };
     if (requestedProof && requestedProof !== recordedProof) return { ok: false, reason: 'plan_proof_mismatch' };
     if (requestedExit && requestedExit !== recordedExit) return { ok: false, reason: 'plan_exit_mismatch' };
-    if (claimedOwner && planOwner && claimedOwner !== planOwner) {
+    if (claimedOwner && planOwner && claimedOwner !== planOwner && !claimedOwnerWins) {
       return { ok: false, reason: 'claimed_by_other', claimed_by: planOwner };
     }
     if (recordedOwner && caller && recordedOwner !== caller) {
@@ -772,7 +772,7 @@ function stageTask(db, {
       stageOwner = claimedBy;
     }
   } else {
-    const plan = recordedDoPlan(row);
+    const plan = recordedDoPlan(row, { claimedOwnerWins: row.status === 'claimed' });
     if (!plan.ok) return { staged: false, reason: plan.reason, claimed_by: plan.claimed_by || null };
     metadata = plan.metadata;
     stageOwner = plan.stageOwner;
@@ -853,7 +853,7 @@ function stageTask(db, {
   metadata.stage_updated_by = cleanStageText(actor) || null;
   if (stageOwner) {
     metadata.stage_owner = stageOwner;
-    metadata.assigned_to = metadata.assigned_to || stageOwner;
+    metadata.assigned_to = targetStage === 'do' ? stageOwner : (metadata.assigned_to || stageOwner);
   }
   if (hasConfidence && Number.isFinite(confidenceValue)) metadata.stage_confidence = Math.max(0, Math.min(1, confidenceValue));
 

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -6337,6 +6337,61 @@ test('task do rolls back the claim when plan ownership changes during claim', ()
   }
 });
 
+test('task do lets current claimant override stale plan owner metadata', () => {
+  if (!hasNodeSqlite()) return;
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, 'tasks.db');
+  const taskDb = require('../lib/task-db');
+  taskDb.close();
+  try {
+    fs.mkdirSync(path.join(dir, 'project-obelisk', 'atris'), { recursive: true });
+    const db = taskDb.open(dbPath);
+    const workspaceRoot = fs.realpathSync(path.join(dir, 'project-obelisk'));
+    const created = taskDb.addTask(db, {
+      title: 'Do should trust the current claimant',
+      tag: 'capture',
+      workspaceRoot,
+      status: 'claimed',
+      claimedBy: 'agi-research',
+      metadata: {
+        stage: 'plan',
+        planned_at: 'old-plan',
+        stage_plan_recorded_at: 'old-plan',
+        stage_owner: 'keshavrao',
+        assigned_to: 'keshavrao',
+        goal_objective: 'Ship the claimed task',
+        stage_goal: 'Ship the claimed task',
+        exit_condition: 'Do starts under the actual claimant',
+        verify: 'node --test task do ownership coverage',
+        proof_needed: 'node --test task do ownership coverage',
+        next_button: 'Start do',
+      },
+    });
+
+    const doing = taskDb.stageTask(db, {
+      id: created.id,
+      actor: 'agi-research',
+      stage: 'do',
+      firstMove: 'continue from the claimed row',
+    });
+    assert.equal(doing.staged, true);
+    assert.match(doing.stage_packet, /owner: agi-research/);
+
+    const updated = taskDb.getTask(db, created.id);
+    assert.equal(updated.status, 'claimed');
+    assert.equal(updated.claimed_by, 'agi-research');
+    assert.equal(updated.metadata.stage, 'do');
+    assert.equal(updated.metadata.stage_owner, 'agi-research');
+    assert.equal(updated.metadata.assigned_to, 'agi-research');
+    assert.equal(updated.metadata.goal_objective, 'Ship the claimed task');
+    const eventTypes = taskDb.listTaskEvents(db, { taskId: created.id }).map(event => event.event_type);
+    assert.deepEqual(eventTypes, ['claimed', 'work_started']);
+  } finally {
+    taskDb.close();
+    cleanupTempDir(dir);
+  }
+});
+
 test('task do assigns legacy claimed rows that have no claimant', () => {
   if (!hasNodeSqlite()) return;
   const dir = makeTempDir();


### PR DESCRIPTION
## Summary
- let a pre-claimed task's current claimed_by owner start Do even when stale Plan metadata still names an older owner
- keep the existing rollback behavior when Plan ownership changes during an open-row claim inside task do
- update Do-stage metadata.assigned_to to the actual Do owner

## Verification
- node --check lib/task-db.js
- node --check test/commands.test.js
- git diff --check
- node --test test/commands.test.js --test-name-pattern "task do reloads latest plan metadata|task do rolls back the claim|task do lets current claimant|task do assigns legacy claimed rows"