### PR TITLE
fix(task): expose current-step selected next key

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -5318,9 +5318,7 @@ function runCurrentTaskStep(taskDb, db, { owner = DEFAULT_OWNER, reviewer = 'cod
     error.current = current;
     throw error;
   }
-  const nextActionKey = current.page && current.page.stage && current.page.stage.next_action
-    ? current.page.stage.next_action.key
-    : null;
+  const nextActionKey = selectedNextKeyFromCurrent(current);
   if (nextActionKey === 'human_accept_waiting') {
     const error = taskStepError(
       'agent_certified_waiting_human',
@@ -5378,6 +5376,7 @@ function runCurrentTaskStep(taskDb, db, { owner = DEFAULT_OWNER, reviewer = 'cod
       projection_path: after.outPath,
       selected_task_id: current.selected_task_id,
       selected_ref: current.selected_ref || null,
+      selected_next_key: nextActionKey,
       selected_reason: current.selected_reason,
       scope: current.scope,
       before: current,
@@ -5414,6 +5413,7 @@ function runCurrentTaskStep(taskDb, db, { owner = DEFAULT_OWNER, reviewer = 'cod
     projection_path: after.outPath,
     selected_task_id: current.selected_task_id,
     selected_ref: current.selected_ref || null,
+    selected_next_key: nextActionKey,
     selected_reason: current.selected_reason,
     scope: current.scope,
     before: current,
@@ -5459,6 +5459,7 @@ function cmdCurrentStep(args) {
         detail: error.message,
         selected_task_id: errorCurrent ? errorCurrent.selected_task_id : null,
         selected_ref: errorCurrent ? errorCurrent.selected_ref : null,
+        selected_next_key: selectedNextKeyFromCurrent(errorCurrent),
         current: errorCurrent,
         page: error.page || null,
       });
@@ -5476,6 +5477,15 @@ function cmdCurrentStep(args) {
   if (result.page.stage.next_action && result.page.stage.next_action.command) {
     console.log(`Next: ${result.page.stage.next_action.command}`);
   }
+}
+
+function selectedNextKeyFromCurrent(current) {
+  if (!current) return null;
+  if (current.next && current.next.key) return current.next.key;
+  if (current.page && current.page.stage && current.page.stage.next_action) {
+    return current.page.stage.next_action.key || null;
+  }
+  return null;
 }
 
 function cmdStep(args) {
@@ -6931,12 +6941,16 @@ async function handleTaskApi(req, res, taskDb, db) {
       const result = runCurrentTaskStep(taskDb, db, options);
       return sendJson(res, 200, result);
     } catch (error) {
+      const errorCurrent = error.current || null;
       return sendJson(res, error.status || 409, {
         ok: false,
         action: 'current_step',
         reason: error.reason || 'step_failed',
         detail: error.message,
-        current: error.current || null,
+        selected_task_id: errorCurrent ? errorCurrent.selected_task_id : null,
+        selected_ref: errorCurrent ? errorCurrent.selected_ref : null,
+        selected_next_key: selectedNextKeyFromCurrent(errorCurrent),
+        current: errorCurrent,
         page: error.page || null,
       });
     }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -6832,6 +6832,7 @@ test('task current-step advances the scoped current task one safe action', () =>
     const doingPayload = JSON.parse(doing.stdout);
     assert.equal(doingPayload.action, 'current_step');
     assert.equal(doingPayload.selected_ref, scopedTask.display_id);
+    assert.equal(doingPayload.selected_next_key, doingPayload.before_current.next.key);
     assert.equal(doingPayload.before_current.scope.goal_id, 'OBL-928');
     assert.equal(doingPayload.before_current.selected_task_id, scopedTask.id);
     assert.equal(doingPayload.before_current.selected_ref, scopedTask.display_id);
@@ -6862,6 +6863,7 @@ test('task current-step advances the scoped current task one safe action', () =>
     const readyPayload = JSON.parse(ready.stdout);
     assert.equal(readyPayload.selected_task_id, scopedTask.id);
     assert.equal(readyPayload.selected_ref, scopedTask.display_id);
+    assert.equal(readyPayload.selected_next_key, readyPayload.before_current.next.key);
     assert.equal(readyPayload.step.step_action, 'ready');
     assert.equal(readyPayload.current.selected_task_id, scopedTask.id);
     assert.equal(readyPayload.current.selected_ref, scopedTask.display_id);
@@ -6947,6 +6949,7 @@ test('task current-step advances the scoped current task one safe action', () =>
     assert.equal(continueStepPayload.before_current.scope.review_state, 'continue-work');
     assert.equal(continueStepPayload.before_current.selected_task_id, continueTask.id);
     assert.equal(continueStepPayload.selected_ref, continueTask.display_id);
+    assert.equal(continueStepPayload.selected_next_key, 'continue_work');
     assert.equal(continueStepPayload.before_current.selected_ref, continueTask.display_id);
     assert.equal(continueStepPayload.before_current.next.key, 'continue_work');
     assert.equal(continueStepPayload.step.step_action, 'continue_work');
@@ -6974,6 +6977,7 @@ test('task current-step advances the scoped current task one safe action', () =>
     const waitingStepPayload = JSON.parse(waitingStep.stdout);
     assert.equal(waitingStepPayload.reason, 'agent_certified_waiting_human');
     assert.equal(waitingStepPayload.selected_ref, waitingTask.display_id);
+    assert.equal(waitingStepPayload.selected_next_key, 'human_accept_waiting');
     assert.equal(waitingStepPayload.current.selected_task_id, waitingTask.id);
     assert.equal(waitingStepPayload.current.selected_ref, waitingTask.display_id);
     assert.equal(waitingStepPayload.current.next.key, 'human_accept_waiting');
@@ -7005,6 +7009,7 @@ test('task current-step advances the scoped current task one safe action', () =>
     const otherPayload = JSON.parse(otherStep.stdout);
     assert.equal(otherPayload.reason, 'claimed_by_other');
     assert.equal(otherPayload.selected_ref, otherTask.display_id);
+    assert.equal(otherPayload.selected_next_key, otherPayload.current.next.key);
     assert.equal(otherPayload.current.selected_task_id, otherTask.id);
     assert.equal(otherPayload.current.selected_ref, otherTask.display_id);
     assert.equal(otherPayload.current.selected_reason, 'active_do_elsewhere');
@@ -11168,6 +11173,7 @@ test('task serve exposes a local task factory API', async () => {
 		    assert.equal(apiCurrentStepContinue.action, 'current_step');
 		    assert.equal(apiCurrentStepContinue.before_current.scope.review_state, 'continue-work');
 		    assert.equal(apiCurrentStepContinue.before_current.selected_task_id, apiContinueTask.id);
+		    assert.equal(apiCurrentStepContinue.selected_next_key, 'continue_work');
 		    assert.equal(apiCurrentStepContinue.step.step_action, 'continue_work');
 		    assert.equal(apiCurrentStepContinue.step.continue_work.action, 'continue_work');
 		    assert.equal(apiCurrentStepContinue.step.continue_work.parent_task_id, apiContinueTask.id);
@@ -11188,6 +11194,8 @@ test('task serve exposes a local task factory API', async () => {
 		    assert.equal(apiCurrentStepWaitingResponse.status, 409);
 		    const apiCurrentStepWaiting = await apiCurrentStepWaitingResponse.json();
 		    assert.equal(apiCurrentStepWaiting.reason, 'agent_certified_waiting_human');
+		    assert.equal(apiCurrentStepWaiting.selected_task_id, apiWaitingTask.id);
+		    assert.equal(apiCurrentStepWaiting.selected_next_key, 'human_accept_waiting');
 		    assert.equal(apiCurrentStepWaiting.current.selected_task_id, apiWaitingTask.id);
 		    assert.equal(apiCurrentStepWaiting.current.next.key, 'human_accept_waiting');
 		    assert.equal(apiCurrentStepWaiting.page.stage.next_action.command, null);
@@ -11219,6 +11227,7 @@ test('task serve exposes a local task factory API', async () => {
 	    assert.equal(apiCurrentStepReady.before_current.scope.goal_id, 'OBL-928');
 	    assert.equal(apiCurrentStepReady.before_current.selected_task_id, apiScopedTask.id);
 	    assert.equal(apiCurrentStepReady.before_current.selected_reason, 'claimed_by_owner');
+	    assert.equal(apiCurrentStepReady.selected_next_key, apiCurrentStepReady.before_current.next.key);
 	    assert.equal(apiCurrentStepReady.step.step_action, 'ready');
 	    assert.equal(apiCurrentStepReady.current.selected_task_id, apiScopedTask.id);
 	    assert.equal(apiCurrentStepReady.current.next.key, 'review_chat');


### PR DESCRIPTION
## What changed
- Add selected_next_key to task current-step JSON success payloads.
- Add selected_next_key plus selected task metadata to CLI/API current-step error payloads.
- Cover CLI and local API current-step success and blocked lanes.

## Proof
- node --check commands/task.js
- node --check test/commands.test.js
- git diff --check
- node --test test/commands.test.js --test-name-pattern "task current-step advances the scoped current task one safe action|task serve exposes a local task factory API" (330/330 passing)

## Risk
Low: JSON contract expansion only; existing selected_task_id, selected_ref, selected_reason, current, and page fields remain unchanged.