### PR TITLE
fix(task): declare current-step identity fields

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -2029,6 +2029,9 @@ function taskQueueCapabilities() {
     },
     current_step: {
       api: { method: 'POST', path: '/api/tasks/current/step?review_state=<lane>' },
+      output_fields: {
+        identity: ['selected_task_id', 'selected_ref', 'selected_next_key'],
+      },
       safety: {
         read_only: false,
         claims_work: 'conditional',
@@ -2365,6 +2368,7 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
   });
   const acceptedLanes = standalone.filters.review_state.accepted || [];
   const currentStepLanes = standalone.current_step.lanes || {};
+  const currentStepIdentityFields = standalone.current_step.output_fields?.identity || [];
   const drainBehavior = reviewLaneDrainBehaviorConformance();
   const actBehavior = reviewLaneActBehaviorConformance();
   const loopBehavior = reviewLaneLoopBehaviorConformance();
@@ -2391,6 +2395,11 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
         && standalone.current_step.safety.xp_after_human_accept === true
         && standalone.current_step.lanes['human-accept-waiting']
         && standalone.current_step.lanes['human-accept-waiting'].safe_for_agent === false
+    ),
+    capabilityCheck(
+      'current_step_declares_identity_output_fields',
+      ['selected_task_id', 'selected_ref', 'selected_next_key'].every(field => currentStepIdentityFields.includes(field)),
+      { identity: currentStepIdentityFields }
     ),
     capabilityCheck(
       'read_only_projection_semantics_declared',

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4566,6 +4566,7 @@ test('task capabilities returns the standalone read-only task capability contrac
     assert.equal(payload.capabilities.commands.queue, 'atris task queue --review-state <lane> --json');
     assert.equal(payload.capabilities.commands.current_step, 'atris task current-step --review-state <lane> --json');
     assert.equal(payload.capabilities.current_step.api.path, '/api/tasks/current/step?review_state=<lane>');
+    assert.deepEqual(payload.capabilities.current_step.output_fields.identity, ['selected_task_id', 'selected_ref', 'selected_next_key']);
     assert.equal(payload.capabilities.current_step.safety.claims_work, 'conditional');
     assert.equal(payload.capabilities.current_step.lanes['continue-work'].creates_or_reuses_follow_up, true);
     assert.equal(payload.capabilities.current_step.lanes['human-accept-waiting'].safe_for_agent, false);
@@ -4627,6 +4628,7 @@ test('task capabilities-check reports contract drift without mutating task truth
     assert.ok(payload.checks.some(check => check.name === 'current_capabilities_match_standalone' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'queue_capabilities_match_standalone' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'current_step_never_human_accepts' && check.ok));
+    assert.ok(payload.checks.some(check => check.name === 'current_step_declares_identity_output_fields' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'capabilities_check_surface_declared' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'review_lane_drain_surface_declared' && check.ok));
     const drainBehaviorCheck = payload.checks.find(check => check.name === 'review_lane_drain_behavior_conforms');


### PR DESCRIPTION
## What changed
- Declare current_step.output_fields.identity in task capabilities.
- Add capabilities-check invariant for selected_task_id, selected_ref, selected_next_key.
- Cover standalone capabilities JSON and capabilities-check report.

## Proof
- node --check commands/task.js
- node --check test/commands.test.js
- git diff --check
- node --test test/commands.test.js --test-name-pattern "task capabilities returns the standalone read-only task capability contract|task capabilities-check reports contract drift|task current-step advances the scoped current task one safe action" (330/330 passing)

## Risk
Low: capabilities contract expansion only; existing lanes/safety behavior is unchanged.