### PR TITLE
BCK-994: Declare current and queue identity outputs

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -1998,6 +1998,9 @@ function taskQueueCapabilities() {
         mutates_task_db: false,
         writes_projection: true,
         requires_task_db: true,
+        output_fields: {
+          identity: ['selected_task_id', 'selected_ref', 'selected_next_key'],
+        },
       },
       queue: {
         command: 'atris task queue --review-state <lane> --json',
@@ -2006,6 +2009,9 @@ function taskQueueCapabilities() {
         mutates_task_db: false,
         writes_projection: true,
         requires_task_db: true,
+        output_fields: {
+          identity: ['selected_task_id', 'selected_ref', 'selected_next_key'],
+        },
       },
     },
     filters: {
@@ -2369,6 +2375,8 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
   const acceptedLanes = standalone.filters.review_state.accepted || [];
   const currentStepLanes = standalone.current_step.lanes || {};
   const currentStepIdentityFields = standalone.current_step.output_fields?.identity || [];
+  const currentIdentityFields = standalone.surfaces.current.output_fields?.identity || [];
+  const queueIdentityFields = standalone.surfaces.queue.output_fields?.identity || [];
   const drainBehavior = reviewLaneDrainBehaviorConformance();
   const actBehavior = reviewLaneActBehaviorConformance();
   const loopBehavior = reviewLaneLoopBehaviorConformance();
@@ -2400,6 +2408,11 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
       'current_step_declares_identity_output_fields',
       ['selected_task_id', 'selected_ref', 'selected_next_key'].every(field => currentStepIdentityFields.includes(field)),
       { identity: currentStepIdentityFields }
+    ),
+    capabilityCheck(
+      'current_and_queue_declare_identity_output_fields',
+      ['selected_task_id', 'selected_ref', 'selected_next_key'].every(field => currentIdentityFields.includes(field) && queueIdentityFields.includes(field)),
+      { current: currentIdentityFields, queue: queueIdentityFields }
     ),
     capabilityCheck(
       'read_only_projection_semantics_declared',

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4551,10 +4551,12 @@ test('task capabilities returns the standalone read-only task capability contrac
     assert.equal(payload.capabilities.surfaces.current.mutates_task_db, false);
     assert.equal(payload.capabilities.surfaces.current.writes_projection, true);
     assert.equal(payload.capabilities.surfaces.current.requires_task_db, true);
+    assert.deepEqual(payload.capabilities.surfaces.current.output_fields.identity, ['selected_task_id', 'selected_ref', 'selected_next_key']);
     assert.equal(payload.capabilities.surfaces.queue.read_only, true);
     assert.equal(payload.capabilities.surfaces.queue.mutates_task_db, false);
     assert.equal(payload.capabilities.surfaces.queue.writes_projection, true);
     assert.equal(payload.capabilities.surfaces.queue.requires_task_db, true);
+    assert.deepEqual(payload.capabilities.surfaces.queue.output_fields.identity, ['selected_task_id', 'selected_ref', 'selected_next_key']);
     assert.deepEqual(payload.capabilities.filters.review_state.accepted, ['needs-agent', 'continue-work', 'proof-boundary-blocked', 'human-accept-waiting', 'certified']);
     assert.equal(payload.capabilities.commands.capabilities, 'atris task capabilities --json');
     assert.equal(payload.capabilities.commands.capabilities_check, 'atris task capabilities-check --json');
@@ -4629,6 +4631,7 @@ test('task capabilities-check reports contract drift without mutating task truth
     assert.ok(payload.checks.some(check => check.name === 'queue_capabilities_match_standalone' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'current_step_never_human_accepts' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'current_step_declares_identity_output_fields' && check.ok));
+    assert.ok(payload.checks.some(check => check.name === 'current_and_queue_declare_identity_output_fields' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'capabilities_check_surface_declared' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'review_lane_drain_surface_declared' && check.ok));
     const drainBehaviorCheck = payload.checks.find(check => check.name === 'review_lane_drain_behavior_conforms');


### PR DESCRIPTION
## Summary
- declare selected_task_id, selected_ref, and selected_next_key as identity output fields for task current --json
- declare the same identity output fields for task queue --json
- add a capabilities-check invariant so the declarations cannot drift silently

## Verification
- node --check commands/task.js
- node --check test/commands.test.js
- git diff --check
- node --test test/commands.test.js --test-name-pattern 'task capabilities returns the standalone read-only task capability contract|task capabilities-check reports contract drift' (330/330 passed)
- live smoke: task capabilities --json reports current/queue/current_step identity fields
- live smoke: task capabilities-check --json returns 18/18 and current_and_queue_declare_identity_output_fields ok