### PR TITLE
BCK-996: Declare review drain identity outputs

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -1941,6 +1941,9 @@ function taskQueueCapabilities() {
         writes_projection: true,
         requires_task_db: true,
         skips_existing_follow_up_children: true,
+        output_fields: {
+          identity: ['selected_task_id', 'selected_ref', 'selected_next_key'],
+        },
       },
       review_lane_act: {
         command: 'atris task review-lane-act --json',
@@ -2377,6 +2380,7 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
   const currentStepIdentityFields = standalone.current_step.output_fields?.identity || [];
   const currentIdentityFields = standalone.surfaces.current.output_fields?.identity || [];
   const queueIdentityFields = standalone.surfaces.queue.output_fields?.identity || [];
+  const reviewLaneDrainIdentityFields = standalone.surfaces.review_lane_drain.output_fields?.identity || [];
   const drainBehavior = reviewLaneDrainBehaviorConformance();
   const actBehavior = reviewLaneActBehaviorConformance();
   const loopBehavior = reviewLaneLoopBehaviorConformance();
@@ -2413,6 +2417,11 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
       'current_and_queue_declare_identity_output_fields',
       ['selected_task_id', 'selected_ref', 'selected_next_key'].every(field => currentIdentityFields.includes(field) && queueIdentityFields.includes(field)),
       { current: currentIdentityFields, queue: queueIdentityFields }
+    ),
+    capabilityCheck(
+      'review_lane_drain_declares_identity_output_fields',
+      ['selected_task_id', 'selected_ref', 'selected_next_key'].every(field => reviewLaneDrainIdentityFields.includes(field)),
+      { identity: reviewLaneDrainIdentityFields }
     ),
     capabilityCheck(
       'read_only_projection_semantics_declared',

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4501,6 +4501,7 @@ test('task capabilities returns the standalone read-only task capability contrac
     assert.equal(payload.capabilities.surfaces.review_lane_drain.writes_projection, true);
     assert.equal(payload.capabilities.surfaces.review_lane_drain.requires_task_db, true);
     assert.equal(payload.capabilities.surfaces.review_lane_drain.skips_existing_follow_up_children, true);
+    assert.deepEqual(payload.capabilities.surfaces.review_lane_drain.output_fields.identity, ['selected_task_id', 'selected_ref', 'selected_next_key']);
     assert.deepEqual(payload.capabilities.surfaces.review_lane_drain.api, { method: 'GET', path: '/api/tasks/review-lane-drain' });
     assert.equal(payload.capabilities.surfaces.review_lane_act.read_only, false);
     assert.equal(payload.capabilities.surfaces.review_lane_act.mutates_task_db, 'conditional');
@@ -4632,6 +4633,7 @@ test('task capabilities-check reports contract drift without mutating task truth
     assert.ok(payload.checks.some(check => check.name === 'current_step_never_human_accepts' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'current_step_declares_identity_output_fields' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'current_and_queue_declare_identity_output_fields' && check.ok));
+    assert.ok(payload.checks.some(check => check.name === 'review_lane_drain_declares_identity_output_fields' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'capabilities_check_surface_declared' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'review_lane_drain_surface_declared' && check.ok));
     const drainBehaviorCheck = payload.checks.find(check => check.name === 'review_lane_drain_behavior_conforms');


### PR DESCRIPTION
## Summary
- declare selected_task_id, selected_ref, and selected_next_key as identity output fields for task review-lane-drain --json
- add a capabilities-check invariant for the review-lane-drain identity declaration
- keep current/queue/current-step identity declarations unchanged

## Verification
- node --check commands/task.js
- node --check test/commands.test.js
- git diff --check
- node --test test/commands.test.js --test-name-pattern 'task capabilities returns the standalone read-only task capability contract|task capabilities-check reports contract drift' (330/330 passed)
- live smoke: task capabilities --json reports review_lane_drain identity fields
- live smoke: task capabilities-check --json returns 19/19 with review_lane_drain_declares_identity_output_fields ok