### PR TITLE
BCK-998: Declare review act identity outputs

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -1955,6 +1955,9 @@ function taskQueueCapabilities() {
         dry_run_flag: '--dry-run',
         allowed_actions: ['review_chat', 'continue_work'],
         blocked_actions: [PROOF_BOUNDARY_BLOCKED_ACTION, 'human_accept_waiting', 'pending_review_chat', 'capabilities_drift', 'none'],
+        output_fields: {
+          identity: ['selected_task_id', 'selected_ref', 'selected_next_key'],
+        },
       },
       review_lane_loop: {
         command: 'atris task review-lane-loop --json',
@@ -2381,6 +2384,7 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
   const currentIdentityFields = standalone.surfaces.current.output_fields?.identity || [];
   const queueIdentityFields = standalone.surfaces.queue.output_fields?.identity || [];
   const reviewLaneDrainIdentityFields = standalone.surfaces.review_lane_drain.output_fields?.identity || [];
+  const reviewLaneActIdentityFields = standalone.surfaces.review_lane_act.output_fields?.identity || [];
   const drainBehavior = reviewLaneDrainBehaviorConformance();
   const actBehavior = reviewLaneActBehaviorConformance();
   const loopBehavior = reviewLaneLoopBehaviorConformance();
@@ -2422,6 +2426,11 @@ function taskCapabilitiesCheckReport(taskDb, db, args = [], options = {}) {
       'review_lane_drain_declares_identity_output_fields',
       ['selected_task_id', 'selected_ref', 'selected_next_key'].every(field => reviewLaneDrainIdentityFields.includes(field)),
       { identity: reviewLaneDrainIdentityFields }
+    ),
+    capabilityCheck(
+      'review_lane_act_declares_identity_output_fields',
+      ['selected_task_id', 'selected_ref', 'selected_next_key'].every(field => reviewLaneActIdentityFields.includes(field)),
+      { identity: reviewLaneActIdentityFields }
     ),
     capabilityCheck(
       'read_only_projection_semantics_declared',

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -4511,6 +4511,7 @@ test('task capabilities returns the standalone read-only task capability contrac
     assert.deepEqual(payload.capabilities.surfaces.review_lane_act.api, { method: 'POST', path: '/api/tasks/review-lane-act' });
     assert.deepEqual(payload.capabilities.surfaces.review_lane_act.allowed_actions, ['review_chat', 'continue_work']);
     assert.ok(payload.capabilities.surfaces.review_lane_act.blocked_actions.includes('human_accept_waiting'));
+    assert.deepEqual(payload.capabilities.surfaces.review_lane_act.output_fields.identity, ['selected_task_id', 'selected_ref', 'selected_next_key']);
     assert.equal(payload.capabilities.surfaces.review_lane_loop.read_only, false);
     assert.equal(payload.capabilities.surfaces.review_lane_loop.mutates_task_db, 'conditional');
     assert.equal(payload.capabilities.surfaces.review_lane_loop.writes_projection, true);
@@ -4634,6 +4635,7 @@ test('task capabilities-check reports contract drift without mutating task truth
     assert.ok(payload.checks.some(check => check.name === 'current_step_declares_identity_output_fields' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'current_and_queue_declare_identity_output_fields' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'review_lane_drain_declares_identity_output_fields' && check.ok));
+    assert.ok(payload.checks.some(check => check.name === 'review_lane_act_declares_identity_output_fields' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'capabilities_check_surface_declared' && check.ok));
     assert.ok(payload.checks.some(check => check.name === 'review_lane_drain_surface_declared' && check.ok));
     const drainBehaviorCheck = payload.checks.find(check => check.name === 'review_lane_drain_behavior_conforms');


### PR DESCRIPTION
## Summary
- declare selected_task_id, selected_ref, and selected_next_key as identity output fields for task review-lane-act --json
- add a capabilities-check invariant for the review-lane-act identity declaration
- keep existing review-lane-act behavior unchanged

## Verification
- node --check commands/task.js
- node --check test/commands.test.js
- git diff --check
- node --test test/commands.test.js --test-name-pattern 'task capabilities returns the standalone read-only task capability contract|task capabilities-check reports contract drift' (330/330 passed)
- live smoke: task capabilities --json reports review_lane_act identity fields
- live smoke: task capabilities-check --json returns 20/20 with review_lane_act_declares_identity_output_fields ok