### PR TITLE
fix(brain): resolve primary state from worktrees

### DIFF
--- a/commands/brain.js
+++ b/commands/brain.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { spawnSync } = require('child_process');
 const { refreshNowFile } = require('./now');
 
 const GENERATED_START = '<!-- ATRIS_BRAIN_COMPILE:START -->';
@@ -243,6 +244,56 @@ function readJsonlRows(filePath) {
   return rows;
 }
 
+function parseGitWorktrees(text) {
+  const out = [];
+  let current = {};
+  for (const raw of `${text || ''}\n`.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) {
+      if (current.worktree) out.push(path.resolve(current.worktree));
+      current = {};
+      continue;
+    }
+    const idx = line.indexOf(' ');
+    if (idx === -1) {
+      current[line] = true;
+    } else {
+      current[line.slice(0, idx)] = line.slice(idx + 1);
+    }
+  }
+  return out;
+}
+
+function primaryWorktreeRoot(root) {
+  const result = spawnSync('git', ['worktree', 'list', '--porcelain'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) return null;
+  const [primary] = parseGitWorktrees(result.stdout);
+  return primary || null;
+}
+
+function stateRowCount(stateDir) {
+  return collectStateFileStats(stateDir)
+    .reduce((sum, item) => sum + item.rows, 0);
+}
+
+function resolveStateRoots(root) {
+  const primary = primaryWorktreeRoot(root);
+  if (!primary || path.resolve(primary) === path.resolve(root)) return [root];
+
+  const primaryStateDir = path.join(primary, '.atris', 'state');
+  if (!fs.existsSync(primaryStateDir)) return [root];
+
+  return stateRowCount(primaryStateDir) > 0 ? [root, primary] : [root];
+}
+
+function resolveStateRoot(root) {
+  const roots = resolveStateRoots(root);
+  return roots[roots.length - 1] || root;
+}
+
 function countTodoItems(todoText) {
   const text = String(todoText || '');
   const hasRenderedSections = /^##\s+(Backlog|In Progress|Blocked|Completed)\s*$/m.test(text);
@@ -384,7 +435,9 @@ function isNextMoveScorecard(row) {
 
 function collectState(root) {
   const atrisDir = path.join(root, 'atris');
-  const stateDir = path.join(root, '.atris', 'state');
+  const stateRoot = resolveStateRoot(root);
+  const stateRoots = resolveStateRoots(root);
+  const stateDirs = stateRoots.map(item => path.join(item, '.atris', 'state'));
   const business = readJson(path.join(root, '.atris', 'business.json')) || {};
   const todoText = readText(path.join(atrisDir, 'TODO.md'));
   const mapText = readText(path.join(atrisDir, 'MAP.md'));
@@ -392,11 +445,11 @@ function collectState(root) {
   const wikiStatus = readText(path.join(atrisDir, 'wiki', 'STATUS.md'));
   const status = readText(path.join(atrisDir, 'STATUS.md'));
 
-  const stateFiles = collectStateFileStats(stateDir);
+  const stateFiles = stateDirs.flatMap(stateDir => collectStateFileStats(stateDir));
 
   const totalRows = stateFiles.reduce((sum, item) => sum + item.rows, 0);
   const validRows = stateFiles.reduce((sum, item) => sum + item.validRows, 0);
-  const latestScorecard = readJsonlRows(path.join(stateDir, 'scorecards.jsonl'))
+  const latestScorecard = stateDirs.flatMap(stateDir => readJsonlRows(path.join(stateDir, 'scorecards.jsonl')))
     .filter(isNextMoveScorecard)
     .sort((a, b) => scorecardTs(a).localeCompare(scorecardTs(b)))
     .pop() || null;
@@ -421,6 +474,8 @@ function collectState(root) {
     mapLineCount: mapText ? mapText.split('\n').length : 0,
     wikiPages: listMarkdown(root, 'atris/wiki', 20),
     stateFiles,
+    stateRoot,
+    stateRoots,
     loopHealth: buildLoopHealth(stateFiles),
     totalRows,
     validRows,
@@ -1027,14 +1082,18 @@ function latestTaskEpisodes(taskEpisodes) {
 
 function recordTaskEpisodeScorecards(options) {
   const root = options.root;
-  const stateDir = path.join(root, '.atris', 'state');
-  const taskEpisodesPath = path.join(stateDir, 'task_episodes.jsonl');
+  const stateRoot = resolveStateRoot(root);
+  const stateDir = path.join(stateRoot, '.atris', 'state');
+  const stateDirs = resolveStateRoots(root).map(item => path.join(item, '.atris', 'state'));
   const scorecardsPath = path.join(stateDir, 'scorecards.jsonl');
-  const workspace = readJson(path.join(root, '.atris', 'business.json')) || {};
-  const taskEpisodes = readJsonlRows(taskEpisodesPath)
+  const workspace =
+    readJson(path.join(stateRoot, '.atris', 'business.json')) ||
+    readJson(path.join(root, '.atris', 'business.json')) ||
+    {};
+  const taskEpisodes = stateDirs.flatMap(item => readJsonlRows(path.join(item, 'task_episodes.jsonl')))
     .filter(row => row && row.schema === 'atris.task_episode.v1');
   const scoreableEpisodes = latestTaskEpisodes(taskEpisodes);
-  const existing = readJsonlRows(scorecardsPath);
+  const existing = stateDirs.flatMap(item => readJsonlRows(path.join(item, 'scorecards.jsonl')));
   const seenEpisodeIds = new Set(existing
     .map(row => row.source_episode_id)
     .filter(Boolean));
@@ -1050,6 +1109,7 @@ function recordTaskEpisodeScorecards(options) {
   }
 
   return {
+    stateRoot,
     taskEpisodes: taskEpisodes.length,
     written: written.length,
     scorecards: written,
@@ -1057,11 +1117,11 @@ function recordTaskEpisodeScorecards(options) {
 }
 
 function verifyTaskEpisodeScorecards(root) {
-  const stateDir = path.join(root, '.atris', 'state');
-  const taskEpisodes = readJsonlRows(path.join(stateDir, 'task_episodes.jsonl'))
+  const stateDirs = resolveStateRoots(root).map(item => path.join(item, '.atris', 'state'));
+  const taskEpisodes = stateDirs.flatMap(item => readJsonlRows(path.join(item, 'task_episodes.jsonl')))
     .filter(row => row && row.schema === 'atris.task_episode.v1');
   const scoreableEpisodes = latestTaskEpisodes(taskEpisodes);
-  const scorecards = readJsonlRows(path.join(stateDir, 'scorecards.jsonl'));
+  const scorecards = stateDirs.flatMap(item => readJsonlRows(path.join(item, 'scorecards.jsonl')));
   const scorecardEpisodeIds = new Set(scorecards
     .map(row => row.source_episode_id)
     .filter(Boolean));
@@ -1121,13 +1181,17 @@ ${rows}`;
 }
 
 function renderStatus(state) {
+  const stateRootLine = state.stateRoot && path.resolve(state.stateRoot) !== path.resolve(state.root)
+    ? `- State root: ${state.stateRoot} (primary checkout)\n`
+    : '';
+
   return `# Atris Brain Status
 
 - Generated: ${state.generatedAt}
 - Workspace: ${state.name}
 - Slug: ${state.slug}
 - Root: ${state.root}
-- Now loaded: ${state.hasNow ? `yes (${state.nowHeading || 'no heading'})` : 'no'}
+${stateRootLine}- Now loaded: ${state.hasNow ? `yes (${state.nowHeading || 'no heading'})` : 'no'}
 - MAP loaded: ${state.hasMap ? `yes (${state.mapLineCount} lines)` : 'no'}
 - Wiki status loaded: ${state.hasWikiStatus ? 'yes' : 'no'}
 - TODO open estimate: ${state.todo.open}
@@ -1168,7 +1232,7 @@ Definitions: operator = current person or agent; move = one concrete high-levera
 
 function renderLedger(state) {
   const rows = state.stateFiles.map(item => {
-    const rel = path.relative(state.root, item.path).replace(/\\/g, '/');
+    const rel = path.relative(state.stateRoot || state.root, item.path).replace(/\\/g, '/');
     return `| \`${rel}\` | ${item.exists ? 'yes' : 'no'} | ${item.rows} | ${item.validRows} | ${item.latestTs || ''} |`;
   }).join('\n');
 

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -3212,6 +3212,113 @@ test('brain scorecard uses latest review episode per task', () => {
   }
 });
 
+test('brain scorecard uses primary checkout state from thin worktrees', () => {
+  const dir = makeTempDir();
+  let worktreePath;
+  try {
+    seedBrainWorkspace(dir);
+    assert.equal(runGit(['init', '-q'], dir).status, 0);
+    assert.equal(runGit(['config', 'user.email', 'test@example.com'], dir).status, 0);
+    assert.equal(runGit(['config', 'user.name', 'Test User'], dir).status, 0);
+    assert.equal(runGit(['add', '.'], dir).status, 0);
+    assert.equal(runGit(['commit', '-qm', 'init'], dir).status, 0);
+
+    worktreePath = path.join(dir, '..', `${path.basename(dir)}-brain-worktree`);
+    assert.equal(runGit(['worktree', 'add', '-q', '--detach', worktreePath, 'HEAD'], dir).status, 0);
+
+    const taskEpisodes = [
+      {
+        schema: 'atris.task_episode.v1',
+        episode_id: 'episode-done',
+        task_id: 'task-primary-state',
+        created_at: '2026-06-01T00:00:00.000Z',
+        state: { title: 'Score worktree brain state', tag: 'brain' },
+        action: { actor: 'researcher', type: 'done' },
+        reward: { value: 0, source: 'task_done' },
+        proof: 'initial proof',
+      },
+      {
+        schema: 'atris.task_episode.v1',
+        episode_id: 'episode-review',
+        task_id: 'task-primary-state',
+        created_at: '2026-06-01T00:01:00.000Z',
+        state: { title: 'Score worktree brain state', tag: 'brain' },
+        action: { actor: 'validator', type: 'review' },
+        reward: { value: 4, source: 'task_review' },
+        lesson: 'Thin worktrees should read the primary state ledger.',
+        proof: 'review proof',
+        next_task_suggestion: 'Use the primary state root for brain reward signals',
+      },
+    ];
+    fs.writeFileSync(
+      path.join(dir, '.atris', 'state', 'task_episodes.jsonl'),
+      taskEpisodes.map(row => JSON.stringify(row)).join('\n') + '\n',
+      'utf8'
+    );
+    const localStateDir = path.join(worktreePath, '.atris', 'state');
+    fs.mkdirSync(localStateDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localStateDir, 'task_episodes.jsonl'),
+      [
+        {
+          schema: 'atris.task_episode.v1',
+          episode_id: 'episode-local-duplicate',
+          task_id: 'task-primary-state',
+          created_at: '2026-06-01T00:02:00.000Z',
+          state: { title: 'Score worktree brain state', tag: 'brain' },
+          action: { actor: 'local', type: 'review' },
+          reward: { value: 1, source: 'local_duplicate' },
+          proof: 'stale local duplicate',
+        },
+        {
+          schema: 'atris.task_episode.v1',
+          episode_id: 'episode-local-review',
+          task_id: 'task-local-state',
+          created_at: '2026-06-01T00:03:00.000Z',
+          state: { title: 'Score local worktree-only state', tag: 'brain' },
+          action: { actor: 'local', type: 'review' },
+          reward: { value: 3, source: 'task_review' },
+          proof: 'local worktree proof',
+        },
+      ].map(row => JSON.stringify(row)).join('\n') + '\n',
+      'utf8'
+    );
+
+    const scorecard = runCli(['brain', 'scorecard', '--root', worktreePath, '--verify', '--json'], { cwd: worktreePath });
+    assert.equal(scorecard.status, 0, scorecard.stderr);
+    const payload = JSON.parse(scorecard.stdout);
+    assert.equal(fs.realpathSync(payload.stateRoot), fs.realpathSync(dir));
+    assert.equal(payload.taskEpisodes, 4);
+    assert.equal(payload.written, 2);
+    assert.equal(payload.scorecards[0].source_episode_id, 'episode-review');
+    assert.equal(payload.scorecards[0].reward, 4);
+    assert.equal(payload.scorecards[1].source_episode_id, 'episode-local-review');
+    assert.equal(payload.scorecards[1].reward, 3);
+    assert.equal(payload.scorecards[0].workspace, 'demo-lab');
+
+    assert.equal(fs.existsSync(path.join(dir, '.atris', 'state', 'scorecards.jsonl')), true);
+    assert.equal(fs.existsSync(path.join(worktreePath, '.atris', 'state', 'scorecards.jsonl')), false);
+
+    const compile = runCli(['brain', 'compile', '--root', worktreePath, '--verify'], { cwd: worktreePath });
+    assert.equal(compile.status, 0, compile.stderr);
+    assert.match(compile.stdout, /State rows: 8 raw \/ 8 valid/);
+    assert.doesNotMatch(compile.stdout, /Turn existing episode rows into the first scorecard/);
+
+    const status = fs.readFileSync(path.join(worktreePath, 'atris', 'brain', 'STATUS.md'), 'utf8');
+    assert.match(status, new RegExp(`State root: ${payload.stateRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\(primary checkout\\)`));
+    const state = collectState(worktreePath);
+    assert.equal(fs.realpathSync(state.stateRoot), fs.realpathSync(dir));
+    assert.deepEqual(
+      state.stateRoots.map(item => fs.realpathSync(item)),
+      [fs.realpathSync(worktreePath), fs.realpathSync(dir)]
+    );
+    assert.equal(state.totalRows, 8);
+  } finally {
+    if (worktreePath) cleanupTempDir(worktreePath);
+    cleanupTempDir(dir);
+  }
+});
+
 test('brain compile rejects meta scorecard next suggestions', () => {
   const dir = makeTempDir();
   try {


### PR DESCRIPTION
## Summary
- Resolve the primary checkout from thin git worktrees so `atris brain compile` and `atris brain scorecard` can see canonical `.atris/state` reward rows.
- Read state from both the local worktree and the primary checkout, while keeping scorecard writes in the primary checkout state directory.
- Extend the worktree regression to prove local-only task episodes are not missed and duplicate task episodes do not create duplicate scorecards.

## Proof
- `node --test --test-name-pattern "brain" test/commands.test.js` -> 51 passed.
- `node --test test/commands.test.js` -> 331 passed.
- `node -c commands/brain.js` -> passed.
- `git diff --check` -> passed.
- Read-only live `collectState` against backend worktree resolved state roots `[thin worktree, /Users/keshavrao/arena/atrisos-backend]`, write root `/Users/keshavrao/arena/atrisos-backend`, `totalRows=4331`, `validRows=4331`, `taskEpisodeRows=1193`, `scorecardRows=373`.

## Review
- Earlier Swarlo approval was for `2ac081021f74522d732c20ae7e16de39a81d3bcb`; current head changed to align with backend union behavior.
- Fresh Swarlo re-ack requested: `review-pr-95-final-71dbe1d-20260606`, assigned to `atris-rl-engineer`.
- Current head: `71dbe1d59836c6d87209a073385fdfcf680cfd30`.
