### PR TITLE
Gate task episode lessons on positive reward

### DIFF
--- a/lib/task-db.js
+++ b/lib/task-db.js
@@ -1192,6 +1192,7 @@ function taskEpisodeFromReview(row, event, payload) {
   const hasProof = Boolean(String(payload.proof || '').trim());
   const label = reviewOutcomeLabel(payload.reward);
   const doneForXp = row.status === 'done';
+  const trainingLesson = rewardValue > 0 ? payload.lesson : '';
   return {
     schema: 'atris.task_episode.v1',
     episode_id: event.event_id,
@@ -1214,7 +1215,7 @@ function taskEpisodeFromReview(row, event, payload) {
       value: payload.reward,
       source: 'task_review',
     },
-    lesson: payload.lesson,
+    lesson: trainingLesson,
     proof: payload.proof,
     next_task_suggestion: payload.next_task,
     goal: goalSignalFromTaskMetadata(metadata),
@@ -1229,7 +1230,7 @@ function taskEpisodeFromReview(row, event, payload) {
       source: 'task_review',
       reward: Number.isFinite(rewardValue) ? rewardValue : 0,
       has_proof: hasProof,
-      has_lesson: Boolean(String(payload.lesson || '').trim()),
+      has_lesson: Boolean(String(trainingLesson || '').trim()),
       has_next_task: Boolean(String(payload.next_task || '').trim()),
     },
   };

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -6045,6 +6045,60 @@ test('task done with proof writes a reviewed proof event', () => {
   }
 });
 
+test('task review keeps verifier notes visible but gates training lessons on positive reward', () => {
+  if (!hasNodeSqlite()) return;
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, 'tasks.db');
+  const env = { ATRIS_TASKS_DB: dbPath, NODE_NO_WARNINGS: '1' };
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const zeroAdd = runCli(['task', 'add', 'Revise weak lesson capture', '--tag', 'rsi', '--json'], { cwd: dir, env });
+    assert.equal(zeroAdd.status, 0, zeroAdd.stderr);
+    const zeroRef = JSON.parse(zeroAdd.stdout).task.display_id;
+
+    const zeroReview = runCli([
+      'task', 'review', zeroRef,
+      '--reward', '0',
+      '--lesson', 'Keep this verifier note visible',
+      '--as', 'validator',
+      '--json',
+    ], { cwd: dir, env });
+    assert.equal(zeroReview.status, 0, zeroReview.stderr);
+    const zeroPayload = JSON.parse(zeroReview.stdout);
+    assert.equal(zeroPayload.task.review.lesson, 'Keep this verifier note visible');
+    assert.equal(zeroPayload.episode.reward.value, 0);
+    assert.equal(zeroPayload.episode.lesson, '');
+    assert.equal(zeroPayload.episode.rl.label, 'revised');
+    assert.equal(zeroPayload.episode.rl.has_lesson, false);
+
+    const negativeAdd = runCli(['task', 'add', 'Reject weak lesson capture', '--tag', 'rsi', '--json'], { cwd: dir, env });
+    assert.equal(negativeAdd.status, 0, negativeAdd.stderr);
+    const negativeRef = JSON.parse(negativeAdd.stdout).task.display_id;
+
+    const negativeReview = runCli([
+      'task', 'review', negativeRef,
+      '--reward', '-1',
+      '--lesson', 'Keep rejected-task rationale visible',
+      '--as', 'validator',
+      '--json',
+    ], { cwd: dir, env });
+    assert.equal(negativeReview.status, 0, negativeReview.stderr);
+    const negativePayload = JSON.parse(negativeReview.stdout);
+    assert.equal(negativePayload.task.review.lesson, 'Keep rejected-task rationale visible');
+    assert.equal(negativePayload.episode.reward.value, -1);
+    assert.equal(negativePayload.episode.lesson, '');
+    assert.equal(negativePayload.episode.rl.label, 'rejected');
+    assert.equal(negativePayload.episode.rl.has_lesson, false);
+
+    const episodePath = path.join(dir, '.atris', 'state', 'task_episodes.jsonl');
+    const episodes = fs.readFileSync(episodePath, 'utf8').trim().split(/\r?\n/).map((line) => JSON.parse(line));
+    assert.deepEqual(episodes.map((episode) => episode.lesson), ['', '']);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('task plan and do record an explicit headless stage contract', () => {
   if (!hasNodeSqlite()) return;
   const dir = makeTempDir();


### PR DESCRIPTION
## Summary
- Keep task review/verifier notes visible on the task record for zero and negative reward reviews.
- Stop zero and negative reward review notes from becoming RL/brain training lessons in task episode rows.
- Add regression coverage for zero and negative reward reviews.

## Proof
- `node --test --test-name-pattern "task review keeps verifier notes|task review writes a reviewed event|task done with proof writes a reviewed proof event|task ready holds work in review" test/commands.test.js` -> 4 passed
- `node --check lib/task-db.js && node --check test/commands.test.js && git diff --check` -> passed
- `node --test --test-name-pattern "brain|task review writes a reviewed event|task review keeps verifier notes" test/commands.test.js` -> 52 passed
- `node --test test/commands.test.js` -> 331 passed, 0 failed

## Risk
- Low code surface, but this touches reward/training semantics. Positive-reward lessons are unchanged; non-positive lessons remain visible in review context but are excluded from episode training fields.