### PR TITLE
fix ax chat alias routing

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -29,7 +29,7 @@ For details, read `atris/wiki/concepts/owner-computer-model.md` before changing 
 ```bash
 # Core CLI logic
 rg "async function interactiveEntry|async function atrisDevEntry|shouldGatherContext|renderContextGathererPrompt" bin/atris.js lib/context-gatherer.js    # Main entry points: cold-start dispatcher, first-contact context gatherer, legacy natural-language mode
-rg "modelForMode|buildPayload|formatUsage|async function chat|postTurn|runAxSpawnCommand|runAxYoutubeCommand|runChatDogfood|extractYoutubeUrl" ax test/cli-smoke.test.js test/ax.test.js  # ax Atris2 local coding-agent CLI: Fast/Pro modes, SSE streaming, workspace_path, chat history, doctor/help, durable worker spawn aliases, local YouTube URL routing, and safe 25-loop --dogfood-chat checklist
+rg "modelForMode|buildPayload|formatUsage|normalizeChatCommandArgs|async function chat|postTurn|runAxSpawnCommand|runAxYoutubeCommand|runChatDogfood|extractYoutubeUrl" ax test/cli-smoke.test.js test/ax.test.js  # ax Atris2 local coding-agent CLI: Fast/Pro modes, SSE streaming, workspace_path, chat subcommand alias, chat history, doctor/help, durable worker spawn aliases, local YouTube URL routing, and safe 25-loop --dogfood-chat checklist
 rg "atrisFastChat|atrisFastOnce|streamProChat|text_delta|Usage: atris fast" bin/atris.js utils/api.js test/commands.test.js test/api-stream.test.js  # Atris2 Fast one-shot chat CLI and SSE text_delta streaming
 rg "brainstormAtris|Usage: atris brainstorm|brainstorm help" commands/brainstorm.js test/commands.test.js  # Brainstorm command + workspace-free help
 rg "function planAtris" commands/workflow.js   # Plan command (line 66)

--- a/ax
+++ b/ax
@@ -6,13 +6,46 @@ const https = require('https');
 const os = require('os');
 const path = require('path');
 const readline = require('readline');
+const { spawnSync } = require('child_process');
+const { Readable } = require('stream');
 const { loadCredentials } = require('./utils/auth');
+const {
+  MEMBER_SLUG,
+  loadAxPrefs,
+  setBypassPermissions,
+  resolveBypassPermissions,
+  permissionsLabel,
+} = require('./lib/ax-prefs');
+const {
+  renderShimmerText,
+} = require('./lib/ax-shimmer');
+const {
+  attachMultilineChatInput,
+  stripMultilineCsiText,
+} = require('./lib/ax-chat-input');
+const {
+  accumulateGoalUsage,
+  buildGoalDirective,
+  clearGoalState,
+  createGoalState,
+  evaluateGoalTurn,
+  finishGoalAchieved,
+  formatGoalAchieved,
+  formatGoalActiveBanner,
+  formatGoalContinue,
+  formatGoalStatus,
+  formatGoalStopped,
+  goalBudgetExceeded,
+  goalTurnLimitReached,
+  parseGoalCommand,
+} = require('./lib/ax-goal');
 
 const EXIT_WORDS = new Set(['exit', 'quit', ':q']);
 const BACKEND = {
   host: '127.0.0.1',
   port: 8000,
-  path: '/api/atris2/turn'
+  path: '/api/atris2/turn',
+  publicBase: 'https://api.atris.ai'
 };
 const DEFAULT_BACKEND_BASE = `http://${BACKEND.host}:${BACKEND.port}`;
 const CODE_FAST = {
@@ -55,14 +88,22 @@ const CONNECTOR_SCOPES = {
 const ANSI = {
   reset: '\x1b[0m',
   bold: '\x1b[1m',
+  italic: '\x1b[3m',
   dim: '\x1b[2m',
   muted: '\x1b[90m',
   accent: '\x1b[36m',
   ok: '\x1b[32m',
-  magenta: '\x1b[35m'
+  safe: '\x1b[34m',
+  warn: '\x1b[33m',
+  magenta: '\x1b[35m',
+  underline: '\x1b[4m',
+  strike: '\x1b[9m',
 };
 
 const TIER_COLORS = { fast: '\x1b[32m', pro: '\x1b[36m', max: '\x1b[35m' };
+const PROGRESS_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const PROGRESS_START_DELAY_MS = 350;
+const PROGRESS_FRAME_MS = 100;
 
 function tierColor(mode) {
   return TIER_COLORS[mode] || ANSI.accent;
@@ -95,11 +136,23 @@ function tierLabel(mode) {
   return 'Atris 2 Pro';
 }
 
-function formatHeader({ mode = 'pro', cwd = process.cwd(), chat = false } = {}, options = {}) {
+function formatHeader({ mode = 'fast', cwd = process.cwd(), chat = false, bypassPermissions, goal } = {}, options = {}) {
+  const goalLine = chat && goal ? formatGoalActiveBanner(goal, {
+    paint: (text, codes) => paint(text, codes, options),
+    bold: ANSI.bold,
+    magenta: ANSI.magenta,
+    muted: ANSI.muted,
+    accent: ANSI.accent,
+    ...options,
+  }) : '';
+  const home = os.homedir();
+  const shortCwd = cwd && home && (cwd === home || cwd.startsWith(`${home}/`)) ? `~${cwd.slice(home.length)}` : cwd;
+  const title = paint(`${tierLabel(mode)}${chat ? ' chat' : ''}`, [ANSI.bold, tierColor(normalizeMode(mode))], options);
+  const titleLine = shortCwd ? `${title}${paint(`  ·  ${shortCwd}`, [ANSI.muted], options)}` : title;
   return [
-    paint(`${tierLabel(mode)}${chat ? ' chat' : ''}`, [ANSI.bold, tierColor(normalizeMode(mode))], options),
-    cwd,
-    chat ? paint('type / for the menu · /fast /pro /max swap tiers · exit to leave', [ANSI.muted], options) : '',
+    titleLine,
+    goalLine,
+    chat ? paint('shift+tab permissions · shift+enter newline · ctrl-c · / · exit', [ANSI.muted], options) : '',
   ].filter(Boolean).join('\n');
 }
 
@@ -108,8 +161,14 @@ function formatUsage() {
     'ax - Atris local/code agent',
     '',
     'Usage:',
-    '  ax [--max|--pro|--fast|--code-fast] [--local|--cloud] <message>',
-    '  ax [--max|--pro|--fast|--code-fast] [--local|--cloud] --chat',
+  '  ax [--fast|--pro|--max|--code-fast] [--local|--cloud] [--bypass|--safe] <message>',
+  '  ax [--fast|--pro|--max|--code-fast] [--local|--cloud] [--bypass|--safe] --chat',
+  '  ax chat [ax] [--fast|--pro|--max]',
+  '  ax spawn <role> --task "..." [--engine manual|codex|claude|cursor|devin]',
+    '  ax spawns [--json]',
+    '  ax youtube <url> [--query "..."] [--json]',
+    '  ax --dogfood-chat [--loops 25] [--json]',
+    '  ax --dogfood-status [--json]',
     '  ax [--max|--pro|--fast] --business <slug> [<message>|--chat]',
     '  ax [--max|--pro|--fast|--code-fast] --doctor',
     '  ax [--max|--fast] --benchmark',
@@ -123,8 +182,30 @@ function formatUsage() {
     '  --cloud force authenticated cloud connectors/chat',
     '  --business <slug>  run tools on that business cloud workspace (EC2)',
     '  --verify <cmd>  gate the turn on this command passing (default: no verifier)',
+    '  --bypass  allow external side effects for this run (default: safe / approval-only)',
+    '  --safe    force approval-only mode for this run',
+    '  --dogfood-chat  run the safe ax fast chat checklist harness',
+    '  --dogfood-status  summarize the overnight dogfood mission progress',
+    '',
+    'Chat:',
+    '  /goal <condition>  work autonomously until the condition is met',
+    '  /goal              show active goal, turns, and evaluator reason',
+    '  /goal clear        stop the active goal',
+    '  /bypass  persist bypass mode (external actions allowed when backend supports it)',
+    '  /safe    persist safe mode (default; approval-only external actions)',
+    '',
+    'Delegation:',
+    '  ax spawn <role> --task "..."          create a worker request from ax',
+    '  atris agent spawn <role> --task "..." same request ledger from the Atris CLI',
+    '  ax youtube <url>                     process a YouTube video through Atris',
+    '  ax --dogfood-chat --loops 25         exercise chat UI and routing without spending credits',
+    '  ax --dogfood-status                  show overnight dogfood proof and remaining loops',
     '',
     'Examples:',
+    '  ax spawn worker --task "Fix the failing smoke test" --engine codex',
+    '  ax youtube https://www.youtube.com/watch?v=VIDEO_ID',
+    '  ax --dogfood-chat --loops 25',
+    '  ax --dogfood-status',
     '  ax --pro find the config file and explain it',
     '  ax --fast what files are here',
     '  ax --max refactor this module and verify the tests',
@@ -145,7 +226,7 @@ function stripAnsi(value) {
     .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
 }
 
-function createRunLogger({ cwd = process.cwd(), mode = 'pro', kind = 'play', output = process.stdout } = {}) {
+function createRunLogger({ cwd = process.cwd(), mode = 'fast', kind = 'play', output = process.stdout } = {}) {
   if (process.env.AX_AUTO_LOG === '0') return null;
   if (output !== process.stdout && output !== process.stderr && !output.isTTY) return null;
 
@@ -185,30 +266,51 @@ function createRunLogger({ cwd = process.cwd(), mode = 'pro', kind = 'play', out
   };
 }
 
-function backendBaseUrl() {
-  return (process.env.AX_BACKEND_URL
-    || process.env.OBELISK_LOCAL_ATRIS2_BACKEND_URL
+function backendBaseUrl(options = {}) {
+  const route = options.route === 'local' || options.forceLocal
+    ? 'local'
+    : options.route === 'cloud' || options.forceCloud
+      ? 'cloud'
+      : 'auto';
+  const localOverride = process.env.AX_BACKEND_URL || process.env.OBELISK_LOCAL_ATRIS2_BACKEND_URL;
+  const cloudOverride = process.env.OBELISK_ATRIS2_BACKEND_URL || process.env.ATRIS_API_BASE || BACKEND.publicBase;
+  if (route === 'cloud') {
+    if (localOverride && !isLoopbackUrl(localOverride)) return localOverride.replace(/\/$/, '');
+    return cloudOverride.replace(/\/$/, '');
+  }
+  if (route === 'auto' && !localOverride) {
+    return cloudOverride.replace(/\/$/, '');
+  }
+  return (localOverride
     || process.env.OBELISK_ATRIS2_BACKEND_URL
     || DEFAULT_BACKEND_BASE).replace(/\/$/, '');
 }
 
-function backendUrl() {
-  return new URL(BACKEND.path, backendBaseUrl()).toString();
+function backendUrl(options = {}) {
+  return new URL(BACKEND.path, backendBaseUrl(options)).toString();
 }
 
-function backendPathUrl(pathname) {
-  return new URL(pathname, backendBaseUrl()).toString();
+function backendPathUrl(pathname, options = {}) {
+  return new URL(pathname, backendBaseUrl(options)).toString();
 }
 
-function codeFastBaseUrl() {
-  return (process.env.AX_CODE_FAST_BACKEND_URL
-    || process.env.AX_CODE_FAST_API_BASE
-    || process.env.ATRIS_API_BASE
-    || CODE_FAST.publicBase).replace(/\/$/, '');
+function codeFastBaseUrl(options = {}) {
+  const route = options.route === 'local' || options.forceLocal
+    ? 'local'
+    : options.route === 'cloud' || options.forceCloud
+      ? 'cloud'
+      : 'auto';
+  const backendOverride = process.env.AX_CODE_FAST_BACKEND_URL;
+  const useBackendOverride = backendOverride && !(route === 'cloud' && isLoopbackUrl(backendOverride));
+  return (useBackendOverride
+    ? backendOverride
+    : process.env.AX_CODE_FAST_API_BASE
+      || process.env.ATRIS_API_BASE
+      || CODE_FAST.publicBase).replace(/\/$/, '');
 }
 
-function codeFastUrl() {
-  return new URL(CODE_FAST.path, codeFastBaseUrl()).toString();
+function codeFastUrl(options = {}) {
+  return new URL(CODE_FAST.path, codeFastBaseUrl(options)).toString();
 }
 
 function isLoopbackUrl(value) {
@@ -231,7 +333,7 @@ function buildRunProfile(options = {}) {
   if (mode === 'code-fast') {
     const route = options.route === 'local' || options.forceLocal ? 'local' : 'cloud';
     return {
-      endpoint: codeFastUrl(),
+      endpoint: codeFastUrl({ route }),
       mode,
       route,
       model: CODE_FAST.model,
@@ -242,15 +344,18 @@ function buildRunProfile(options = {}) {
       reasoning: 'Composer 2.5 fast lane; charges 10 credits per public turn'
     };
   }
-  const route = resolveRoute(options.message || 'doctor', options);
-  const payload = buildPayload(options.message || 'doctor', { mode, cwd, route });
+  const profileMessage = options.message || 'what files are here?';
+  const route = resolveRoute(profileMessage, options);
+  const payload = buildPayload(profileMessage, { mode, cwd, route, bypassPermissions: options.bypassPermissions });
   return {
-    endpoint: backendUrl(),
+    endpoint: backendUrl({ route }),
     mode,
     route,
     model: payload.model,
     workspace_path: payload.workspace_path || 'cloud',
     max_turns: payload.max_turns,
+    member_slug: payload.member_slug,
+    bypass_permissions: payload.bypass_permissions,
     streaming: true,
     runtime: route === 'cloud' ? 'authenticated cloud connectors/chat' : 'local workspace',
     reasoning: mode === 'max'
@@ -264,6 +369,8 @@ function buildRunProfile(options = {}) {
 function formatRunProfile(profile, options = {}) {
   const rows = [
     ['mode', profile.mode],
+    ['agent', profile.member_slug || MEMBER_SLUG],
+    ['permissions', profile.bypass_permissions ? 'bypass' : 'safe'],
     ['endpoint', profile.endpoint],
     ['route', profile.route || 'auto'],
     ['workspace', formatPathSubject(profile.workspace_path, options)],
@@ -307,9 +414,9 @@ function authUserId() {
   }
 }
 
-function isLoopbackBackend() {
+function isLoopbackBackend(options = {}) {
   try {
-    const parsed = new URL(backendBaseUrl());
+    const parsed = new URL(backendBaseUrl(options));
     return ['127.0.0.1', 'localhost', '::1'].includes(parsed.hostname);
   } catch (_) {
     return false;
@@ -491,10 +598,20 @@ function githubWorkspaceIntent(message) {
   return /\b(push|commit|commits?|branch|branches|checkout|merge|rebase|tag|release|pr|pull request|pull-request|repo change|code change|small change)\b/i.test(text);
 }
 
+function casualChatIntent(message) {
+  const text = String(message || '').trim();
+  if (!text) return false;
+  if (workspaceIntent(text) || mentionsConnector(text) || githubWorkspaceIntent(text)) return false;
+  if (/^(hi+|hello+|hey+|yo+|sup|gm|good morning|good afternoon|good evening|thanks?|thank you|ok+|okay|k|cool|nice|lol|lmao|haha|why\??|what\??|huh\??|yes|no|nah|yep|nope)[.!?]*$/i.test(text)) return true;
+  if (/^(hi|hello|hey)\b/i.test(text)) return true;
+  return /^[a-z]{1,8}[.!?]*$/i.test(text);
+}
+
 function resolveRoute(message, options = {}) {
   if (options.route === 'local' || options.forceLocal) return 'local';
   if (options.route === 'cloud' || options.forceCloud) return 'cloud';
   if (githubWorkspaceIntent(message)) return 'local';
+  if (casualChatIntent(message)) return 'cloud';
   if (mentionsConnector(message) && !workspaceIntent(message)) return 'cloud';
   return 'local';
 }
@@ -502,13 +619,197 @@ function resolveRoute(message, options = {}) {
 function normalizeMode(mode) {
   if (mode === 'code-fast' || mode === 'code') return 'code-fast';
   if (mode === 'max') return 'max';
-  return mode === 'fast' ? 'fast' : 'pro';
+  if (mode === 'pro') return 'pro';
+  return 'fast';
 }
 
 function formatPrompt(mode, options = {}) {
-  if (!mode) return '› ';
   const tier = normalizeMode(mode);
-  return `${paint(tier, [ANSI.bold, tierColor(tier)], options)} › `;
+  const goalHint = options.goal && options.goal.active
+    ? `${paint('◎ ', [ANSI.bold, ANSI.magenta], options)}`
+    : '';
+  if (!mode) return `${goalHint}› `;
+  return `${goalHint}${paint(tier, [ANSI.bold, tierColor(tier)], options)} › `;
+}
+
+function terminalWidth(options = {}) {
+  const cols = Number(options.columns || process.stdout.columns || 0);
+  if (Number.isFinite(cols) && cols >= 48) return cols;
+  return 72;
+}
+
+function inputBoxPlainWidth(options = {}) {
+  const cols = Number(options.columns || process.stdout.columns || 0);
+  if (Number.isFinite(cols) && cols >= 48) return cols - 1;
+  return 71;
+}
+
+function inputBoxLayoutOptions(stream, overrides = {}) {
+  const cols = Number(stream?.columns || process.stdout.columns || 0);
+  return {
+    ...overrides,
+    columns: Number.isFinite(cols) && cols >= 48 ? cols - 1 : 71,
+    isTTY: stream?.isTTY ?? process.stdout.isTTY,
+  };
+}
+
+function buildInputBoxTopPlain(options = {}) {
+  const width = inputBoxPlainWidth(options);
+  return `╭${'─'.repeat(Math.max(0, width - 2))}╮`;
+}
+
+// The mode + newline affordance lives on its own line BELOW the box (claude
+// style), so the rules above/below stay clean and we never say "enter send".
+function buildInputBoxStatusPlain(options = {}) {
+  return `  ${formatPermissionModeBrief(options)} · shift+enter`;
+}
+
+function buildInputBoxBottomPlain(options = {}) {
+  const width = inputBoxPlainWidth(options);
+  return `╰${'─'.repeat(Math.max(0, width - 2))}╯`;
+}
+
+function formatInputBoxInputRow(prompt, line, options = {}) {
+  const width = inputBoxPlainWidth(options);
+  const promptPlain = stripAnsi(prompt);
+  const linePlain = stripAnsi(String(line || ''));
+  const rightBar = paint('│', [ANSI.dim, ANSI.muted], options);
+  const rightPlain = '│';
+  const pad = Math.max(0, width - promptPlain.length - linePlain.length - rightPlain.length);
+  return `${prompt}${line}${' '.repeat(pad)}${rightBar}`;
+}
+
+function formatPermissionModeBrief(options = {}) {
+  return resolveBypassPermissions(options) ? 'full access' : 'approve';
+}
+
+function permissionAccentCodes(options = {}) {
+  return resolveBypassPermissions(options) ? [ANSI.dim, ANSI.warn] : [ANSI.dim, ANSI.safe];
+}
+
+function formatPermissionToggleMessage(bypassPermissions, options = {}) {
+  const persistPrefs = options.persistPrefs !== false;
+  const suffix = persistPrefs ? ' (saved)' : ' (session)';
+  if (bypassPermissions) {
+    return paint(`· Full access${suffix} — external actions can run without approval`, [ANSI.warn], options);
+  }
+  return paint(`· Approve mode${suffix} — external actions ask before they run`, [ANSI.safe], options);
+}
+
+function isPermissionToggleKey(key) {
+  if (!key) return false;
+  if (key.shift && key.name === 'tab') return true;
+  const sequence = String(key.sequence || '');
+  return sequence === '\x1b[Z' || sequence === '\x1b[1;2Z';
+}
+
+function isMultilineInsertKey(str, key) {
+  if (!key) return str === '\n';
+  if (key.shift && (key.name === 'return' || key.name === 'enter')) return true;
+  if (key.meta && (key.name === 'return' || key.name === 'enter')) return true;
+  if (str === '\n' && key.name !== 'return') return true;
+  return false;
+}
+
+function insertMultilineBreak(rl) {
+  if (!rl) return;
+  // Insert a literal newline at the cursor. rl.write('\n') would SUBMIT the
+  // line (readline treats it as Enter) and also re-enter our _ttyWrite hook.
+  if (typeof rl._insertString === 'function') {
+    rl._insertString('\n');
+    return;
+  }
+  if (typeof rl.line === 'string') {
+    const cursor = Number.isFinite(rl.cursor) ? rl.cursor : rl.line.length;
+    rl.line = rl.line.slice(0, cursor) + '\n' + rl.line.slice(cursor);
+    rl.cursor = cursor + 1;
+    if (typeof rl._refreshLine === 'function') rl._refreshLine();
+  }
+}
+
+function formatInputBoxTop(options = {}) {
+  return paint(buildInputBoxTopPlain(options), [ANSI.dim, ANSI.muted], options);
+}
+
+function formatInputBoxBottom(options = {}) {
+  return paint(buildInputBoxBottomPlain(options), [ANSI.dim, ANSI.muted], options);
+}
+
+// Status line shown below the box: permission mode + the shift+enter newline
+// affordance, mode-colored. Drawn by the repaint, cleared on submit.
+function formatInputBoxStatus(options = {}) {
+  const plain = buildInputBoxStatusPlain(options);
+  const modeLabel = formatPermissionModeBrief(options);
+  const idx = plain.indexOf(modeLabel);
+  if (idx === -1) return paint(plain, [ANSI.dim, ANSI.muted], options);
+  const modePainted = paint(modeLabel, permissionAccentCodes(options), options);
+  const dim = [ANSI.dim, ANSI.muted];
+  return `${paint(plain.slice(0, idx), dim, options)}${modePainted}${paint(plain.slice(idx + modeLabel.length), dim, options)}`;
+}
+
+function closeInputBox(output, options = {}) {
+  // On submit the cursor sits on the bottom-rule row: redraw the rule, then
+  // clear the status line the repaint left below it and leave the cursor on a
+  // fresh row for the turn output.
+  output.write(`\r\x1b[2K${formatInputBoxBottom(options)}\n\x1b[2K\r`);
+}
+
+// Keep the input box closed while the user is typing: after each readline
+// render, repaint the bottom rule one row below the (possibly wrapped/multiline)
+// input plus a status line below that, then return the cursor. readline clears
+// to end-of-display on every refresh, so both must be redrawn each time. Writes
+// to the raw stream readline renders to (not the logger) since these are
+// transient cursor moves.
+function repaintInputBoxBottom(rl, output, options = {}) {
+  if (!rl || !output || typeof output.write !== 'function') return;
+  if (typeof rl._getDisplayPos !== 'function' || typeof rl.getCursorPos !== 'function') return;
+  let total;
+  let cur;
+  try {
+    total = rl._getDisplayPos(`${rl._prompt || ''}${rl.line || ''}`);
+    cur = rl.getCursorPos();
+  } catch {
+    return;
+  }
+  if (!total || !cur) return;
+  // When the input is taller than the viewport the terminal scrolls and the
+  // relative cursor math below can't land the rule reliably (it would corrupt
+  // the scrollback). Degrade gracefully: skip the closing rule for a giant
+  // input rather than scramble it. readline still renders the text correctly.
+  const rows = Number(output.rows || (typeof process !== 'undefined' && process.stdout && process.stdout.rows) || 0);
+  if (rows && total.rows + 3 >= rows) return;
+  const down = Math.max(1, (total.rows - cur.rows) + 1);
+  let seq = `\r\x1b[${down}B\x1b[2K${formatInputBoxBottom(options)}`;
+  seq += `\r\x1b[1B\x1b[2K${formatInputBoxStatus(options)}`;
+  seq += `\x1b[${down + 1}A\r`;
+  if (cur.cols > 0) seq += `\x1b[${cur.cols}C`;
+  output.write(seq);
+}
+
+function formatChatInputInnerPrefix(mode, options = {}) {
+  const tier = normalizeMode(mode);
+  const goalHint = options.goal && options.goal.active
+    ? `${paint('◎ ', [ANSI.bold, ANSI.magenta], options)}`
+    : '';
+  const tierPart = mode
+    ? `${goalHint}${paint(tier, [ANSI.bold, tierColor(tier)], options)} › `
+    : `${goalHint}› `;
+  return `${paint('→ ', [ANSI.muted], options)}${tierPart}`;
+}
+
+function formatChatInputPrompt(mode, options = {}) {
+  // Two-space indent (no left bar) to match the plain rules and the status line.
+  return `  ${formatChatInputInnerPrefix(mode, options)}`;
+}
+
+const PERMISSION_COMMANDS = new Map([
+  ['/bypass', true],
+  ['/safe', false],
+]);
+
+function chatPermissionCommand(line) {
+  const key = String(line || '').trim().toLowerCase();
+  return PERMISSION_COMMANDS.has(key) ? PERMISSION_COMMANDS.get(key) : null;
 }
 
 const TIER_COMMANDS = new Map([
@@ -522,21 +823,70 @@ function chatTierCommand(line) {
 }
 
 const CHAT_COMMANDS = [
+  ['/goal', 'set/show autonomous completion condition'],
   ['/fast', 'quick answers, lowest latency'],
   ['/pro', 'deeper tool loop for real work'],
   ['/max', 'highest reasoning for the hardest jobs'],
+  ['/bypass', 'allow external side effects (persisted)'],
+  ['/safe', 'approval-only external actions (default, persisted)'],
   ['/help', 'show this menu'],
   ['exit', 'leave chat'],
 ];
 
+const CHAT_SHORTCUTS = [
+  ['shift+tab', 'toggle approve ↔ full access'],
+  ['shift+enter', 'new line (enter sends)'],
+];
+
+const CHAT_DOGFOOD_BASE_CASES = [
+  { input: '/help', kind: 'command', coverage: 'menu' },
+  { input: '/fast', kind: 'command', coverage: 'tier_fast' },
+  { input: 'hi', kind: 'turn', expectRoute: 'cloud', coverage: 'small_talk' },
+  { input: 'pop', kind: 'turn', expectRoute: 'cloud', coverage: 'short_noise' },
+  { input: 'hello why', kind: 'turn', expectRoute: 'cloud', coverage: 'greeting_phrase' },
+  { input: 'what files are here?', kind: 'turn', expectRoute: 'local', coverage: 'workspace_read' },
+  { input: 'search src for the input component', kind: 'turn', expectRoute: 'local', coverage: 'workspace_search' },
+  { input: 'fix the xp game tests', kind: 'turn', expectRoute: 'local', coverage: 'workspace_fix' },
+  { input: 'what is on my calendar today?', kind: 'turn', expectRoute: 'cloud', coverage: 'connector_read' },
+  { input: 'which integrations are connected?', kind: 'turn', expectRoute: 'cloud', coverage: 'connector_status' },
+  { input: 'what github repos do I have?', kind: 'turn', expectRoute: 'cloud', coverage: 'github_read' },
+  { input: 'push something to github', kind: 'turn', expectRoute: 'local', coverage: 'github_workspace_mutation' },
+  { input: 'https://www.youtube.com/watch?v=gBukk9LIklc', kind: 'youtube', coverage: 'youtube_url' },
+  { input: '/max', kind: 'command', coverage: 'tier_max' },
+  { input: 'refactor this module and verify the tests', kind: 'turn', expectRoute: 'local', expectMode: 'max', coverage: 'max_local' },
+  { input: '/pro', kind: 'command', coverage: 'tier_pro' },
+  { input: 'send a slack message to the team', kind: 'turn', expectRoute: 'cloud', expectMode: 'pro', coverage: 'connector_write_safe' },
+  { input: '/bypass', kind: 'command', coverage: 'permission_bypass' },
+  { input: 'send a slack message to the team', kind: 'turn', expectRoute: 'cloud', expectBypass: true, coverage: 'connector_write_bypass' },
+  { input: '/safe', kind: 'command', coverage: 'permission_safe' },
+  { input: 'send a slack message to the team', kind: 'turn', expectRoute: 'cloud', expectBypass: false, coverage: 'connector_write_resafe' },
+  { input: '/wat', kind: 'command', coverage: 'unknown_slash' },
+  { input: '/goal', kind: 'command', coverage: 'goal_status' },
+  { input: 'oj', kind: 'turn', expectRoute: 'cloud', coverage: 'short_noise_repeat' },
+  { input: 'read MAP.md and do not edit', kind: 'turn', expectRoute: 'local', coverage: 'workspace_read_specific' },
+];
+
+function buildChatDogfoodCases(loopCount = 25) {
+  const count = Math.max(1, Number(loopCount) || 25);
+  const cases = [];
+  for (let i = 0; i < count; i += 1) {
+    cases.push({ ...CHAT_DOGFOOD_BASE_CASES[i % CHAT_DOGFOOD_BASE_CASES.length], index: i + 1 });
+  }
+  return cases;
+}
+
 function chatMenu(options = {}) {
-  return CHAT_COMMANDS
+  const commands = CHAT_COMMANDS
     .map(([name, desc]) => {
       const tier = TIER_COMMANDS.get(name);
       const color = tier ? tierColor(tier) : ANSI.accent;
       return `  ${paint(name.padEnd(6), [color], options)}  ${paint(desc, [ANSI.muted], options)}`;
     })
     .join('\n');
+  const shortcuts = CHAT_SHORTCUTS
+    .map(([name, desc]) => `  ${paint(name.padEnd(6), [ANSI.ok], options)}  ${paint(desc, [ANSI.muted], options)}`)
+    .join('\n');
+  return `${commands}\n${shortcuts}`;
 }
 
 function chatCompleter(line) {
@@ -547,10 +897,132 @@ function chatCompleter(line) {
   return [hits.length ? hits : names, trimmed];
 }
 
-function formatWorkingLine(ms, verb, frame) {
+function parsePermissionFlags(args) {
+  let bypassPermissions;
+  if (args.includes('--bypass')) bypassPermissions = true;
+  if (args.includes('--safe')) bypassPermissions = false;
+  return bypassPermissions;
+}
+
+function stripPermissionFlags(args) {
+  return args.filter(arg => arg !== '--bypass' && arg !== '--safe');
+}
+
+function normalizeChatCommandArgs(args = []) {
+  const normalized = [...args];
+  let firstPositional = -1;
+  const flagsWithValue = new Set(['--business', '--verify', '--loops']);
+
+  for (let i = 0; i < normalized.length; i += 1) {
+    const arg = String(normalized[i] || '');
+    if (flagsWithValue.has(arg)) {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('-')) continue;
+    firstPositional = i;
+    break;
+  }
+
+  let chatRequested = normalized.includes('--chat');
+  if (firstPositional !== -1 && normalized[firstPositional] === 'chat') {
+    chatRequested = true;
+    normalized.splice(firstPositional, 1, '--chat');
+    const target = String(normalized[firstPositional + 1] || '').toLowerCase();
+    if (target === MEMBER_SLUG || target === 'ax') {
+      normalized.splice(firstPositional + 1, 1);
+    }
+  }
+
+  return { args: normalized, chatRequested };
+}
+
+function isAxSpawnCommand(command) {
+  return ['spawn', 'spawns', 'spawn-list', 'list-spawns', 'spawn-status', 'spawn-show'].includes(String(command || ''));
+}
+
+function runAxSpawnCommand(args = [], deps = {}) {
+  const [command, ...rest] = args;
+  const root = deps.root || process.cwd();
+  const output = deps.output || ((line = '') => console.log(line));
+  const {
+    agentSpawnCommand,
+    agentSpawnListCommand,
+    agentSpawnStatusCommand,
+  } = require('./commands/agent-spawn');
+
+  if (command === 'spawn') return agentSpawnCommand(rest, { root, output, commandName: 'ax spawn' });
+  if (command === 'spawns' || command === 'spawn-list' || command === 'list-spawns') {
+    return agentSpawnListCommand(rest, { root, output });
+  }
+  if (command === 'spawn-status' || command === 'spawn-show') {
+    return agentSpawnStatusCommand(rest, { root, output });
+  }
+  throw new Error('Unknown ax spawn command');
+}
+
+const YOUTUBE_URL_PATTERN = /\bhttps?:\/\/(?:www\.)?(?:youtube\.com\/watch\?[^\s]+|youtu\.be\/[^\s]+|youtube\.com\/shorts\/[^\s]+)/i;
+
+function cleanYoutubeUrl(url) {
+  return String(url || '').replace(/[),.;\]]+$/g, '');
+}
+
+function extractYoutubeUrl(text) {
+  const match = String(text || '').match(YOUTUBE_URL_PATTERN);
+  return match ? cleanYoutubeUrl(match[0]) : null;
+}
+
+function youtubeQueryFromPrompt(prompt, youtubeUrl) {
+  const withoutUrl = String(prompt || '').replace(youtubeUrl, '').trim();
+  return withoutUrl.replace(/^[-:,\s]+|[-:,\s]+$/g, '').trim();
+}
+
+function buildAxYoutubeArgs(prompt, extraArgs = []) {
+  const text = Array.isArray(prompt) ? prompt.join(' ') : String(prompt || '');
+  const youtubeUrl = extractYoutubeUrl(text);
+  if (!youtubeUrl) return null;
+  const query = youtubeQueryFromPrompt(text, youtubeUrl);
+  const args = [youtubeUrl];
+  if (query) args.push('--query', query);
+  return args.concat(extraArgs || []);
+}
+
+async function runAxYoutubeCommand(args = [], deps = {}) {
+  const output = deps.output || ((line = '') => console.log(line));
+  const commandArgs = args[0] === 'youtube' ? args.slice(1) : args;
+  const inferred = args[0] === 'youtube' ? null : buildAxYoutubeArgs(commandArgs);
+  const finalArgs = inferred || commandArgs;
+  const youtubeCommand = deps.youtubeCommand || require('./commands/youtube').youtubeCommand;
+  const commandName = args[0] === 'youtube' ? 'ax youtube' : deps.commandName;
+  return youtubeCommand(finalArgs, { ...deps, output, commandName });
+}
+
+function normalizeWorkingOptions(frameOrOptions, maybeOptions = {}) {
+  if (typeof frameOrOptions === 'string') {
+    return { ...maybeOptions, frameChar: frameOrOptions };
+  }
+  if (frameOrOptions && typeof frameOrOptions === 'object') {
+    return frameOrOptions;
+  }
+  return maybeOptions;
+}
+
+function formatWorkingLine(ms, verb, frameOrOptions, maybeOptions = {}) {
+  const options = normalizeWorkingOptions(frameOrOptions, maybeOptions);
   const totalSeconds = Math.max(1, Math.round((Number(ms) || 0) / 1000));
-  if (verb) return `${frame || '•'} ${verb}… (${formatSeconds(totalSeconds)} · ctrl-c to interrupt)`;
-  return `• Working (${formatSeconds(totalSeconds)} • ctrl-c to interrupt)`;
+  const tick = Number.isFinite(options.tick) ? options.tick : null;
+  const labelVerb = String(verb || 'Thinking').trim() || 'Thinking';
+  const meta = paint(
+    `(${formatSeconds(totalSeconds)} · ctrl-c to interrupt)`,
+    [ANSI.dim, ANSI.muted],
+    options
+  );
+  const label = tick === null
+    ? paint(labelVerb, [ANSI.muted], options)
+    : renderShimmerText(labelVerb, tick ?? 0, options);
+  const suffix = paint('…', [ANSI.dim, ANSI.muted], options);
+  const prefix = paint('•', [ANSI.muted], options);
+  return `${prefix} ${label}${suffix} ${meta}`;
 }
 
 function verbForTool(tool) {
@@ -559,7 +1031,8 @@ function verbForTool(tool) {
   if (name.includes('grep') || name.includes('glob') || name.includes('search')) return 'Searching';
   if (name.includes('bash') || name.includes('command') || name.includes('run')) return 'Running';
   if (name.includes('write') || name.includes('edit')) return 'Editing';
-  return 'Working';
+  if (name.includes('think') || name.includes('reason') || name === 'task') return 'Thinking';
+  return 'Thinking';
 }
 
 function formatDoneLine(ms, credits) {
@@ -581,7 +1054,18 @@ function paint(text, codes, options = {}) {
   return `${codes.join('')}${text}${ANSI.reset}`;
 }
 
-function renderTerminalMarkdown(text, options = {}) {
+function formatMarkdownLink(label, url, options = {}) {
+  const display = String(label || '').trim();
+  const href = String(url || '').trim();
+  if (!href) return display;
+  const colored = paint(display, [ANSI.accent, ANSI.underline], options);
+  if (useColor(options) && (/^(https?:\/\/|file:\/\/)/i.test(href) || href.startsWith('/'))) {
+    return hyperlinkPath(colored, href, options);
+  }
+  return `${display} (${href})`;
+}
+
+function renderTerminalInline(text, options = {}) {
   let rendered = String(text || '');
   const codeSpans = [];
   rendered = rendered.replace(/`([^`\n]+)`/g, (_, code) => {
@@ -589,23 +1073,131 @@ function renderTerminalMarkdown(text, options = {}) {
     codeSpans.push(code);
     return token;
   });
-  rendered = rendered.replace(/^#{1,6}\s+(.+)$/gm, (_, title) => paint(title, [ANSI.bold], options));
+  rendered = rendered.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, url) => formatMarkdownLink(label, url, options));
+  rendered = rendered.replace(/\*\*\*([^*\n]+)\*\*\*/g, (_, value) => paint(value, [ANSI.bold, ANSI.italic], options));
   rendered = rendered.replace(/\*\*([^*\n]+)\*\*/g, (_, value) => paint(value, [ANSI.bold], options));
   rendered = rendered.replace(/__([^_\n]+)__/g, (_, value) => paint(value, [ANSI.bold], options));
+  rendered = rendered.replace(/~~([^~\n]+)~~/g, (_, value) => paint(value, [ANSI.strike], options));
+  rendered = rendered.replace(/\*([^*\n]+)\*/g, (_, value) => paint(value, [ANSI.italic], options));
+  rendered = rendered.replace(/_([^_\n]+)_/g, (_, value) => paint(value, [ANSI.italic], options));
   rendered = rendered.replace(/\u0000CODE(\d+)\u0000/g, (_, index) => paint(codeSpans[Number(index)] || '', [ANSI.accent], options));
   return rendered;
+}
+
+function renderTerminalBlockLine(line, options = {}) {
+  const header = line.match(/^(#{1,6})\s+(.+)$/);
+  if (header) return paint(header[2], [ANSI.bold], options);
+
+  const list = line.match(/^(\s*)(?:[*+-]|\d+\.)\s+(.*)$/);
+  if (list) {
+    const bullet = paint('•', [ANSI.accent], options);
+    return `${list[1]}${bullet} ${renderTerminalInline(list[2], options)}`;
+  }
+
+  const quote = line.match(/^>\s?(.*)$/);
+  if (quote) {
+    return `${paint('▏ ', [ANSI.muted], options)}${renderTerminalInline(quote[1], options)}`;
+  }
+
+  if (/^(\*{3,}|-{3,}|_{3,})$/.test(line.trim())) {
+    const width = Math.min(Math.max(16, terminalWidth(options) - 4), 48);
+    return paint('─'.repeat(width), [ANSI.dim, ANSI.muted], options);
+  }
+
+  return renderTerminalInline(line, options);
+}
+
+function renderTerminalMarkdown(text, options = {}) {
+  const source = String(text || '');
+  const parts = [];
+  const fence = /```[^\n]*\n([\s\S]*?)```/g;
+  let last = 0;
+  let match = fence.exec(source);
+  while (match) {
+    if (match.index > last) {
+      parts.push({ kind: 'text', value: source.slice(last, match.index) });
+    }
+    parts.push({ kind: 'code', value: match[1] || '' });
+    last = match.index + match[0].length;
+    match = fence.exec(source);
+  }
+  if (last < source.length) parts.push({ kind: 'text', value: source.slice(last) });
+
+  return parts.map((part) => {
+    if (part.kind === 'code') {
+      return part.value
+        .replace(/\n$/, '')
+        .split('\n')
+        .map((line) => paint(`  ${line}`, [ANSI.muted], options))
+        .join('\n');
+    }
+    return part.value
+      .split('\n')
+      .map((line) => renderTerminalBlockLine(line, options))
+      .join('\n');
+  }).join('\n');
+}
+
+function renderFenceBuffer(buffer, options = {}) {
+  return String(buffer || '')
+    .replace(/\n$/, '')
+    .split('\n')
+    .map((line) => paint(`  ${line}`, [ANSI.muted], options))
+    .join('\n');
 }
 
 function resetMarkdownState(state) {
   state.markdownMode = 'normal';
   state.markdownBuffer = '';
   state.markdownCarry = '';
+  state.markdownDelim = '';
+  state.atLineStart = true;
 }
 
 function ensureMarkdownState(state) {
   if (!state.markdownMode) state.markdownMode = 'normal';
   if (typeof state.markdownBuffer !== 'string') state.markdownBuffer = '';
   if (typeof state.markdownCarry !== 'string') state.markdownCarry = '';
+  if (typeof state.markdownDelim !== 'string') state.markdownDelim = '';
+  if (typeof state.atLineStart !== 'boolean') state.atLineStart = true;
+}
+
+function streamingListMarkerAt(input, index) {
+  const rest = input.slice(index);
+  const match = rest.match(/^(\s*)(?:[*+-]|\d+\.)\s+/);
+  if (!match) return null;
+  return { length: match[0].length, indent: match[1] || '' };
+}
+
+function streamingHeadingAt(input, index) {
+  const rest = input.slice(index);
+  const match = rest.match(/^#{1,6}\s+([^\n]*)/);
+  if (!match) return null;
+  return { length: match[0].length, title: match[1] || '' };
+}
+
+function streamingBlockquoteAt(input, index) {
+  const rest = input.slice(index);
+  const match = rest.match(/^>\s?/);
+  if (!match) return null;
+  return { length: match[0].length };
+}
+
+function streamingHorizontalRuleAt(input, index) {
+  const rest = input.slice(index);
+  const match = rest.match(/^(-{3,}|\*{3,}|_{3,})(?=\n|$)/);
+  if (!match) return null;
+  return { length: match[0].length };
+}
+
+function streamingLinkAt(input, index, options) {
+  const rest = input.slice(index);
+  const match = rest.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+  if (!match) return null;
+  return {
+    length: match[0].length,
+    rendered: formatMarkdownLink(match[1], match[2], options),
+  };
 }
 
 function renderStreamingMarkdown(state, text, options = {}) {
@@ -615,42 +1207,238 @@ function renderStreamingMarkdown(state, text, options = {}) {
   let out = '';
 
   for (let i = 0; i < input.length;) {
+    if (state.markdownMode === 'fence') {
+      if (state.atLineStart) {
+        const rest = input.slice(i);
+        if (/^```/.test(rest)) {
+          out += renderFenceBuffer(state.markdownBuffer, options);
+          state.markdownBuffer = '';
+          state.markdownMode = 'normal';
+          const nl = rest.indexOf('\n');
+          if (nl === -1) { i = input.length; state.atLineStart = true; continue; }
+          out += '\n';
+          i += nl + 1;
+          state.atLineStart = true;
+          continue;
+        }
+        if (/^`{1,3}$/.test(rest)) { state.markdownCarry = rest; break; }
+      }
+      const c = input[i];
+      state.markdownBuffer += c;
+      state.atLineStart = c === '\n';
+      i += 1;
+      continue;
+    }
+
+    if (state.markdownMode === 'normal' && state.atLineStart) {
+      const rest = input.slice(i);
+      // Code fence ```lang … ``` — wait for the full opening line, then stream
+      // the body as an indented block (handled by the 'fence' branch above).
+      if (/^```/.test(rest)) {
+        const nl = rest.indexOf('\n');
+        if (nl === -1) { state.markdownCarry = rest; break; }
+        state.markdownMode = 'fence';
+        state.markdownBuffer = '';
+        state.atLineStart = true;
+        i += nl + 1;
+        continue;
+      }
+      // Incomplete block marker at the end of this delta (heading ##, fence ```,
+      // bullet - / +, numbered 1.) — carry it so the next delta completes the
+      // marker instead of leaking it as plain text.
+      if (/^(?:#{1,6}|`{1,3}|[-+]|\d{1,9}\.)$/.test(rest)) { state.markdownCarry = rest; break; }
+
+      const heading = streamingHeadingAt(input, i);
+      if (heading) {
+        out += paint(heading.title, [ANSI.bold], options);
+        i += heading.length;
+        if (input[i] === '\n') {
+          out += '\n';
+          i += 1;
+          state.atLineStart = true;
+        } else {
+          state.atLineStart = false;
+        }
+        continue;
+      }
+      const list = streamingListMarkerAt(input, i);
+      if (list) {
+        out += `${list.indent}${paint('•', [ANSI.accent], options)} `;
+        i += list.length;
+        state.atLineStart = false;
+        continue;
+      }
+      const quote = streamingBlockquoteAt(input, i);
+      if (quote) {
+        out += paint('▏ ', [ANSI.muted], options);
+        i += quote.length;
+        state.atLineStart = false;
+        continue;
+      }
+      const hr = streamingHorizontalRuleAt(input, i);
+      if (hr) {
+        const width = Math.min(Math.max(16, terminalWidth(options) - 4), 48);
+        out += paint('─'.repeat(width), [ANSI.dim, ANSI.muted], options);
+        i += hr.length;
+        if (input[i] === '\n') {
+          out += '\n';
+          i += 1;
+          state.atLineStart = true;
+        } else {
+          state.atLineStart = false;
+        }
+        continue;
+      }
+    }
+
     const char = input[i];
     const next = input[i + 1];
+    const third = input[i + 2];
 
     if (state.markdownMode === 'normal') {
-      if (char === '*' && next === undefined) {
-        state.markdownCarry = '*';
+      const link = streamingLinkAt(input, i, options);
+      if (link) {
+        out += link.rendered;
+        i += link.length;
+        state.atLineStart = false;
+        continue;
+      }
+      if (char === '[') {
+        state.markdownCarry = '[';
         break;
+      }
+      if (char === '*' && next === '*' && third === '*') {
+        state.markdownMode = 'bold_italic';
+        state.markdownBuffer = '';
+        state.markdownDelim = '***';
+        i += 3;
+        continue;
       }
       if (char === '*' && next === '*') {
         state.markdownMode = 'bold';
         state.markdownBuffer = '';
+        state.markdownDelim = '**';
+        i += 2;
+        continue;
+      }
+      if (char === '*') {
+        if (next === undefined) {
+          state.markdownCarry = '*';
+          break;
+        }
+        state.markdownMode = 'italic';
+        state.markdownBuffer = '';
+        state.markdownDelim = '*';
+        i += 1;
+        continue;
+      }
+      if (char === '_' && next === '_') {
+        state.markdownMode = 'bold';
+        state.markdownBuffer = '';
+        state.markdownDelim = '__';
+        i += 2;
+        continue;
+      }
+      if (char === '_') {
+        if (next === undefined) {
+          state.markdownCarry = '_';
+          break;
+        }
+        state.markdownMode = 'italic';
+        state.markdownBuffer = '';
+        state.markdownDelim = '_';
+        i += 1;
+        continue;
+      }
+      if (char === '~' && next === '~') {
+        state.markdownMode = 'strike';
+        state.markdownBuffer = '';
+        state.markdownDelim = '~~';
         i += 2;
         continue;
       }
       if (char === '`') {
         state.markdownMode = 'code';
         state.markdownBuffer = '';
+        state.markdownDelim = '`';
         i += 1;
         continue;
       }
       out += char;
+      if (char === '\n') state.atLineStart = true;
+      else state.atLineStart = false;
+      i += 1;
+      continue;
+    }
+
+    if (state.markdownMode === 'bold_italic') {
+      if (char === '*' && next === '*' && third === '*') {
+        out += paint(state.markdownBuffer, [ANSI.bold, ANSI.italic], options);
+        state.markdownMode = 'normal';
+        state.markdownBuffer = '';
+        state.markdownDelim = '';
+        i += 3;
+        continue;
+      }
+      if (char === '*' && next === undefined) {
+        state.markdownCarry = '*';
+        break;
+      }
+      state.markdownBuffer += char;
       i += 1;
       continue;
     }
 
     if (state.markdownMode === 'bold') {
-      if (char === '*' && next === undefined) {
-        state.markdownCarry = '*';
-        break;
-      }
-      if (char === '*' && next === '*') {
+      const close = state.markdownDelim === '__' ? (char === '_' && next === '_') : (char === '*' && next === '*');
+      if (close) {
         out += paint(state.markdownBuffer, [ANSI.bold], options);
         state.markdownMode = 'normal';
         state.markdownBuffer = '';
+        state.markdownDelim = '';
         i += 2;
         continue;
+      }
+      if ((char === '*' || char === '_') && next === undefined) {
+        state.markdownCarry = char;
+        break;
+      }
+      state.markdownBuffer += char;
+      i += 1;
+      continue;
+    }
+
+    if (state.markdownMode === 'italic') {
+      const close = char === state.markdownDelim && next !== state.markdownDelim;
+      if (close) {
+        out += paint(state.markdownBuffer, [ANSI.italic], options);
+        state.markdownMode = 'normal';
+        state.markdownBuffer = '';
+        state.markdownDelim = '';
+        i += 1;
+        continue;
+      }
+      if (char === state.markdownDelim && next === undefined) {
+        state.markdownCarry = char;
+        break;
+      }
+      state.markdownBuffer += char;
+      i += 1;
+      continue;
+    }
+
+    if (state.markdownMode === 'strike') {
+      if (char === '~' && next === '~') {
+        out += paint(state.markdownBuffer, [ANSI.strike], options);
+        state.markdownMode = 'normal';
+        state.markdownBuffer = '';
+        state.markdownDelim = '';
+        i += 2;
+        continue;
+      }
+      if (char === '~' && next === undefined) {
+        state.markdownCarry = '~';
+        break;
       }
       state.markdownBuffer += char;
       i += 1;
@@ -677,10 +1465,19 @@ function renderStreamingMarkdown(state, text, options = {}) {
 function flushStreamingMarkdown(state, output) {
   ensureMarkdownState(state);
   let out = state.markdownCarry || '';
-  if (state.markdownMode === 'bold' && state.markdownBuffer) {
+  state.markdownCarry = '';
+  if (state.markdownMode === 'bold_italic' && state.markdownBuffer) {
+    out += paint(state.markdownBuffer, [ANSI.bold, ANSI.italic], output);
+  } else if (state.markdownMode === 'bold' && state.markdownBuffer) {
     out += paint(state.markdownBuffer, [ANSI.bold], output);
+  } else if (state.markdownMode === 'italic' && state.markdownBuffer) {
+    out += paint(state.markdownBuffer, [ANSI.italic], output);
+  } else if (state.markdownMode === 'strike' && state.markdownBuffer) {
+    out += paint(state.markdownBuffer, [ANSI.strike], output);
   } else if (state.markdownMode === 'code' && state.markdownBuffer) {
     out += paint(state.markdownBuffer, [ANSI.accent], output);
+  } else if (state.markdownMode === 'fence' && state.markdownBuffer) {
+    out += renderFenceBuffer(state.markdownBuffer, output);
   }
   resetMarkdownState(state);
   if (out) output.write(out);
@@ -730,21 +1527,26 @@ function createProgressReporter(output, options = {}) {
   const enabled = options.showProgress !== false;
   const isTty = Boolean(output && output.isTTY);
   const startedAt = Date.now();
-  const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
   let frameIndex = 0;
-  let verb = 'Working';
+  let verb = 'Thinking';
   let interval = null;
   let timeout = null;
   let shown = false;
   let closed = false;
+  const renderOptions = () => ({
+    ...output,
+    color: options.color,
+    tick: frameIndex,
+    frameIndex,
+  });
 
   const render = () => {
     if (!enabled || closed) return;
     if (isTty) {
-      const frame = paint(frames[frameIndex++ % frames.length], [ANSI.accent], output);
-      output.write(`\r${formatWorkingLine(Date.now() - startedAt, verb, frame)}\x1b[K`);
+      output.write(`\r${formatWorkingLine(Date.now() - startedAt, verb, renderOptions())}\x1b[K`);
+      frameIndex += 1;
     } else if (!shown) {
-      output.write(`${formatWorkingLine(Date.now() - startedAt)}\n`);
+      output.write(`${formatWorkingLine(Date.now() - startedAt, verb, renderOptions())}\n`);
     }
     shown = true;
   };
@@ -754,11 +1556,11 @@ function createProgressReporter(output, options = {}) {
       if (!enabled) return;
       timeout = setTimeout(() => {
         render();
-        if (isTty) interval = setInterval(render, 120);
-      }, 700);
+        if (isTty) interval = setInterval(render, PROGRESS_FRAME_MS);
+      }, PROGRESS_START_DELAY_MS);
     },
     setVerb(next) {
-      verb = next || 'Working';
+      verb = next || 'Thinking';
     },
     clear() {
       if (!isTty || !shown || closed) return;
@@ -773,6 +1575,17 @@ function createProgressReporter(output, options = {}) {
       shown = false;
     }
   };
+}
+
+function manageTurnInterrupt(onInterrupt, options = {}) {
+  const trigger = () => onInterrupt();
+  const register = options.registerAbort;
+  if (typeof register === 'function') {
+    register(trigger);
+    return () => register(null);
+  }
+  process.once('SIGINT', trigger);
+  return () => process.removeListener('SIGINT', trigger);
 }
 
 function parseSseBlock(block) {
@@ -888,7 +1701,7 @@ function stopProgress(state) {
 }
 
 function flushPendingText(state, output) {
-  const hasMarkdownRemainder = output && output.isTTY && (
+  const hasMarkdownRemainder = output && (
     state.markdownCarry
     || state.markdownBuffer
     || (state.markdownMode && state.markdownMode !== 'normal')
@@ -900,7 +1713,7 @@ function flushPendingText(state, output) {
     output.write('● ');
     state.needsBullet = false;
   }
-  if (state.pendingText) output.write(output && output.isTTY ? renderTerminalMarkdown(state.pendingText, output) : state.pendingText);
+  if (state.pendingText) output.write(renderTerminalMarkdown(state.pendingText, output));
   const flushedMarkdown = hasMarkdownRemainder ? flushStreamingMarkdown(state, output) : '';
   state.wroteText = true;
   state.wroteActivity = true;
@@ -956,7 +1769,8 @@ function buildMessage(message, history = []) {
     'Recent conversation:',
     compactHistory(history),
     '',
-    `Current user message: ${trimmed}`,
+    '# Current user message',
+    trimmed,
   ].join('\n');
 }
 
@@ -964,12 +1778,15 @@ function buildPayload(message, options = {}) {
   const mode = normalizeMode(options.mode);
   const route = options.business ? 'local' : resolveRoute(message, options);
   const local = route !== 'cloud';
+  const bypass = resolveBypassPermissions(options);
   const verifyCommand = String(options.verify || '').trim();
   const payload = {
     message: buildMessage(message, options.history || []),
     model: modelForMode(mode),
-    max_turns: local ? (mode === 'fast' ? 8 : 14) : 1,
-    verify_command: verifyCommand || 'true'
+    max_turns: options.goalEval ? 1 : (local ? (mode === 'fast' ? 8 : 14) : 1),
+    verify_command: verifyCommand || 'true',
+    member_slug: MEMBER_SLUG,
+    bypass_permissions: bypass,
   };
   if (options.business) {
     // Business cloud workspace: the model loop stays on the backend and every
@@ -986,7 +1803,7 @@ function buildPayload(message, options = {}) {
   if (!local && options.connectionUserId) {
     payload.connection_user_id = options.connectionUserId;
   }
-  if (!local && connectorWriteIntent(message)) {
+  if (!local && bypass && connectorWriteIntent(message)) {
     payload.allow_external_actions = true;
     payload.cleanup_external_actions = true;
     payload.max_turns = mode === 'fast' ? 2 : 4;
@@ -1052,6 +1869,7 @@ function handleEvent(event, state, output) {
       writeAuxLine(state, output, formatToolResultLine(summarizeToolResult(result, output), output));
       state.lastAux = 'result';
     }
+    if (state.progress && state.progress.setVerb) state.progress.setVerb('Thinking');
     return;
   }
 
@@ -1082,8 +1900,14 @@ function handleEvent(event, state, output) {
       clearRetriedText(state);
       return;
     }
+    if (state.progress && state.progress.setVerb && /think|reason|plan/i.test(event.message)) {
+      state.progress.setVerb('Thinking');
+    }
     flushPendingText(state, output);
-    writeAuxLine(state, output, paint(`· ${formatStatusMessage(event.message)}`, [ANSI.muted], output));
+    const statusText = formatStatusMessage(event.message);
+    if (statusText) {
+      writeAuxLine(state, output, paint(`✦ ${statusText}`, [ANSI.bold, ANSI.magenta], output));
+    }
     return;
   }
 
@@ -1111,7 +1935,7 @@ async function postTurn(message, options = {}) {
   const connectionContext = options.connectionContext || (shouldSendConnectionContext
     ? await buildConnectionContext({ token, localWorkspace: local })
     : null);
-  const connectionUserId = !local && isLoopbackBackend() ? authUserId() : '';
+  const connectionUserId = !local && isLoopbackBackend({ route }) ? authUserId() : '';
   const payload = buildPayload(message, { ...options, route, connectionContext, connectionUserId });
   const postData = JSON.stringify(payload);
   const output = options.output || process.stdout;
@@ -1119,7 +1943,7 @@ async function postTurn(message, options = {}) {
   // SSE traffic in between, so the socket-idle timeout needs more headroom.
   const baseTimeoutMs = payload.model === 'atris:max' ? 300000 : payload.model === 'atris:pro' ? 180000 : 60000;
   const timeoutMs = options.business ? Math.max(baseTimeoutMs, 180000) : baseTimeoutMs;
-  const turnUrl = new URL(backendUrl());
+  const turnUrl = new URL(backendUrl({ route }));
   const transport = turnUrl.protocol === 'https:' ? https : http;
   const state = {
     events: [],
@@ -1137,15 +1961,19 @@ async function postTurn(message, options = {}) {
     markdownMode: 'normal',
     markdownBuffer: '',
     markdownCarry: '',
+    atLineStart: true,
     relay: options.business ? {
       chain: Promise.resolve(),
       execute: options.business.executor,
-      post: (callId, result) => options.business.postToolResult(callId, result, backendBaseUrl())
+      post: (callId, result) => options.business.postToolResult(callId, result, backendBaseUrl({ route }))
     } : null
   };
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    let interrupted = false;
+    let req = null;
+    let removeInterrupt = null;
     const startedAt = Date.now();
     state.progress = createProgressReporter(output, options);
     state.progress.start();
@@ -1153,6 +1981,8 @@ async function postTurn(message, options = {}) {
     const finish = (error, value) => {
       if (settled) return;
       settled = true;
+      if (removeInterrupt) removeInterrupt();
+      removeInterrupt = null;
       if (state.progress) state.progress.stop();
       state.progress = null;
       state.durationMs = Date.now() - startedAt;
@@ -1160,7 +1990,15 @@ async function postTurn(message, options = {}) {
       else resolve(value);
     };
 
-    const req = transport.request({
+    removeInterrupt = manageTurnInterrupt(() => {
+      if (settled) return;
+      interrupted = true;
+      flushPendingText(state, output);
+      if (req) req.destroy();
+      finish(null, { ...state, interrupted: true });
+    }, options);
+
+    req = transport.request({
       hostname: turnUrl.hostname,
       port: turnUrl.port || (turnUrl.protocol === 'https:' ? 443 : 80),
       path: `${turnUrl.pathname}${turnUrl.search}`,
@@ -1225,8 +2063,12 @@ async function postTurn(message, options = {}) {
       });
     });
 
-    req.on('error', finish);
+    req.on('error', (error) => {
+      if (interrupted) return;
+      finish(error);
+    });
     req.setTimeout(timeoutMs, () => {
+      if (settled) return;
       finish(new Error(`Request timeout after ${timeoutMs / 1000}s`));
       req.destroy();
     });
@@ -1246,7 +2088,7 @@ async function postCodeFastTurn(message, options = {}) {
   const output = options.output || process.stdout;
   const token = authToken();
   const timeoutMs = Math.max(10000, Math.min(600000, Number(payload.timeout_seconds || 180) * 1000));
-  const turnUrl = new URL(codeFastUrl());
+  const turnUrl = new URL(codeFastUrl({ ...options, route }));
   const transport = turnUrl.protocol === 'https:' ? https : http;
   const state = {
     events: [],
@@ -1263,11 +2105,15 @@ async function postCodeFastTurn(message, options = {}) {
     lastAux: '',
     markdownMode: 'normal',
     markdownBuffer: '',
-    markdownCarry: ''
+    markdownCarry: '',
+    atLineStart: true,
   };
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    let interrupted = false;
+    let req = null;
+    let removeInterrupt = null;
     const startedAt = Date.now();
     state.progress = createProgressReporter(output, options);
     state.progress.start();
@@ -1275,6 +2121,8 @@ async function postCodeFastTurn(message, options = {}) {
     const finish = (error, value) => {
       if (settled) return;
       settled = true;
+      if (removeInterrupt) removeInterrupt();
+      removeInterrupt = null;
       if (state.progress) state.progress.stop();
       state.progress = null;
       state.durationMs = Date.now() - startedAt;
@@ -1282,7 +2130,15 @@ async function postCodeFastTurn(message, options = {}) {
       else resolve(value);
     };
 
-    const req = transport.request({
+    removeInterrupt = manageTurnInterrupt(() => {
+      if (settled) return;
+      interrupted = true;
+      flushPendingText(state, output);
+      if (req) req.destroy();
+      finish(null, { ...state, interrupted: true });
+    }, options);
+
+    req = transport.request({
       hostname: turnUrl.hostname,
       port: turnUrl.port || (turnUrl.protocol === 'https:' ? 443 : 80),
       path: `${turnUrl.pathname}${turnUrl.search}`,
@@ -1334,8 +2190,12 @@ async function postCodeFastTurn(message, options = {}) {
       });
     });
 
-    req.on('error', finish);
+    req.on('error', (error) => {
+      if (interrupted) return;
+      finish(error);
+    });
     req.setTimeout(timeoutMs, () => {
+      if (settled) return;
       finish(new Error(`Request timeout after ${timeoutMs / 1000}s`));
       req.destroy();
     });
@@ -1350,15 +2210,137 @@ function turnFunctionForMode(mode) {
 
 async function chat(options = {}) {
   let mode = normalizeMode(options.mode);
+  let bypassPermissions = resolveBypassPermissions(options);
   const cwd = options.cwd || process.cwd();
   const input = options.input || process.stdin;
   const baseOutput = options.output || process.stdout;
   const logger = createRunLogger({ cwd, mode, kind: 'play', output: baseOutput });
   const output = logger ? logger.output : baseOutput;
   const history = [];
+  let goalState = null;
+  let lastAchievedGoal = null;
 
-  output.write(`${formatHeader({ mode, cwd, chat: true }, output)}\n\n`);
-  if (logger) output.write(`${formatAuxRow('log', formatPathSubject(logger.path, output), output)}\n\n`);
+  const goalPaintOptions = {
+    paint: (text, codes) => paint(text, codes, output),
+    bold: ANSI.bold,
+    magenta: ANSI.magenta,
+    muted: ANSI.muted,
+    accent: ANSI.accent,
+    ok: ANSI.ok,
+  };
+
+  const writeHeader = () => {
+    output.write(`${formatHeader({ mode, cwd, chat: true, bypassPermissions, goal: goalState }, output)}\n\n`);
+  };
+
+  writeHeader();
+
+  const executeChatTurn = async (message, turnOptions = {}) => {
+    let result;
+    try {
+      const turnFn = typeof options.turnFunction === 'function'
+        ? options.turnFunction
+        : turnFunctionForMode(mode);
+      result = await turnFn(message, {
+        mode,
+        cwd,
+        history,
+        output,
+        route: options.route,
+        business: options.business,
+        verify: options.verify,
+        bypassPermissions,
+        registerAbort: options.registerAbort,
+        goalEval: turnOptions.goalEval === true,
+      });
+    } finally {
+      if (typeof options.registerAbort === 'function') options.registerAbort(null);
+    }
+
+    if (result.interrupted) {
+      if (result.output && !result.output.endsWith('\n')) output.write('\n');
+      if (!turnOptions.goalEval) {
+        output.write(`${paint('· Interrupted', [ANSI.muted], output)}\n\n`);
+      }
+      if (result.output && result.output.trim()) {
+        history.push({ role: 'user', content: message });
+        history.push({ role: 'assistant', content: result.output });
+      }
+      return result;
+    }
+
+    if (result.output && !result.output.endsWith('\n')) output.write('\n');
+    if (!turnOptions.goalEval) {
+      output.write(`${formatDoneLine(result.durationMs, creditsFromState(result))}\n\n`);
+    }
+    history.push({ role: 'user', content: message });
+    history.push({ role: 'assistant', content: result.output || '' });
+    return result;
+  };
+
+  const runGoalLoop = async (activeGoal) => {
+    output.write(`${formatGoalStatus(activeGoal, goalPaintOptions)}\n\n`);
+    writeHeader();
+
+    while (activeGoal.active) {
+      const directive = buildGoalDirective(activeGoal, { continue: activeGoal.turns > 0 });
+      if (activeGoal.turns > 0) {
+        output.write(`${formatGoalContinue(activeGoal, goalPaintOptions)}\n\n`);
+      }
+      output.write('\n');
+
+      const result = await executeChatTurn(directive, { goalLoop: true });
+      activeGoal.turns += 1;
+      accumulateGoalUsage(activeGoal, result, creditsFromState);
+
+      if (result.interrupted) {
+        output.write(`${paint('· Goal turn interrupted — /goal for status · /goal clear to stop', [ANSI.muted], output)}\n\n`);
+        return;
+      }
+
+      const evalResult = await evaluateGoalTurn(activeGoal, {
+        history,
+        lastOutput: result.output,
+        turnOptions: {
+          mode,
+          cwd,
+          bypassPermissions,
+          route: options.route,
+          business: options.business,
+          verify: options.verify,
+          registerAbort: options.registerAbort,
+        },
+      }, { postTurn, evaluateGoal: options.evaluateGoal });
+
+      activeGoal.evalTurns += 1;
+      activeGoal.lastReason = evalResult.reason || activeGoal.lastReason;
+
+      if (evalResult.achieved) {
+        finishGoalAchieved(activeGoal, evalResult.reason);
+        output.write(`${formatGoalAchieved(activeGoal, goalPaintOptions)}\n\n`);
+        lastAchievedGoal = { ...activeGoal };
+        goalState = null;
+        writeHeader();
+        return;
+      }
+
+      if (goalTurnLimitReached(activeGoal)) {
+        clearGoalState(activeGoal);
+        output.write(`${formatGoalStopped(activeGoal, 'Turn limit reached.', goalPaintOptions)}\n\n`);
+        goalState = null;
+        writeHeader();
+        return;
+      }
+
+      if (goalBudgetExceeded(activeGoal)) {
+        clearGoalState(activeGoal);
+        output.write(`${formatGoalStopped(activeGoal, 'Token budget reached.', goalPaintOptions)}\n\n`);
+        goalState = null;
+        writeHeader();
+        return;
+      }
+    }
+  };
 
   const runLine = async (line) => {
     const trimmed = String(line || '').trim();
@@ -1378,18 +2360,68 @@ async function chat(options = {}) {
       return false;
     }
 
+    const permission = chatPermissionCommand(trimmed);
+    if (permission !== null) {
+      bypassPermissions = permission;
+      const persistPrefs = options.persistPrefs !== false;
+      setBypassPermissions(permission, { persist: persistPrefs });
+      if (logger) logger.write(`${trimmed}\n`);
+      output.write(`${formatPermissionToggleMessage(permission, { ...output, persistPrefs })}\n\n`);
+      return false;
+    }
+
+    const goalCmd = parseGoalCommand(trimmed);
+    if (goalCmd) {
+      if (logger) logger.write(`${trimmed}\n`);
+      if (goalCmd.action === 'clear') {
+        if (goalState) clearGoalState(goalState);
+        goalState = null;
+        output.write(`${paint('· Goal cleared', [ANSI.ok], output)}\n\n`);
+        writeHeader();
+        return false;
+      }
+      if (goalCmd.action === 'status') {
+        output.write(`${formatGoalStatus(goalState || lastAchievedGoal, goalPaintOptions)}\n\n`);
+        return false;
+      }
+      if (goalCmd.action === 'set') {
+        if (goalState && goalState.active) clearGoalState(goalState);
+        goalState = createGoalState(goalCmd.condition, goalCmd);
+        lastAchievedGoal = null;
+        await runGoalLoop(goalState);
+        return false;
+      }
+    }
+
     if (trimmed.startsWith('/')) {
       output.write(`${chatMenu(output)}\n\n`);
       return false;
     }
 
-    if (logger) logger.write(`${formatPrompt(mode)}${trimmed}\n`);
+    if (extractYoutubeUrl(trimmed)) {
+      if (logger) logger.write(`${formatPrompt(mode, { ...output, goal: goalState })}${trimmed}\n`);
+      output.write('\n');
+      const startedAt = Date.now();
+      const youtubeOutput = [];
+      await runAxYoutubeCommand([trimmed], {
+        youtubeCommand: options.youtubeCommand,
+        ensureValidCredentials: options.ensureValidCredentials,
+        apiRequestJson: options.apiRequestJson,
+        output: (line = '') => {
+          const text = String(line);
+          youtubeOutput.push(text);
+          output.write(`${text}\n`);
+        },
+      });
+      output.write(`${formatDoneLine(Date.now() - startedAt)}\n\n`);
+      history.push({ role: 'user', content: trimmed });
+      history.push({ role: 'assistant', content: youtubeOutput.join('\n') });
+      return false;
+    }
+
+    if (logger) logger.write(`${formatPrompt(mode, { ...output, goal: goalState })}${trimmed}\n`);
     output.write('\n');
-    const result = await turnFunctionForMode(mode)(trimmed, { mode, cwd, history, output, route: options.route, business: options.business, verify: options.verify });
-    if (result.output && !result.output.endsWith('\n')) output.write('\n');
-    output.write(`${formatDoneLine(result.durationMs, creditsFromState(result))}\n\n`);
-    history.push({ role: 'user', content: trimmed });
-    history.push({ role: 'assistant', content: result.output || '' });
+    await executeChatTurn(trimmed);
     return false;
   };
 
@@ -1402,22 +2434,443 @@ async function chat(options = {}) {
     return;
   }
 
-  const rl = readline.createInterface({ input, output: baseOutput, completer: chatCompleter });
-  const ask = () => new Promise(resolve => rl.question(formatPrompt(mode, baseOutput), resolve));
-  while (true) {
-    const line = await ask();
+  const rl = readline.createInterface({
+    input,
+    output: baseOutput,
+    completer: chatCompleter,
+    crlfDelay: Infinity,
+  });
+  readline.emitKeypressEvents(input, rl);
+  // Bracketed paste: terminals wrap pasted text in \x1b[200~ … \x1b[201~ so a
+  // multi-line paste lands as ONE message instead of submitting on every
+  // newline. readline + the multiline hook already understand the markers; we
+  // just have to turn the mode on (and off again on every exit path).
+  const setBracketedPaste = (on) => {
+    if (baseOutput && baseOutput.isTTY && typeof baseOutput.write === 'function') {
+      baseOutput.write(on ? '\x1b[?2004h' : '\x1b[?2004l');
+    }
+  };
+  const disableBracketedPasteOnExit = () => setBracketedPaste(false);
+  setBracketedPaste(true);
+  process.once('exit', disableBracketedPasteOnExit);
+  // readline can't emit a 'line' string that holds a literal newline, so the
+  // multiline hook hands us the true buffer here and ask() prefers it.
+  let pendingMultilineLine = null;
+  const detachMultilineInput = attachMultilineChatInput(rl, {
+    insertBreak: insertMultilineBreak,
+    onSubmit: (line) => { pendingMultilineLine = line; },
+  });
+  const boxLayoutOptions = () => inputBoxLayoutOptions(baseOutput, { bypassPermissions });
+  let exiting = false;
+  let awaitingInput = false;
+  // Repaint the box bottom rule after every readline render so the frame stays
+  // closed while typing (empty, wrapped, and multiline input alike).
+  const baseRefreshLine = typeof rl._refreshLine === 'function' ? rl._refreshLine.bind(rl) : null;
+  if (baseRefreshLine) {
+    rl._refreshLine = () => {
+      baseRefreshLine();
+      if (awaitingInput) repaintInputBoxBottom(rl, baseOutput, boxLayoutOptions());
+    };
+  }
+  let turnAbort = null;
+  options.registerAbort = (fn) => {
+    turnAbort = typeof fn === 'function' ? fn : null;
+  };
+  const onChatKeypress = (_str, key) => {
+    if (!awaitingInput) return;
+    if (!isPermissionToggleKey(key)) return;
+    bypassPermissions = !bypassPermissions;
+    const persistPrefs = options.persistPrefs !== false;
+    setBypassPermissions(bypassPermissions, { persist: persistPrefs });
+    if (logger) logger.write(`[shift+tab permissions ${bypassPermissions ? 'bypass' : 'safe'}]\n`);
+    // The mode label lives on the status line below the box now, so repaint
+    // that (it also restores the cursor) instead of redrawing the plain top.
+    repaintInputBoxBottom(rl, baseOutput, boxLayoutOptions());
+  };
+  input.prependListener('keypress', onChatKeypress);
+  rl.on('SIGINT', () => {
+    if (turnAbort) {
+      turnAbort();
+      return;
+    }
+    exiting = true;
+    output.write('\n');
+    rl.close();
+  });
+  const ask = () => new Promise((resolve, reject) => {
+    function onClose() {
+      reject(new Error('CHAT_CLOSED'));
+    }
+    rl.once('close', onClose);
+    awaitingInput = true;
+    const layout = boxLayoutOptions();
+    output.write(`\n${formatInputBoxTop(layout)}\n`);
+    pendingMultilineLine = null;
+    rl.question(formatChatInputPrompt(mode, { ...layout, goal: goalState }), (answer) => {
+      awaitingInput = false;
+      rl.removeListener('close', onClose);
+      closeInputBox(output, layout);
+      const captured = pendingMultilineLine;
+      pendingMultilineLine = null;
+      resolve(stripMultilineCsiText(captured != null ? captured : answer));
+    });
+  });
+  while (!exiting) {
+    let line = '';
+    try {
+      line = await ask();
+    } catch (error) {
+      if (error && error.message === 'CHAT_CLOSED') break;
+      throw error;
+    }
     if (await runLine(line)) {
       rl.close();
       break;
     }
   }
+  input.removeListener('keypress', onChatKeypress);
+  detachMultilineInput();
+  if (baseRefreshLine) rl._refreshLine = baseRefreshLine;
+  setBracketedPaste(false);
+  process.removeListener('exit', disableBracketedPasteOnExit);
   if (logger) logger.close(0);
+}
+
+function newestAxLog(cwd, sinceMs = 0) {
+  const runsDir = path.join(cwd, 'atris', 'runs');
+  if (!fs.existsSync(runsDir)) return null;
+  let newest = null;
+  for (const name of fs.readdirSync(runsDir)) {
+    if (!/^ax-.*\.log$/.test(name)) continue;
+    const full = path.join(runsDir, name);
+    let stat = null;
+    try {
+      stat = fs.statSync(full);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile() || stat.mtimeMs < sinceMs) continue;
+    if (!newest || stat.mtimeMs > newest.mtimeMs) newest = { path: full, mtimeMs: stat.mtimeMs };
+  }
+  return newest ? newest.path : null;
+}
+
+function makeChecklistItem(id, label, passed, evidence = '') {
+  return { id, label, passed: passed === true, evidence: compactText(evidence, 180) };
+}
+
+function compactText(text, max = 180) {
+  const one = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!one) return '';
+  return one.length <= max ? one : `${one.slice(0, max - 3)}...`;
+}
+
+function buildDogfoodChecklist({ cases, outputText, turnCalls, youtubeCalls, logPath }) {
+  const turnCases = cases.filter(item => item.kind === 'turn');
+  const paired = turnCases.map((item, index) => ({ case: item, call: turnCalls[index] || null }));
+  const smallTalk = paired.filter(item => /small_talk|short_noise|greeting/.test(item.case.coverage));
+  const local = paired.filter(item => item.case.expectRoute === 'local');
+  const cloud = paired.filter(item => item.case.expectRoute === 'cloud');
+  const bypassCall = paired.find(item => item.case.coverage === 'connector_write_bypass')?.call;
+  const safeCalls = paired.filter(item => /connector_write_(safe|resafe)/.test(item.case.coverage)).map(item => item.call);
+  const maxCall = paired.find(item => item.case.coverage === 'max_local')?.call;
+  const firstHeader = outputText.split(/\r?\n/).slice(0, 4).map(stripAnsi);
+  const longestHeader = firstHeader.reduce((max, line) => Math.max(max, line.length), 0);
+  const modelPattern = /atris:|composer-2-5|gpt-|kimi|fable|fireworks|openrouter/i;
+  const errorPattern = /Cannot access 'business'|Blocked: direct network access|ReferenceError|TypeError|UnhandledPromiseRejection|ECONNREFUSED|HTTP 5\d\d/i;
+
+  return [
+    makeChecklistItem('loops_25', 'Ran the requested loop count', cases.length === 25, `${cases.length}/25 loops`),
+    makeChecklistItem('header_compact', 'Chat header fits a small terminal', longestHeader <= 96 && /shift\+enter/.test(outputText), `longest header line ${longestHeader}`),
+    makeChecklistItem('menu_discoverable', 'Slash menu exposes key controls', /\/goal/.test(outputText) && /\/fast/.test(outputText) && /\/safe/.test(outputText), 'menu printed by /help and unknown slash'),
+    makeChecklistItem('small_talk_cloud', 'Greetings/noise avoid workspace listings', smallTalk.length >= 4 && smallTalk.every(item => item.call?.route === 'cloud' && !item.call?.workspace_path), smallTalk.map(item => `${item.case.input}:${item.call?.route}`).join(', ')),
+    makeChecklistItem('workspace_local', 'Workspace asks still use local tools', local.length >= 5 && local.every(item => item.call?.route === 'local' && item.call?.workspace_path), local.map(item => `${item.case.coverage}:${item.call?.route}`).join(', ')),
+    makeChecklistItem('connectors_cloud', 'Connector reads/writes stay cloud by default', cloud.length >= 8 && cloud.every(item => item.call?.route === 'cloud'), cloud.map(item => `${item.case.coverage}:${item.call?.route}`).join(', ')),
+    makeChecklistItem('tier_switches', 'Tier commands affect following turns', maxCall?.mode === 'max', `max turn mode ${maxCall?.mode || 'missing'}`),
+    makeChecklistItem('permission_gates', 'Safe/bypass gates are visible in payloads', bypassCall?.allow_external_actions === true && safeCalls.every(call => call && call.allow_external_actions !== true), `bypass=${bypassCall?.allow_external_actions === true}; safe=${safeCalls.length}`),
+    makeChecklistItem('youtube_shortcut', 'YouTube URLs route to local processor path', youtubeCalls.length === 1 && !turnCalls.some(call => extractYoutubeUrl(call.message)), `${youtubeCalls.length} youtube call(s)`),
+    makeChecklistItem('no_model_ids', 'UI hides backend model ids', !modelPattern.test(outputText), 'no raw model ids in transcript'),
+    makeChecklistItem('no_error_patterns', 'Transcript has no known crash/block patterns', !errorPattern.test(outputText), 'business TDZ/network/crash patterns absent'),
+    makeChecklistItem('log_written', 'Dogfood leaves an inspectable ax run log', Boolean(logPath && fs.existsSync(logPath)), logPath || 'missing'),
+  ];
+}
+
+async function runChatDogfood(options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const loops = Math.max(1, Number(options.loops) || 25);
+  const cases = buildChatDogfoodCases(loops);
+  const startedAt = Date.now();
+  const chunks = [];
+  const output = options.output || {
+    isTTY: true,
+    color: false,
+    write(chunk) {
+      chunks.push(String(chunk || ''));
+      return true;
+    },
+  };
+  const turnCalls = [];
+  const youtubeCalls = [];
+  const turnFunction = options.live === true ? undefined : async (message, turnOptions = {}) => {
+    const route = resolveRoute(message, turnOptions);
+    const payload = buildPayload(message, { ...turnOptions, route });
+    const record = {
+      message,
+      mode: normalizeMode(turnOptions.mode),
+      route,
+      workspace_path: payload.workspace_path || null,
+      max_turns: payload.max_turns,
+      bypass_permissions: payload.bypass_permissions === true,
+      allow_external_actions: payload.allow_external_actions === true,
+    };
+    turnCalls.push(record);
+    const text = `dogfood ok: ${record.mode}/${record.route}`;
+    if (turnOptions.output) turnOptions.output.write(text);
+    return {
+      output: text,
+      durationMs: 1,
+      events: [{ type: 'receipt', receipt: { billing: { billed: false }, dogfood: record } }],
+    };
+  };
+  const youtubeCommand = async (argv, deps = {}) => {
+    youtubeCalls.push(argv);
+    if (deps.output) deps.output(`dogfood youtube: ${argv[0] || 'missing-url'}`);
+    return 0;
+  };
+  const input = Readable.from(cases.map(item => `${item.input}\n`).concat('exit\n'));
+
+  await chat({
+    mode: 'fast',
+    cwd,
+    input,
+    output,
+    turnFunction,
+    youtubeCommand: options.youtubeCommand || youtubeCommand,
+    persistPrefs: false,
+    bypassPermissions: false,
+  });
+
+  const outputText = typeof output.text === 'function' ? output.text() : chunks.join('');
+  const logPath = newestAxLog(cwd, startedAt - 1000);
+  const checklist = buildDogfoodChecklist({ cases, outputText, turnCalls, youtubeCalls, logPath });
+  const failures = checklist.filter(item => !item.passed);
+  return {
+    schema: 'atris.ax_chat_dogfood.v1',
+    mode: 'fast',
+    loops_requested: loops,
+    loops_run: cases.length,
+    dry_run: options.live !== true,
+    cwd,
+    log_path: logPath,
+    turn_calls: turnCalls,
+    youtube_calls: youtubeCalls,
+    checklist,
+    failures,
+    output: outputText,
+  };
+}
+
+function formatChatDogfoodReport(report) {
+  const passed = report.checklist.filter(item => item.passed).length;
+  const lines = [
+    'Ax fast chat dogfood',
+    `loops: ${report.loops_run}/${report.loops_requested}`,
+    `checklist: ${passed}/${report.checklist.length} passed`,
+    `log: ${report.log_path || 'missing'}`,
+    '',
+  ];
+  for (const item of report.checklist) {
+    lines.push(`${item.passed ? 'ok' : 'fail'} ${item.id} — ${item.evidence || item.label}`);
+  }
+  if (report.failures.length) {
+    lines.push('');
+    lines.push(`failures: ${report.failures.map(item => item.id).join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+function safeJsonFile(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readJsonlRows(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    return fs.readFileSync(filePath, 'utf8')
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(line => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function parseDogfoodVerifierOutput(stdout = '') {
+  const text = String(stdout || '');
+  const loops = text.match(/loops:\s*(\d+)\/(\d+)/i);
+  const checklist = text.match(/checklist:\s*(\d+)\/(\d+)\s+passed/i);
+  const log = text.match(/^log:\s*(.+)$/im);
+  return {
+    loops_passed: loops ? Number(loops[1]) : 0,
+    loops_total: loops ? Number(loops[2]) : 0,
+    checklist_passed: checklist ? Number(checklist[1]) : 0,
+    checklist_total: checklist ? Number(checklist[2]) : 0,
+    log_path: log ? log[1].trim() : null,
+  };
+}
+
+function latestDogfoodMission(cwd = process.cwd()) {
+  const rows = readJsonlRows(path.join(cwd, '.atris', 'state', 'missions.jsonl'));
+  const byId = new Map();
+  for (const row of rows) {
+    if (!row || row.schema !== 'atris.mission.v1') continue;
+    if (!/--dogfood-chat/.test(String(row.verifier || ''))) continue;
+    byId.set(row.id, row);
+  }
+  const missions = Array.from(byId.values());
+  missions.sort((a, b) => new Date(b.updated_at || b.created_at || 0) - new Date(a.updated_at || a.created_at || 0));
+  return missions[0] || null;
+}
+
+function collectDogfoodTicks(cwd, mission) {
+  const runsDir = path.join(cwd, 'atris', 'runs');
+  const out = new Map();
+  if (!mission || !mission.id || !fs.existsSync(runsDir)) return [];
+  const prefix = `mission-${mission.id}-`;
+  for (const name of fs.readdirSync(runsDir)) {
+    if (!name.startsWith(prefix) || !name.endsWith('.json')) continue;
+    const full = path.join(runsDir, name);
+    const payload = safeJsonFile(full);
+    if (!payload) continue;
+    let mtimeMs = 0;
+    try {
+      mtimeMs = fs.statSync(full).mtimeMs;
+    } catch {}
+    const body = payload.result || payload;
+    const stdout = body.verifier_result?.stdout || payload.verifier_result?.stdout || payload.mission?.verifier_result?.stdout || '';
+    const ticks = [];
+    if (payload.tick) ticks.push(payload.tick);
+    if (body.tick) ticks.push(body.tick);
+    if (Array.isArray(payload.ticks)) ticks.push(...payload.ticks);
+    if (Array.isArray(body.ticks)) ticks.push(...body.ticks);
+    for (const tick of ticks) {
+      const index = Number(tick && tick.tick_index);
+      if (!Number.isFinite(index) || index < 1) continue;
+      const previous = out.get(index);
+      if (previous && previous.mtimeMs > mtimeMs) continue;
+      const summary = parseDogfoodVerifierOutput(stdout);
+      out.set(index, {
+        index,
+        verifier_passed: tick.verifier_passed === true || body.verifier_result?.passed === true || payload.verifier_result?.passed === true,
+        receipt_path: path.relative(cwd, full),
+        mtimeMs,
+        ...summary,
+      });
+    }
+  }
+  return Array.from(out.values()).sort((a, b) => a.index - b.index);
+}
+
+function dogfoodCrontabInstalled(crontabText = null) {
+  const text = crontabText !== null ? String(crontabText || '') : (() => {
+    try {
+      const res = spawnSync('crontab', ['-l'], { encoding: 'utf8', timeout: 8000 });
+      return res.status === 0 ? String(res.stdout || '') : '';
+    } catch {
+      return '';
+    }
+  })();
+  return /ATRIS_AX_FAST_CHAT_DOGFOOD/.test(text);
+}
+
+function countDogfoodCronRuns(cwd = process.cwd(), cronLogText = null) {
+  const text = cronLogText !== null
+    ? String(cronLogText || '')
+    : String(safeReadText(path.join(cwd, 'atris', 'runs', 'ax-fast-chat-overnight-cron.log')) || '');
+  return (text.match(/^=== ax fast chat dogfood tick /gm) || []).length;
+}
+
+function safeReadText(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return '';
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function buildChatDogfoodStatus(options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const targetLoops = Math.max(1, Number(options.targetLoops) || 25);
+  const mission = options.mission || latestDogfoodMission(cwd);
+  const ticks = collectDogfoodTicks(cwd, mission);
+  const cleanTicks = ticks.filter(tick => tick.verifier_passed && tick.loops_passed > 0);
+  const cleanLoops = cleanTicks.reduce((sum, tick) => sum + tick.loops_passed, 0);
+  const latestClean = cleanTicks[cleanTicks.length - 1] || null;
+  const latestTick = ticks[ticks.length - 1] || null;
+  const checklistPassed = latestClean && latestClean.checklist_total > 0 && latestClean.checklist_passed === latestClean.checklist_total;
+  const cronInstalled = dogfoodCrontabInstalled(options.crontabText ?? null);
+  const cronRuns = countDogfoodCronRuns(cwd, options.cronLogText ?? null);
+  return {
+    schema: 'atris.ax_chat_dogfood_status.v1',
+    cwd,
+    mission_id: mission ? mission.id : null,
+    mission_status: mission ? mission.status : null,
+    mission_cadence: mission ? mission.cadence : null,
+    last_tick_index: mission ? Number(mission.last_tick_index || 0) : 0,
+    last_tick_at: mission ? mission.last_tick_at || null : null,
+    target_loops: targetLoops,
+    clean_chat_loops: cleanLoops,
+    remaining_loops: Math.max(0, targetLoops - cleanLoops),
+    target_met: cleanLoops >= targetLoops,
+    clean_tick_count: cleanTicks.length,
+    latest_receipt_path: latestClean ? latestClean.receipt_path : latestTick ? latestTick.receipt_path : null,
+    latest_log_path: latestClean ? latestClean.log_path : null,
+    latest_checklist_passed: checklistPassed === true,
+    cron_installed: cronInstalled,
+    cron_runs: cronRuns,
+    overnight_proven: cronRuns > 0 && cleanLoops >= targetLoops,
+  };
+}
+
+function formatChatDogfoodStatusReport(status) {
+  const lines = [
+    'Ax fast chat overnight',
+    `mission: ${status.mission_id || 'missing'}`,
+    `status: ${status.mission_status || 'missing'} · cadence ${status.mission_cadence || 'n/a'}`,
+    `loops: ${status.clean_chat_loops}/${status.target_loops} clean (${status.remaining_loops} remaining)`,
+    `ticks: ${status.clean_tick_count} clean · last ${status.last_tick_index || 0} at ${status.last_tick_at || 'never'}`,
+    `checklist: ${status.latest_checklist_passed ? 'passed' : 'missing/failing'}`,
+    `cron: ${status.cron_installed ? 'installed' : 'missing'} · runs ${status.cron_runs}`,
+    `receipt: ${status.latest_receipt_path || 'missing'}`,
+    `log: ${status.latest_log_path || 'missing'}`,
+  ];
+  lines.push(status.overnight_proven ? 'result: overnight 25-loop proof is complete' : 'result: still collecting overnight proof');
+  return lines.join('\n');
 }
 
 function printBackendHint() {
   console.log('');
-  console.log('Start backend:');
-  console.log(`cd /Users/keshavrao/arena/atrisos-backend/backend && ATRIS2_ALLOW_LOCAL_WORKSPACE=1 ENVIRONMENT=development ENV=development ../venv/bin/uvicorn main:app --host ${BACKEND.host} --port ${BACKEND.port}`);
+  console.log('Hosted lane:');
+  console.log('ax --cloud "hello"');
+  console.log('');
+  console.log('Cloud API:');
+  console.log(`ATRIS_API_BASE=${BACKEND.publicBase}`);
+  console.log('');
+  console.log('Local workspace lane:');
+  console.log(`Set AX_BACKEND_URL=http://${BACKEND.host}:${BACKEND.port} after starting a local Atris2 backend.`);
 }
 
 function bufferedOutput() {
@@ -1597,11 +3050,34 @@ async function runBenchmark(options = {}) {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
+  let args = process.argv.slice(2);
+  if (isAxSpawnCommand(args[0])) {
+    try {
+      runAxSpawnCommand(args, { root: process.cwd() });
+    } catch (error) {
+      console.error(`x ${error.message}`);
+      process.exit(1);
+    }
+    return;
+  }
+  if (args[0] === 'youtube') {
+    try {
+      await runAxYoutubeCommand(args, { output: (line = '') => console.log(line) });
+    } catch (error) {
+      console.error(`x ${error.message}`);
+      process.exit(1);
+    }
+    return;
+  }
   if (args.includes('--help') || args.includes('-h')) {
     console.log(formatUsage());
     return;
   }
+
+  const bypassPermissions = parsePermissionFlags(args);
+  args = stripPermissionFlags(args);
+  const chatArgs = normalizeChatCommandArgs(args);
+  args = chatArgs.args;
 
   // --business <slug>: chat against that business's cloud workspace. The flag
   // takes a value, so splice the pair out before building the prompt.
@@ -1629,16 +3105,62 @@ async function main() {
     args.splice(verifyIdx, 2);
   }
 
-  const mode = args.includes('--code-fast') || args.includes('--code') ? 'code-fast' : args.includes('--max') ? 'max' : args.includes('--fast') ? 'fast' : 'pro';
+  let dogfoodLoops = 25;
+  const loopsIdx = args.indexOf('--loops');
+  if (loopsIdx !== -1) {
+    dogfoodLoops = Number(args[loopsIdx + 1]);
+    if (!Number.isInteger(dogfoodLoops) || dogfoodLoops < 1 || dogfoodLoops > 100) {
+      console.error('Usage: ax --dogfood-chat --loops <1-100>');
+      process.exit(1);
+    }
+    args.splice(loopsIdx, 2);
+  }
+
+  const mode = args.includes('--code-fast') || args.includes('--code') ? 'code-fast'
+    : args.includes('--max') ? 'max'
+      : args.includes('--pro') ? 'pro'
+        : 'fast';
   const doctor = args.includes('--doctor');
   const benchmark = args.includes('--benchmark');
+  const dogfoodChat = args.includes('--dogfood-chat');
+  const dogfoodStatus = args.includes('--dogfood-status');
+  const dogfoodJson = dogfoodChat && args.includes('--json');
+  const dogfoodLive = dogfoodChat && args.includes('--live');
   const forceCloud = args.includes('--cloud');
   const forceLocal = args.includes('--local');
   const route = forceCloud ? 'cloud' : forceLocal ? 'local' : 'auto';
   const prompt = args
-    .filter(arg => !['--max', '--fast', '--pro', '--code-fast', '--code', '--chat', '--doctor', '--benchmark', '--local', '--cloud', '--help', '-h'].includes(arg))
+    .filter(arg => !['--max', '--fast', '--pro', '--code-fast', '--code', '--chat', '--doctor', '--benchmark', '--dogfood-chat', '--dogfood-status', '--json', '--live', '--local', '--cloud', '--help', '-h'].includes(arg))
     .join(' ')
     .trim();
+
+  if (dogfoodStatus) {
+    const status = buildChatDogfoodStatus({ cwd: process.cwd(), targetLoops: dogfoodLoops });
+    console.log(args.includes('--json') ? JSON.stringify(status, null, 2) : formatChatDogfoodStatusReport(status));
+    return;
+  }
+
+  if (dogfoodChat) {
+    try {
+      const report = await runChatDogfood({ mode, cwd: process.cwd(), loops: dogfoodLoops, live: dogfoodLive });
+      console.log(dogfoodJson ? JSON.stringify(report, null, 2) : formatChatDogfoodReport(report));
+      if (report.failures.length) process.exit(1);
+    } catch (error) {
+      console.error(`x ${error.message}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (prompt && extractYoutubeUrl(prompt)) {
+    try {
+      await runAxYoutubeCommand([prompt], { output: (line = '') => console.log(line) });
+    } catch (error) {
+      console.error(`x ${error.message}`);
+      process.exit(1);
+    }
+    return;
+  }
 
   let business = null;
   if (businessSlug) {
@@ -1671,6 +3193,15 @@ async function main() {
     console.log(`cloud workspace: ${biz.businessName || businessSlug}`);
   }
 
+  const runOptions = {
+    mode,
+    cwd: process.cwd(),
+    route: route === 'auto' ? undefined : route,
+    business,
+    verify,
+    bypassPermissions,
+  };
+
   try {
     if (benchmark) {
       await runBenchmark({ mode, cwd: process.cwd(), output: process.stdout });
@@ -1678,20 +3209,25 @@ async function main() {
     }
 
     if (doctor) {
-      console.log(formatHeader({ mode, cwd: process.cwd(), chat: false }, process.stdout));
+      console.log(formatHeader({ mode, cwd: process.cwd(), chat: false, bypassPermissions: resolveBypassPermissions(runOptions) }, process.stdout));
       console.log('');
-      console.log(formatRunProfile(buildRunProfile({ mode, cwd: process.cwd(), route: route === 'auto' ? undefined : route }), process.stdout));
+      console.log(formatRunProfile(buildRunProfile(runOptions), process.stdout));
       return;
     }
 
-    if (!prompt || args.includes('--chat')) {
-      await chat({ mode, cwd: process.cwd(), route: route === 'auto' ? undefined : route, business, verify });
+    if (!prompt || chatArgs.chatRequested) {
+      await chat(runOptions);
       return;
     }
 
-    console.log(formatHeader({ mode, cwd: process.cwd(), chat: false }, process.stdout));
+    console.log(formatHeader({ mode, cwd: process.cwd(), chat: false, bypassPermissions: resolveBypassPermissions(runOptions) }, process.stdout));
     console.log('');
-    const result = await turnFunctionForMode(mode)(prompt, { mode, cwd: process.cwd(), route: route === 'auto' ? undefined : route, business, verify });
+    const result = await turnFunctionForMode(mode)(prompt, runOptions);
+    if (result.interrupted) {
+      console.log('');
+      console.log('· Interrupted');
+      process.exit(130);
+    }
     console.log('');
     console.log(formatDoneLine(result.durationMs, creditsFromState(result)));
   } catch (error) {
@@ -1710,15 +3246,29 @@ module.exports = {
   authUserId,
   backendBaseUrl,
   backendUrl,
+  buildAxYoutubeArgs,
   buildCodeFastPayload,
+  buildChatDogfoodCases,
+  buildChatDogfoodStatus,
+  buildMessage,
   buildPayload,
   cachedIntegrationStatus,
   buildConnectionContext,
   buildRunProfile,
   chat,
   chatCompleter,
+  chatGoalCommand: parseGoalCommand,
   chatMenu,
+  chatPermissionCommand,
   chatTierCommand,
+  loadAxPrefs,
+  MEMBER_SLUG,
+  parsePermissionFlags,
+  permissionsLabel,
+  printBackendHint,
+  resolveBypassPermissions,
+  runAxSpawnCommand,
+  setBypassPermissions,
   codeFastWorkspaceNotice,
   creditsFromState,
   codeFastBaseUrl,
@@ -1726,24 +3276,55 @@ module.exports = {
   createRunLogger,
   createProgressReporter,
   formatDoneLine,
+  formatChatDogfoodReport,
+  formatChatDogfoodStatusReport,
   formatDuration,
   formatHeader,
   formatPathSubject,
+  buildInputBoxBottomPlain,
+  buildInputBoxStatusPlain,
+  buildInputBoxTopPlain,
+  closeInputBox,
+  repaintInputBoxBottom,
+  formatChatInputInnerPrefix,
+  formatChatInputPrompt,
+  formatInputBoxBottom,
+  formatInputBoxInputRow,
+  formatInputBoxStatus,
+  formatInputBoxTop,
+  formatPermissionModeBrief,
+  formatPermissionToggleMessage,
   formatPrompt,
+  insertMultilineBreak,
+  inputBoxLayoutOptions,
+  inputBoxPlainWidth,
+  isMultilineInsertKey,
+  isPermissionToggleKey,
+  permissionAccentCodes,
   formatRunProfile,
   formatStatusMessage,
   formatSystemInit,
   formatUsage,
   formatWorkingLine,
   handleEvent,
+  extractYoutubeUrl,
+  isAxSpawnCommand,
+  manageTurnInterrupt,
   modelForMode,
+  normalizeChatCommandArgs,
   parseSseBlock,
   postCodeFastTurn,
   postTurn,
+  renderTerminalInline,
+  renderTerminalBlockLine,
+  formatMarkdownLink,
   renderStreamingMarkdown,
+  renderShimmerText,
   renderTerminalMarkdown,
   resolveRoute,
   runBenchmark,
+  runChatDogfood,
+  runAxYoutubeCommand,
   summarizeToolInput,
   summarizeToolResult,
   tierLabel

--- a/commands/youtube.js
+++ b/commands/youtube.js
@@ -1,0 +1,183 @@
+const { apiRequestJson } = require('../utils/api');
+const { ensureValidCredentials } = require('../utils/auth');
+
+const DEFAULT_QUERY = 'Extract main topics, key insights, and actionable takeaways.';
+const DEFAULT_TIMEOUT_MS = 300000;
+
+function showYoutubeHelp(output = console.log, commandName = 'atris youtube') {
+  output('');
+  output(`Usage: ${commandName} process <youtube-url> [options]`);
+  output(`       ${commandName} <youtube-url> [options]`);
+  output('');
+  output('Process a YouTube video through Atris using Gemini native video analysis.');
+  output('');
+  output('Options:');
+  output('  --query, -q <text>  Focus question for the analysis');
+  output('  --agent <id>        Agent id to store knowledge against');
+  output('  --store             Save as agent knowledge (requires --agent)');
+  output('  --timeout <sec>     Request timeout in seconds (default: 300)');
+  output('  --json              Print the raw JSON response');
+  output('  -h, --help          This help');
+  output('');
+  output('Examples:');
+  output(`  ${commandName} https://www.youtube.com/watch?v=VIDEO_ID`);
+  output(`  ${commandName} process https://youtu.be/VIDEO_ID --query "Key takeaways"`);
+  output('');
+}
+
+function readValue(args, index, name) {
+  if (index >= args.length - 1 || String(args[index + 1]).startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return args[index + 1];
+}
+
+function parseTimeoutMs(raw) {
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error('--timeout must be a positive number of seconds');
+  }
+  return Math.round(seconds * 1000);
+}
+
+function parseYoutubeArgs(argv = []) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    json: false,
+    youtubeUrl: null,
+    query: DEFAULT_QUERY,
+    agentId: null,
+    storeAsKnowledge: false,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  };
+
+  if (args.length === 0 || ['help', '--help', '-h'].includes(args[0])) {
+    options.help = true;
+    return options;
+  }
+
+  if (['process', 'analyze', 'watch'].includes(args[0])) {
+    args.shift();
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h' || arg === 'help') {
+      options.help = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--store' || arg === '--store-as-knowledge') {
+      options.storeAsKnowledge = true;
+    } else if (arg === '--query' || arg === '-q') {
+      options.query = readValue(args, i, arg);
+      i++;
+    } else if (arg.startsWith('--query=')) {
+      options.query = arg.slice('--query='.length);
+    } else if (arg === '--agent' || arg === '--agent-id') {
+      options.agentId = readValue(args, i, arg);
+      i++;
+    } else if (arg.startsWith('--agent=')) {
+      options.agentId = arg.slice('--agent='.length);
+    } else if (arg === '--timeout') {
+      options.timeoutMs = parseTimeoutMs(readValue(args, i, arg));
+      i++;
+    } else if (arg.startsWith('--timeout=')) {
+      options.timeoutMs = parseTimeoutMs(arg.slice('--timeout='.length));
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else if (!options.youtubeUrl) {
+      options.youtubeUrl = arg;
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+
+  if (options.help) return options;
+  if (!options.youtubeUrl) throw new Error('Missing YouTube URL. Run "atris youtube --help".');
+  if (options.storeAsKnowledge && !options.agentId) {
+    throw new Error('--store requires --agent <id>');
+  }
+  return options;
+}
+
+function buildYoutubePayload(options) {
+  const payload = {
+    youtube_url: options.youtubeUrl,
+    query: options.query || DEFAULT_QUERY,
+  };
+  if (options.agentId) payload.agent_id = options.agentId;
+  if (options.storeAsKnowledge) payload.store_as_knowledge = true;
+  return payload;
+}
+
+async function processYoutube(options, deps = {}) {
+  const apiFn = deps.apiRequestJson || apiRequestJson;
+  const ensureFn = deps.ensureValidCredentials || ensureValidCredentials;
+  const ensured = await ensureFn(apiFn);
+  const creds = ensured && ensured.credentials;
+  if (!creds?.token) {
+    const detail = ensured?.detail || ensured?.error;
+    throw new Error(detail ? `Authentication failed: ${detail}. Run "atris login".` : 'Not logged in. Run "atris login".');
+  }
+
+  const result = await apiFn('/agent/process_youtube', {
+    method: 'POST',
+    token: creds.token,
+    timeoutMs: options.timeoutMs,
+    body: buildYoutubePayload(options),
+  });
+
+  if (!result.ok) {
+    const hint = result.status === 401
+      ? ' Run "atris login --force".'
+      : result.status === 402
+        ? ' Check Atris credits.'
+        : '';
+    throw new Error(`YouTube processing failed (${result.status}): ${result.error || result.text || 'unknown error'}.${hint}`);
+  }
+
+  return result.data;
+}
+
+function formatYoutubeResult(data) {
+  const lines = [];
+  const metadata = data?.metadata || {};
+  lines.push(data?.message || 'YouTube video processed successfully');
+  if (metadata.title) lines.push(`Title: ${metadata.title}`);
+  if (metadata.channel) lines.push(`Channel: ${metadata.channel}`);
+  if (data?.credits_used !== undefined || data?.credits_remaining !== undefined) {
+    const used = data.credits_used !== undefined ? data.credits_used : '?';
+    const remaining = data.credits_remaining !== undefined ? data.credits_remaining : '?';
+    lines.push(`Credits: ${used} used, ${remaining} remaining`);
+  }
+  const analysis = data?.video_analysis || data?.analysis || data?.result;
+  if (analysis) {
+    lines.push('');
+    lines.push(String(analysis).trim());
+  }
+  return lines.join('\n');
+}
+
+async function youtubeCommand(argv = process.argv.slice(3), deps = {}) {
+  const output = deps.output || ((line = '') => console.log(line));
+  const options = parseYoutubeArgs(argv);
+  if (options.help) {
+    showYoutubeHelp(output, deps.commandName || 'atris youtube');
+    return 0;
+  }
+  const data = await processYoutube(options, deps);
+  output(options.json ? JSON.stringify(data, null, 2) : formatYoutubeResult(data));
+  return 0;
+}
+
+module.exports = {
+  DEFAULT_QUERY,
+  DEFAULT_TIMEOUT_MS,
+  showYoutubeHelp,
+  parseYoutubeArgs,
+  buildYoutubePayload,
+  processYoutube,
+  formatYoutubeResult,
+  youtubeCommand,
+};

--- a/lib/ax-chat-input.js
+++ b/lib/ax-chat-input.js
@@ -1,0 +1,164 @@
+const MULTILINE_CSI = [
+  '\x1b[13;2~',
+  '\x1b[27;2;13~',
+  '\x1b[23~',
+  '\x1b[13;2u',
+];
+
+const MULTILINE_CSI_RE = /\x1b\[(?:13;2~|27;2;13~|23~|13;2u)/;
+const MULTILINE_CSI_VISIBLE_RE = /\[(?:13;2~|27;2;13~|23~|13;2u)/g;
+
+// Node's readline cannot emit a 'line' whose buffer contains a literal "\n"
+// (it reorders the text around the newline on submit). So newlines live in the
+// buffer as this sentinel while typing is rendered, then are restored to "\n"
+// when the answer is read back via stripMultilineCsiText.
+const MULTILINE_PLACEHOLDER = '\x1f';
+const MULTILINE_PLACEHOLDER_RE = /\x1f/g;
+
+function isMultilineCsiPrefix(buffer) {
+  const value = String(buffer || '');
+  if (!value) return false;
+  return MULTILINE_CSI.some((seq) => seq.startsWith(value));
+}
+
+function isMultilineCsiComplete(buffer) {
+  return MULTILINE_CSI.includes(String(buffer || ''));
+}
+
+function isMultilineCsiKey(key) {
+  const sequence = String(key?.sequence || '');
+  return MULTILINE_CSI_RE.test(sequence);
+}
+
+function isMultilineInsertKey(str, key) {
+  if (!key) return str === '\n';
+  if (key.shift && (key.name === 'return' || key.name === 'enter')) return true;
+  if (key.meta && (key.name === 'return' || key.name === 'enter')) return true;
+  if (str === '\n' && key.name !== 'return') return true;
+  return false;
+}
+
+function isSubmitKey(str, key) {
+  if (key && (key.name === 'return' || key.name === 'enter') && !key.shift && !key.meta) return true;
+  if (!key && str === '\r') return true;
+  return false;
+}
+
+function stripMultilineCsiText(text) {
+  return String(text || '')
+    .replace(MULTILINE_PLACEHOLDER_RE, '\n')
+    .replace(/\x1b\[20[01]~/g, '')
+    .replace(/\x1b\[(?:13;2~|27;2;13~|23~|13;2u)/g, '\n')
+    .replace(MULTILINE_CSI_VISIBLE_RE, '\n')
+    .replace(/\^?\[\[27;2;13~/g, '\n');
+}
+
+// The raw bytes a keypress represents. readline's keypress decoder mangles
+// some CSI sequences (e.g. it splits \x1b[27;2;13~ into a malformed escape
+// whose `sequence` is \x1b[27;2; followed by literal "1", "3", "~"), so when
+// `str` is empty we fall back to the decoded `sequence`.
+function keyBytes(str, key) {
+  if (typeof str === 'string' && str.length > 0) return str;
+  if (key && typeof key.sequence === 'string' && key.sequence.length > 0) return key.sequence;
+  return typeof str === 'string' ? str : '';
+}
+
+function defaultInsertBreak(rl) {
+  if (!rl) return;
+  // _insertString splices a literal newline at the cursor; rl.write('\n')
+  // would instead SUBMIT the line, so it must not be used here.
+  if (typeof rl._insertString === 'function') {
+    rl._insertString('\n');
+    return;
+  }
+  if (typeof rl.line === 'string') {
+    const cursor = Number.isFinite(rl.cursor) ? rl.cursor : rl.line.length;
+    rl.line = rl.line.slice(0, cursor) + '\n' + rl.line.slice(cursor);
+    rl.cursor = cursor + 1;
+    if (typeof rl._refreshLine === 'function') rl._refreshLine();
+    return;
+  }
+  if (typeof rl.write === 'function') rl.write('\n');
+}
+
+function attachMultilineChatInput(rl, { insertBreak = defaultInsertBreak, onSubmit } = {}) {
+  if (!rl || typeof rl._ttyWrite !== 'function') return () => {};
+  const ttyWrite = rl._ttyWrite.bind(rl);
+  let escBuffer = null;
+
+  rl._ttyWrite = (str, key) => {
+    const bytes = keyBytes(str, key);
+
+    // Mid-sequence: keypress decoder shredded a multiline CSI across calls and
+    // we're reassembling it (e.g. \x1b[27;2; then "1", "3", "~").
+    if (escBuffer !== null) {
+      escBuffer += bytes;
+      if (isMultilineCsiComplete(escBuffer)) {
+        escBuffer = null;
+        insertBreak(rl);
+        return;
+      }
+      if (isMultilineCsiPrefix(escBuffer) && escBuffer.length <= 24) {
+        return;
+      }
+      // Diverged from every target sequence: replay the swallowed bytes
+      // literally (current keypress is already included in the buffer).
+      const replay = escBuffer;
+      escBuffer = null;
+      for (const ch of replay) ttyWrite(ch);
+      return;
+    }
+
+    // Whole multiline CSI delivered in a single keypress (terminals or Node
+    // versions that don't shred it).
+    if (isMultilineCsiKey(key) || MULTILINE_CSI_RE.test(bytes)) {
+      insertBreak(rl);
+      return;
+    }
+
+    // Start of a shredded multiline CSI: begin buffering from the raw escape.
+    if (bytes && bytes.charCodeAt(0) === 0x1b && isMultilineCsiPrefix(bytes)) {
+      escBuffer = bytes;
+      if (isMultilineCsiComplete(escBuffer)) {
+        escBuffer = null;
+        insertBreak(rl);
+      }
+      return;
+    }
+
+    // Plain Shift+Enter / Meta+Enter / synthetic \n.
+    if (isMultilineInsertKey(str, key)) {
+      insertBreak(rl);
+      return;
+    }
+
+    // Submit (Enter): the line buffer keeps its literal "\n" so readline's own
+    // multiline cursor math advances past every wrapped row (otherwise the box
+    // bottom border overwrites a row). readline mangles the emitted 'line'
+    // string when it holds a newline, so we hand the true buffer to onSubmit
+    // and the caller reads that instead of the line event.
+    if (isSubmitKey(str, key) && typeof rl.line === 'string' && rl.line.includes('\n')) {
+      if (typeof onSubmit === 'function') onSubmit(rl.line);
+    }
+
+    ttyWrite(str, key);
+  };
+
+  return () => {
+    rl._ttyWrite = ttyWrite;
+    escBuffer = null;
+  };
+}
+
+module.exports = {
+  MULTILINE_CSI,
+  MULTILINE_PLACEHOLDER,
+  attachMultilineChatInput,
+  isMultilineCsiComplete,
+  isMultilineCsiKey,
+  isMultilineInsertKey,
+  isMultilineCsiPrefix,
+  isSubmitKey,
+  stripMultilineCsiText,
+  keyBytes,
+};

--- a/lib/ax-goal.js
+++ b/lib/ax-goal.js
@@ -1,0 +1,307 @@
+const GOAL_CLEAR_ALIASES = new Set(['clear', 'stop', 'off', 'reset', 'none', 'cancel']);
+const GOAL_ACHIEVED_RE = /^\s*GOAL_ACHIEVED:\s*(.+)$/im;
+const GOAL_JSON_RE = /\{[\s\S]*"achieved"\s*:\s*(true|false)[\s\S]*\}/i;
+
+function parseTokenBudget(raw) {
+  const text = String(raw || '').trim().toUpperCase();
+  const match = text.match(/^(\d+(?:\.\d+)?)([KMB])?$/);
+  if (!match) return null;
+  let value = Number(match[1]);
+  if (match[2] === 'K') value *= 1000;
+  if (match[2] === 'M') value *= 1000000;
+  if (match[2] === 'B') value *= 1000000000;
+  return Math.round(value);
+}
+
+function parseGoalCommand(line) {
+  const raw = String(line || '').trim();
+  const lower = raw.toLowerCase();
+  if (!lower.startsWith('/goal')) return null;
+
+  const rest = raw.slice(5).trim();
+  if (!rest) return { action: 'status' };
+
+  const firstWord = rest.split(/\s+/)[0].toLowerCase();
+  if (GOAL_CLEAR_ALIASES.has(firstWord)) return { action: 'clear' };
+
+  let condition = rest;
+  let tokenBudget = null;
+  const tokensMatch = condition.match(/^--tokens\s+(\S+)\s+([\s\S]+)$/i);
+  if (tokensMatch) {
+    tokenBudget = parseTokenBudget(tokensMatch[1]);
+    condition = tokensMatch[2].trim();
+  }
+
+  const maxTurnsMatch = condition.match(/\b(?:max|stop after|within)\s+(\d+)\s+turns?\b/i);
+  const maxTurns = maxTurnsMatch ? Number(maxTurnsMatch[1]) : null;
+
+  if (!condition) return { action: 'status' };
+  return { action: 'set', condition, maxTurns, tokenBudget };
+}
+
+function createGoalState(condition, options = {}) {
+  return {
+    active: true,
+    condition: String(condition || '').trim(),
+    maxTurns: Number.isFinite(options.maxTurns) ? options.maxTurns : null,
+    tokenBudget: Number.isFinite(options.tokenBudget) ? options.tokenBudget : null,
+    turns: 0,
+    evalTurns: 0,
+    tokensUsed: 0,
+    creditsUsed: 0,
+    startedAt: Date.now(),
+    lastReason: 'Goal started — working toward the condition.',
+    achieved: false,
+    achievedAt: null,
+  };
+}
+
+function goalElapsedMs(goal) {
+  const end = goal.achievedAt || Date.now();
+  return Math.max(0, end - (goal.startedAt || end));
+}
+
+function truncateGoalText(text, limit = 72) {
+  const value = String(text || '').trim();
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit - 1)}…`;
+}
+
+function compactGoalHistory(history = [], limit = 8) {
+  return history
+    .slice(-limit)
+    .map(turn => `${turn.role}: ${String(turn.content || '').slice(0, 900)}`)
+    .join('\n');
+}
+
+function buildGoalDirective(goal, options = {}) {
+  const condition = goal.condition;
+  const reason = goal.lastReason && goal.turns > 0
+    ? `\nEvaluator guidance from last turn: ${goal.lastReason}`
+    : '';
+  return [
+    'Work autonomously toward this completion condition:',
+    condition,
+    '',
+    'Use local tools as needed. Do not ask the user for permission between steps.',
+    'Do not declare the goal achieved yourself — a separate evaluator decides that.',
+    reason,
+    options.continue ? '\nContinue from the recent conversation below.' : '',
+  ].filter(Boolean).join('\n');
+}
+
+function buildGoalEvalPrompt(goal, history, lastOutput) {
+  return [
+    'You are a strict goal evaluator for a coding agent session.',
+    'Reply with JSON only: {"achieved": true|false, "reason": "short reason"}',
+    'Judge only from observable evidence in the transcript and latest output.',
+    'If the condition requires command output or file contents, require proof in the transcript.',
+    '',
+    `Goal condition: ${goal.condition}`,
+    '',
+    'Recent conversation:',
+    compactGoalHistory(history),
+    '',
+    'Latest assistant output:',
+    String(lastOutput || '').slice(0, 4000),
+  ].join('\n');
+}
+
+function parseGoalEvalResponse(text) {
+  const raw = String(text || '').trim();
+  if (!raw) return null;
+
+  const marker = raw.match(GOAL_ACHIEVED_RE);
+  if (marker) {
+    return { achieved: true, reason: marker[1].trim() };
+  }
+
+  const jsonMatch = raw.match(GOAL_JSON_RE);
+  if (!jsonMatch) return null;
+  try {
+    const parsed = JSON.parse(jsonMatch[0]);
+    return {
+      achieved: parsed.achieved === true,
+      reason: String(parsed.reason || '').trim() || (parsed.achieved ? 'Condition met.' : 'Condition not met yet.'),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseGoalAchievedMarker(text) {
+  const marker = String(text || '').match(GOAL_ACHIEVED_RE);
+  if (!marker) return null;
+  return { achieved: true, reason: marker[1].trim() };
+}
+
+function accumulateGoalUsage(goal, result, creditsFromState) {
+  if (!goal || !result) return;
+  const credits = typeof creditsFromState === 'function' ? creditsFromState(result) : null;
+  if (Number.isFinite(credits) && credits > 0) {
+    goal.creditsUsed += credits;
+  }
+  const approxTokens = Math.max(0, Math.round(String(result.output || '').length / 4));
+  goal.tokensUsed += approxTokens;
+}
+
+function goalBudgetExceeded(goal) {
+  if (!goal || !Number.isFinite(goal.tokenBudget)) return false;
+  return goal.tokensUsed >= goal.tokenBudget;
+}
+
+function goalTurnLimitReached(goal) {
+  if (!goal || !Number.isFinite(goal.maxTurns)) return false;
+  return goal.turns >= goal.maxTurns;
+}
+
+function clearGoalState(goal) {
+  if (!goal) return null;
+  goal.active = false;
+  return goal;
+}
+
+function finishGoalAchieved(goal, reason) {
+  goal.active = false;
+  goal.achieved = true;
+  goal.achievedAt = Date.now();
+  goal.lastReason = reason || 'Condition met.';
+  return goal;
+}
+
+function formatGoalCounter(goal) {
+  const turns = `${goal.turns}${Number.isFinite(goal.maxTurns) ? `/${goal.maxTurns}` : ''}`;
+  const duration = `${Math.max(1, Math.round(goalElapsedMs(goal) / 1000))}s`;
+  const usage = [];
+  if (goal.creditsUsed > 0) usage.push(`${goal.creditsUsed} credits`);
+  if (goal.tokensUsed > 0) usage.push(`~${goal.tokensUsed} tokens`);
+  return { turns, duration, usage: usage.join(' · ') };
+}
+
+function formatGoalStatus(goal, options = {}) {
+  const paint = options.paint || ((text) => String(text));
+  if (!goal) {
+    return 'No active goal. Set one with /goal <condition>.';
+  }
+
+  const counter = formatGoalCounter(goal);
+  const lines = [];
+
+  if (goal.active) {
+    lines.push(paint('◎ /goal active', [options.bold, options.magenta]));
+    lines.push(paint(goal.condition, [options.bold]));
+    lines.push(paint(`turn ${counter.turns} · ${counter.duration}${counter.usage ? ` · ${counter.usage}` : ''}`, [options.muted]));
+    if (goal.lastReason) lines.push(paint(`reason: ${goal.lastReason}`, [options.muted]));
+    if (Number.isFinite(goal.tokenBudget)) {
+      lines.push(paint(`budget: ~${goal.tokensUsed}/${goal.tokenBudget} tokens`, [options.muted]));
+    }
+    return lines.join('\n');
+  }
+
+  if (goal.achieved) {
+    lines.push(paint('✦ /goal achieved', [options.bold, options.ok || options.magenta]));
+    lines.push(paint(goal.condition, [options.bold]));
+    lines.push(paint(`${counter.turns} turns · ${counter.duration}${counter.usage ? ` · ${counter.usage}` : ''}`, [options.muted]));
+    if (goal.lastReason) lines.push(paint(`reason: ${goal.lastReason}`, [options.muted]));
+    return lines.join('\n');
+  }
+
+  lines.push(paint('Goal stopped.', [options.muted]));
+  lines.push(paint(goal.condition, [options.bold]));
+  lines.push(paint(`turn ${counter.turns} · ${counter.duration}`, [options.muted]));
+  if (goal.lastReason) lines.push(paint(`reason: ${goal.lastReason}`, [options.muted]));
+  return lines.join('\n');
+}
+
+function formatGoalActiveBanner(goal, options = {}) {
+  if (!goal || !goal.active) return '';
+  const paint = options.paint || ((text) => String(text));
+  const counter = formatGoalCounter(goal);
+  return paint(
+    `◎ /goal active · ${truncateGoalText(goal.condition, 56)} · turn ${counter.turns}${Number.isFinite(goal.maxTurns) ? `/${goal.maxTurns}` : ''} · ${counter.duration}`,
+    [options.bold, options.magenta]
+  );
+}
+
+function formatGoalAchieved(goal, options = {}) {
+  const paint = options.paint || ((text) => String(text));
+  const counter = formatGoalCounter(goal);
+  return [
+    paint('✦ Goal achieved', [options.bold, options.magenta]),
+    paint(goal.condition, [options.bold, options.accent]),
+    paint(`${counter.turns} turns · ${counter.duration}${counter.usage ? ` · ${counter.usage}` : ''}`, [options.muted]),
+    goal.lastReason ? paint(`reason: ${goal.lastReason}`, [options.muted]) : '',
+  ].filter(Boolean).join('\n');
+}
+
+function formatGoalContinue(goal, options = {}) {
+  const paint = options.paint || ((text) => String(text));
+  return paint(`◎ continuing goal · turn ${goal.turns + 1}${Number.isFinite(goal.maxTurns) ? `/${goal.maxTurns}` : ''} · ${goal.lastReason}`, [options.magenta]);
+}
+
+function formatGoalStopped(goal, reason, options = {}) {
+  const paint = options.paint || ((text) => String(text));
+  const counter = formatGoalCounter(goal);
+  return [
+    paint('◎ Goal stopped', [options.bold, options.muted]),
+    paint(reason, [options.muted]),
+    paint(`${counter.turns} turns · ${counter.duration}`, [options.muted]),
+  ].join('\n');
+}
+
+async function evaluateGoalTurn(goal, ctx = {}, deps = {}) {
+  const marker = parseGoalAchievedMarker(ctx.lastOutput);
+  if (marker) return marker;
+
+  if (typeof deps.evaluateGoal === 'function') {
+    return deps.evaluateGoal(goal, ctx);
+  }
+
+  if (typeof deps.postTurn !== 'function') {
+    return { achieved: false, reason: goal.lastReason || 'Condition not met yet.' };
+  }
+
+  const evalOutput = { isTTY: false, write() {} };
+  try {
+    const result = await deps.postTurn(buildGoalEvalPrompt(goal, ctx.history || [], ctx.lastOutput), {
+      ...(ctx.turnOptions || {}),
+      mode: 'fast',
+      history: [],
+      output: evalOutput,
+      showProgress: false,
+      goalEval: true,
+    });
+    const parsed = parseGoalEvalResponse(result.output);
+    if (parsed) return parsed;
+  } catch (error) {
+    return { achieved: false, reason: `Evaluator unavailable: ${error.message}` };
+  }
+
+  return { achieved: false, reason: goal.lastReason || 'Condition not met yet.' };
+}
+
+module.exports = {
+  GOAL_CLEAR_ALIASES,
+  accumulateGoalUsage,
+  buildGoalDirective,
+  buildGoalEvalPrompt,
+  clearGoalState,
+  compactGoalHistory,
+  createGoalState,
+  evaluateGoalTurn,
+  finishGoalAchieved,
+  formatGoalAchieved,
+  formatGoalActiveBanner,
+  formatGoalContinue,
+  formatGoalCounter,
+  formatGoalStatus,
+  formatGoalStopped,
+  goalBudgetExceeded,
+  goalElapsedMs,
+  goalTurnLimitReached,
+  parseGoalAchievedMarker,
+  parseGoalCommand,
+  parseGoalEvalResponse,
+  parseTokenBudget,
+  truncateGoalText,
+};

--- a/lib/ax-prefs.js
+++ b/lib/ax-prefs.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const MEMBER_SLUG = 'ax';
+const PREFS_PATH = path.join(os.homedir(), '.atris', 'ax.json');
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+function truthy(value) {
+  return TRUTHY.has(String(value || '').trim().toLowerCase());
+}
+
+function loadAxPrefs() {
+  try {
+    if (!fs.existsSync(PREFS_PATH)) {
+      return { member_slug: MEMBER_SLUG, bypass_permissions: false };
+    }
+    const parsed = JSON.parse(fs.readFileSync(PREFS_PATH, 'utf8'));
+    return {
+      member_slug: MEMBER_SLUG,
+      bypass_permissions: parsed.bypass_permissions === true,
+    };
+  } catch {
+    return { member_slug: MEMBER_SLUG, bypass_permissions: false };
+  }
+}
+
+function saveAxPrefs(prefs) {
+  fs.mkdirSync(path.dirname(PREFS_PATH), { recursive: true });
+  fs.writeFileSync(PREFS_PATH, `${JSON.stringify({
+    member_slug: MEMBER_SLUG,
+    bypass_permissions: prefs.bypass_permissions === true,
+    updated_at: new Date().toISOString(),
+  }, null, 2)}\n`);
+  return loadAxPrefs();
+}
+
+function setBypassPermissions(enabled, { persist = true } = {}) {
+  const next = { member_slug: MEMBER_SLUG, bypass_permissions: enabled === true };
+  return persist ? saveAxPrefs(next) : next;
+}
+
+function resolveBypassPermissions(options = {}) {
+  if (options.bypassPermissions === true) return true;
+  if (options.bypassPermissions === false) return false;
+  if (truthy(process.env.AX_BYPASS_PERMISSIONS)) return true;
+  if (truthy(process.env.AX_SAFE_PERMISSIONS)) return false;
+  return loadAxPrefs().bypass_permissions === true;
+}
+
+function permissionsLabel(options = {}) {
+  return resolveBypassPermissions(options) ? 'bypass' : 'safe';
+}
+
+module.exports = {
+  MEMBER_SLUG,
+  PREFS_PATH,
+  loadAxPrefs,
+  saveAxPrefs,
+  setBypassPermissions,
+  resolveBypassPermissions,
+  permissionsLabel,
+};

--- a/lib/ax-shimmer.js
+++ b/lib/ax-shimmer.js
@@ -1,0 +1,63 @@
+const ANSI = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  muted: '\x1b[90m',
+  white: '\x1b[37m',
+  bright: '\x1b[97m',
+};
+
+function useColor(options = {}) {
+  if (options.color === false) return false;
+  if (process.env.NO_COLOR) return false;
+  return Boolean(options.color || options.isTTY);
+}
+
+function paint(text, codes, options = {}) {
+  if (!useColor(options)) return String(text);
+  const styles = codes.filter(Boolean);
+  if (!styles.length) return String(text);
+  return `${styles.join('')}${text}${ANSI.reset}`;
+}
+
+const SHIMMER_TICK_STEP = 0.44;
+
+function shimmerStyleForDistance(dist) {
+  // Obelisk .shimmer-text: pure grayscale luminance sweep — no bold, no hue.
+  const t = Math.min(Math.max(dist, 0) / 3.4, 1);
+  if (t <= 0.2) return [ANSI.bright];
+  if (t <= 0.48) return [ANSI.white];
+  if (t <= 0.72) return [ANSI.muted];
+  return [ANSI.dim, ANSI.muted];
+}
+
+function renderShimmerText(text, tick = 0, options = {}) {
+  const value = String(text || '');
+  if (!value) return '';
+  if (!useColor(options)) return value;
+
+  const len = Math.max(1, value.length);
+  const cycle = len + 12;
+  const head = (Number(tick) * SHIMMER_TICK_STEP) % cycle;
+
+  let out = '';
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (char === ' ') {
+      out += ' ';
+      continue;
+    }
+    let dist = Math.abs(i - head);
+    if (dist > cycle / 2) dist = cycle - dist;
+    out += paint(char, shimmerStyleForDistance(dist), options);
+  }
+  return out;
+}
+
+module.exports = {
+  ANSI,
+  SHIMMER_TICK_STEP,
+  paint,
+  renderShimmerText,
+  shimmerStyleForDistance,
+  useColor,
+};

--- a/test/ax-chat-input.test.js
+++ b/test/ax-chat-input.test.js
@@ -1,0 +1,157 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const readline = require('node:readline');
+const { PassThrough } = require('node:stream');
+const {
+  attachMultilineChatInput,
+  isMultilineCsiComplete,
+  isMultilineCsiKey,
+  isMultilineInsertKey,
+  isMultilineCsiPrefix,
+  isSubmitKey,
+  stripMultilineCsiText,
+} = require('../lib/ax-chat-input');
+
+// Drive a real readline interface (the unit mock below cannot catch the
+// keypress decoder shredding \x1b[27;2;13~ or readline mangling an embedded
+// newline on submit — both real regressions this guards). readline cannot emit
+// a 'line' string holding a literal newline, so the multiline value is read
+// from onSubmit exactly as ax does, with the single-line case falling back to
+// the line event.
+function runRealChat(chunks) {
+  return new Promise((resolve, reject) => {
+    const input = new PassThrough();
+    input.isTTY = true;
+    input.setRawMode = () => {};
+    const output = new PassThrough();
+    output.isTTY = true;
+    const rl = readline.createInterface({ input, output, terminal: true });
+    readline.emitKeypressEvents(input, rl);
+    let writes = 0;
+    const realWrite = rl.write.bind(rl);
+    rl.write = (...args) => {
+      if (++writes > 500) {
+        reject(new Error('runaway rl.write recursion'));
+        return undefined;
+      }
+      return realWrite(...args);
+    };
+    let captured = null;
+    attachMultilineChatInput(rl, { onSubmit: (line) => { captured = line; } });
+    const timer = setTimeout(() => reject(new Error('no line event')), 2000);
+    rl.on('line', (line) => {
+      clearTimeout(timer);
+      rl.close();
+      resolve(stripMultilineCsiText(captured != null ? captured : line));
+    });
+    for (const chunk of chunks) input.write(chunk);
+  });
+}
+
+function createMockRl() {
+  const breaks = [];
+  const rl = {
+    line: '',
+    cursor: 0,
+    write(value) {
+      const text = String(value);
+      if (text === '\n') {
+        breaks.push('\n');
+        this.line += '\n';
+      } else {
+        this.line += text;
+      }
+      this.cursor = this.line.length;
+    },
+    _ttyWrite(str) {
+      this.line += String(str);
+      this.cursor = this.line.length;
+    },
+  };
+  attachMultilineChatInput(rl, {
+    insertBreak: (target) => target.write('\n'),
+  });
+  return { rl, breaks };
+}
+
+test('ttyWrite wrapper swallows split cursor shift+enter CSI', () => {
+  const { rl, breaks } = createMockRl();
+  rl._ttyWrite('\x1b', { name: 'escape', sequence: '\x1b' });
+  for (const ch of '[27;2;13~') rl._ttyWrite(ch, { sequence: ch });
+  assert.equal(breaks.length, 1);
+  assert.equal(rl.line, '\n');
+});
+
+test('ttyWrite wrapper swallows full shift+enter CSI key', () => {
+  const { rl, breaks } = createMockRl();
+  rl._ttyWrite('', { sequence: '\x1b[27;2;13~' });
+  assert.equal(breaks.length, 1);
+  assert.equal(rl.line, '\n');
+});
+
+test('ttyWrite wrapper keeps normal typing', () => {
+  const { rl, breaks } = createMockRl();
+  rl._ttyWrite('h', { sequence: 'h' });
+  rl._ttyWrite('i', { sequence: 'i' });
+  assert.equal(breaks.length, 0);
+  assert.equal(rl.line, 'hi');
+});
+
+test('chat input helpers recognize multiline CSI', () => {
+  assert.equal(isMultilineCsiPrefix('\x1b['), true);
+  assert.equal(isMultilineCsiComplete('\x1b[27;2;13~'), true);
+  assert.equal(isMultilineCsiKey({ sequence: '\x1b[27;2;13~' }), true);
+  assert.equal(isMultilineInsertKey('', { shift: true, name: 'return' }), true);
+});
+
+test('stripMultilineCsiText converts leaked visible CSI to newlines', () => {
+  assert.equal(stripMultilineCsiText('hi[27;2;13~ there'), 'hi\n there');
+  assert.equal(stripMultilineCsiText('hi\x1b[27;2;13~ there'), 'hi\n there');
+});
+
+test('stripMultilineCsiText restores the submit-time newline sentinel', () => {
+  assert.equal(stripMultilineCsiText('foo\x1fbar'), 'foo\nbar');
+});
+
+test('isSubmitKey only matches a plain Enter', () => {
+  assert.equal(isSubmitKey('\r', { name: 'return' }), true);
+  assert.equal(isSubmitKey('\r', null), true);
+  assert.equal(isSubmitKey('', { name: 'return', shift: true }), false);
+  assert.equal(isSubmitKey('', { name: 'return', meta: true }), false);
+  assert.equal(isSubmitKey('a', { name: 'a' }), false);
+});
+
+test('real readline turns xterm shift+enter (\\x1b[27;2;13~) into a newline', async () => {
+  // This is the exact sequence the keypress decoder shreds into \x1b[27;2;
+  // plus literal "1", "3", "~"; the mock cannot reproduce it.
+  assert.equal(await runRealChat(['foo', '\x1b[27;2;13~', 'bar', '\r']), 'foo\nbar');
+});
+
+test('real readline handles byte-split shift+enter and multiple breaks', async () => {
+  assert.equal(await runRealChat(['foo', ...'\x1b[27;2;13~', 'bar', '\r']), 'foo\nbar');
+  assert.equal(
+    await runRealChat(['a', '\x1b[27;2;13~', 'b', '\x1b[27;2;13~', 'c', '\r']),
+    'a\nb\nc',
+  );
+});
+
+test('real readline covers csi/kitty shift+enter variants and plain submit', async () => {
+  assert.equal(await runRealChat(['foo', '\x1b[13;2~', 'bar', '\r']), 'foo\nbar');
+  assert.equal(await runRealChat(['foo', '\x1b[23~', 'bar', '\r']), 'foo\nbar');
+  assert.equal(await runRealChat(['foo', '\x1b[13;2u', 'bar', '\r']), 'foo\nbar');
+  assert.equal(await runRealChat(['hello', '\r']), 'hello');
+});
+
+test('real readline keeps a bracketed paste as one multi-line message', async () => {
+  // Terminals wrap pastes in \x1b[200~ … \x1b[201~; the whole block must become
+  // a single message instead of submitting on each embedded newline.
+  assert.equal(
+    await runRealChat(['\x1b[200~line one\nline two\nline three\x1b[201~', '\r']),
+    'line one\nline two\nline three',
+  );
+  // text typed before + paste appended, then sent
+  assert.equal(
+    await runRealChat(['note: ', '\x1b[200~pasted\nlines\x1b[201~', '\r']),
+    'note: pasted\nlines',
+  );
+});

--- a/test/ax-goal.test.js
+++ b/test/ax-goal.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const goal = require('../lib/ax-goal');
+
+test('parseGoalCommand handles set, status, clear, and token budget', () => {
+  assert.deepEqual(goal.parseGoalCommand('/goal'), { action: 'status' });
+  assert.deepEqual(goal.parseGoalCommand('/goal clear'), { action: 'clear' });
+  assert.deepEqual(goal.parseGoalCommand('/goal stop'), { action: 'clear' });
+  assert.deepEqual(goal.parseGoalCommand('/goal npm test exits 0, max 5 turns'), {
+    action: 'set',
+    condition: 'npm test exits 0, max 5 turns',
+    maxTurns: 5,
+    tokenBudget: null,
+  });
+  assert.deepEqual(goal.parseGoalCommand('/goal --tokens 250K fix the failing suite'), {
+    action: 'set',
+    condition: 'fix the failing suite',
+    maxTurns: null,
+    tokenBudget: 250000,
+  });
+});
+
+test('goal evaluator parses json and achieved markers', () => {
+  assert.deepEqual(
+    goal.parseGoalEvalResponse('{"achieved": true, "reason": "tests passed"}'),
+    { achieved: true, reason: 'tests passed' }
+  );
+  assert.deepEqual(
+    goal.parseGoalAchievedMarker('done\nGOAL_ACHIEVED: npm test passed'),
+    { achieved: true, reason: 'npm test passed' }
+  );
+});
+
+test('goal counter and achieved formatting', () => {
+  const active = goal.createGoalState('npm test exits 0', { maxTurns: 3 });
+  active.turns = 2;
+  active.startedAt = Date.now() - 5000;
+  active.lastReason = 'tests still failing';
+
+  assert.match(goal.formatGoalStatus(active, { paint: (t) => t, bold: '', magenta: '', muted: '' }), /◎ \/goal active/);
+  assert.match(goal.formatGoalStatus(active, { paint: (t) => t, bold: '', magenta: '', muted: '' }), /turn 2\/3/);
+  assert.match(goal.formatGoalActiveBanner(active, { paint: (t) => t, bold: '', magenta: '' }), /npm test exits 0/);
+
+  goal.finishGoalAchieved(active, 'npm test passed');
+  assert.match(goal.formatGoalAchieved(active, { paint: (t) => t, bold: '', magenta: '', muted: '', accent: '' }), /Goal achieved/);
+  assert.match(goal.formatGoalAchieved(active, { paint: (t) => t, bold: '', magenta: '', muted: '', accent: '' }), /2\/3 turns/);
+});
+
+test('evaluateGoalTurn uses injected evaluator and marker fallback', async () => {
+  const state = goal.createGoalState('ship fix');
+  const injected = await goal.evaluateGoalTurn(state, {
+    history: [{ role: 'assistant', content: 'fixed it' }],
+    lastOutput: 'all good',
+  }, {
+    evaluateGoal: async () => ({ achieved: true, reason: 'verified in tests' }),
+  });
+  assert.equal(injected.achieved, true);
+
+  const marker = await goal.evaluateGoalTurn(state, {
+    history: [],
+    lastOutput: 'GOAL_ACHIEVED: suite green',
+  }, {});
+  assert.equal(marker.achieved, true);
+});

--- a/test/ax-prefs.test.js
+++ b/test/ax-prefs.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const prefs = require('../lib/ax-prefs');
+
+test('ax prefs default to safe mode with member slug ax', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-prefs-'));
+  const oldHome = process.env.HOME;
+  process.env.HOME = root;
+  try {
+    const loaded = prefs.loadAxPrefs();
+    assert.equal(loaded.member_slug, 'ax');
+    assert.equal(loaded.bypass_permissions, false);
+    assert.equal(prefs.resolveBypassPermissions({}), false);
+  } finally {
+    process.env.HOME = oldHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('ax prefs persist bypass toggle', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-prefs-save-'));
+  const oldHome = process.env.HOME;
+  process.env.HOME = root;
+  try {
+    prefs.setBypassPermissions(true);
+    assert.equal(prefs.loadAxPrefs().bypass_permissions, true);
+    prefs.setBypassPermissions(false);
+    assert.equal(prefs.loadAxPrefs().bypass_permissions, false);
+  } finally {
+    process.env.HOME = oldHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('ax env and flag overrides beat saved prefs', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-prefs-env-'));
+  const oldHome = process.env.HOME;
+  const oldBypass = process.env.AX_BYPASS_PERMISSIONS;
+  process.env.HOME = root;
+  try {
+    prefs.setBypassPermissions(false);
+    process.env.AX_BYPASS_PERMISSIONS = '1';
+    assert.equal(prefs.resolveBypassPermissions({}), true);
+    assert.equal(prefs.resolveBypassPermissions({ bypassPermissions: false }), false);
+  } finally {
+    process.env.HOME = oldHome;
+    if (oldBypass === undefined) delete process.env.AX_BYPASS_PERMISSIONS;
+    else process.env.AX_BYPASS_PERMISSIONS = oldBypass;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/ax-shimmer.test.js
+++ b/test/ax-shimmer.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { renderShimmerText, shimmerStyleForDistance, ANSI } = require('../lib/ax-shimmer');
+
+test('renderShimmerText animates pure grayscale luminance across ticks', () => {
+  const colored = { color: true, isTTY: true };
+  const previousNoColor = process.env.NO_COLOR;
+  delete process.env.NO_COLOR;
+  try {
+    const a = renderShimmerText('Working', 2, colored);
+    const b = renderShimmerText('Working', 8, colored);
+    assert.match(a, /W.*o.*r.*k.*i.*n.*g/);
+    assert.notEqual(a, b);
+    assert.match(a, /\x1b\[97m/);
+    assert.doesNotMatch(a, /\x1b\[1m/);
+    assert.doesNotMatch(a, /\x1b\[3[56]m/);
+  } finally {
+    if (previousNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = previousNoColor;
+  }
+});
+
+test('shimmerStyleForDistance is grayscale only with a bright peak and dim trough', () => {
+  assert.deepEqual(shimmerStyleForDistance(0), [ANSI.bright]);
+  assert.deepEqual(shimmerStyleForDistance(3), [ANSI.dim, ANSI.muted]);
+  assert.ok(!shimmerStyleForDistance(1).includes('\x1b[1m'));
+});
+
+test('renderShimmerText is plain without color', () => {
+  assert.equal(renderShimmerText('Reading', 4, { color: false }), 'Reading');
+});

--- a/test/ax.test.js
+++ b/test/ax.test.js
@@ -3,8 +3,267 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { Readable } = require('node:stream');
 
 const ax = require('../ax');
+const repoRoot = path.resolve(__dirname, '..');
+
+test('ax fast chat starts without business initialization crash', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-chat-start-'));
+  try {
+    const res = spawnSync(process.execPath, [path.join(repoRoot, 'ax'), '--fast', '--chat'], {
+      cwd: dir,
+      input: '/exit\n',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ATRIS_SKIP_UPDATE_CHECK: '1',
+      },
+    });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /Atris 2 Fast chat/);
+    assert.doesNotMatch(res.stderr, /Cannot access 'business' before initialization/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ax chat subcommand alias starts chat instead of sending a local prompt', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-chat-alias-'));
+  try {
+    assert.deepEqual(ax.normalizeChatCommandArgs(['chat', 'ax', '--fast']), {
+      args: ['--chat', '--fast'],
+      chatRequested: true,
+    });
+
+    const res = spawnSync(process.execPath, [path.join(repoRoot, 'ax'), 'chat', 'ax', '--fast'], {
+      cwd: dir,
+      input: '/exit\n',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ATRIS_SKIP_UPDATE_CHECK: '1',
+        AX_BACKEND_URL: 'http://127.0.0.1:1',
+      },
+    });
+
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /Atris 2 Fast chat/);
+    assert.doesNotMatch(res.stderr, /ECONNREFUSED|Request timeout|chat ax/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ax spawn aliases create and inspect durable worker requests without backend chat', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-spawn-'));
+  try {
+    assert.equal(ax.isAxSpawnCommand('spawn'), true);
+
+    const created = spawnSync(process.execPath, [
+      path.join(repoRoot, 'ax'),
+      'spawn',
+      'worker',
+      '--task',
+      'Fix one bounded bug',
+      '--engine',
+      'codex',
+      '--json',
+    ], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ATRIS_SKIP_UPDATE_CHECK: '1',
+      },
+    });
+    assert.equal(created.status, 0, created.stderr || created.stdout);
+    const payload = JSON.parse(created.stdout);
+    assert.equal(payload.action, 'spawn_created');
+    assert.equal(payload.request.role, 'worker');
+    assert.equal(payload.request.task, 'Fix one bounded bug');
+    assert.match(payload.request.command, /^codex exec /);
+    assert.doesNotMatch(created.stdout, /Atris 2/);
+
+    const listed = spawnSync(process.execPath, [path.join(repoRoot, 'ax'), 'spawns', '--json'], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ATRIS_SKIP_UPDATE_CHECK: '1',
+      },
+    });
+    assert.equal(listed.status, 0, listed.stderr || listed.stdout);
+    assert.equal(JSON.parse(listed.stdout).requests.length, 1);
+
+    const shown = spawnSync(process.execPath, [path.join(repoRoot, 'ax'), 'spawn-status', payload.request.id, '--json'], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ATRIS_SKIP_UPDATE_CHECK: '1',
+      },
+    });
+    assert.equal(shown.status, 0, shown.stderr || shown.stdout);
+    assert.equal(JSON.parse(shown.stdout).request.id, payload.request.id);
+
+    const help = spawnSync(process.execPath, [path.join(repoRoot, 'ax'), 'spawn', '--help'], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ATRIS_SKIP_UPDATE_CHECK: '1',
+      },
+    });
+    assert.equal(help.status, 0, help.stderr || help.stdout);
+    assert.match(help.stdout, /Usage: ax spawn <role>/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ax detects YouTube URLs and builds local processor args', async () => {
+  const url = 'https://www.youtube.com/watch?v=gBukk9LIklc';
+  assert.equal(ax.extractYoutubeUrl(`watch ${url}.`), url);
+  assert.deepEqual(ax.buildAxYoutubeArgs(url), [url]);
+  assert.deepEqual(ax.buildAxYoutubeArgs(`extract takeaways ${url}`), [
+    url,
+    '--query',
+    'extract takeaways',
+  ]);
+
+  const calls = [];
+  await ax.runAxYoutubeCommand(['summarize this', url], {
+    youtubeCommand: async (argv) => {
+      calls.push(argv);
+      return 0;
+    },
+  });
+  assert.deepEqual(calls[0], [url, '--query', 'summarize this']);
+
+  const explicit = [];
+  await ax.runAxYoutubeCommand(['youtube', url, '--json'], {
+    youtubeCommand: async (argv) => {
+      explicit.push(argv);
+      return 0;
+    },
+  });
+  assert.deepEqual(explicit[0], [url, '--json']);
+
+  const helpOutput = [];
+  await ax.runAxYoutubeCommand(['youtube', '--help'], {
+    output: (line) => helpOutput.push(line),
+  });
+  assert.match(helpOutput.join('\n'), /Usage: ax youtube process/);
+});
+
+test('ax chat routes pasted YouTube URLs to local processor without backend chat', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-youtube-chat-'));
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+  const url = 'https://www.youtube.com/watch?v=gBukk9LIklc';
+  const calls = [];
+  const writes = [];
+  try {
+    await ax.chat({
+      mode: 'fast',
+      cwd: dir,
+      input: Readable.from([`${url}\n`]),
+      output: {
+        isTTY: false,
+        write(chunk) {
+          writes.push(String(chunk));
+          return true;
+        },
+      },
+      youtubeCommand: async (argv, deps) => {
+        calls.push(argv);
+        deps.output('processed via local youtube command');
+        return 0;
+      },
+    });
+
+    assert.deepEqual(calls, [[url]]);
+    const text = writes.join('');
+    assert.match(text, /processed via local youtube command/);
+    assert.doesNotMatch(text, /Blocked: direct network access/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ax dogfoods fast chat with a 25-loop checklist', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-dogfood-chat-'));
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+  try {
+    const report = await ax.runChatDogfood({ cwd: dir, loops: 25 });
+    assert.equal(report.schema, 'atris.ax_chat_dogfood.v1');
+    assert.equal(report.loops_run, 25);
+    assert.equal(report.failures.length, 0);
+    assert.equal(report.checklist.every(item => item.passed), true);
+    assert.ok(fs.existsSync(report.log_path));
+    assert.equal(report.turn_calls.some(call => call.message === 'hi' && call.route === 'cloud' && !call.workspace_path), true);
+    assert.equal(report.turn_calls.some(call => call.message === 'what files are here?' && call.route === 'local' && call.workspace_path === dir), true);
+    assert.equal(report.youtube_calls.length, 1);
+    assert.match(ax.formatChatDogfoodReport(report), /loops: 25\/25/);
+    assert.match(ax.formatChatDogfoodReport(report), /checklist: 12\/12 passed/);
+    assert.doesNotMatch(report.output, /atris:|composer-2-5|gpt-|kimi|fable|fireworks|openrouter/i);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ax dogfood status summarizes overnight mission proof', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-dogfood-status-'));
+  const missionId = 'mission-test-dogfood';
+  try {
+    fs.mkdirSync(path.join(dir, '.atris', 'state'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'atris', 'runs'), { recursive: true });
+    fs.appendFileSync(path.join(dir, '.atris', 'state', 'missions.jsonl'), `${JSON.stringify({
+      schema: 'atris.mission.v1',
+      id: missionId,
+      status: 'ready',
+      cadence: '13m',
+      verifier: 'node ax --dogfood-chat --loops 25',
+      last_tick_index: 2,
+      last_tick_at: '2026-06-23T08:00:00.000Z',
+      updated_at: '2026-06-23T08:00:00.000Z',
+    })}\n`);
+
+    const stdout = [
+      'Ax fast chat dogfood',
+      'loops: 25/25',
+      'checklist: 12/12 passed',
+      `log: ${path.join(dir, 'atris', 'runs', 'ax-play-test.log')}`,
+    ].join('\n');
+    for (const index of [1, 2]) {
+      fs.writeFileSync(path.join(dir, 'atris', 'runs', `mission-${missionId}-tick-${index}.json`), JSON.stringify({
+        tick: { tick_index: index, verifier_passed: true },
+        verifier_result: { passed: true, stdout },
+      }));
+    }
+    fs.writeFileSync(path.join(dir, 'atris', 'runs', 'ax-fast-chat-overnight-cron.log'), [
+      '=== ax fast chat dogfood tick 2026-06-23T08:00:00Z ===',
+      'ok',
+    ].join('\n'));
+
+    const status = ax.buildChatDogfoodStatus({
+      cwd: dir,
+      crontabText: '*/13 * * * * tick.sh # ATRIS_AX_FAST_CHAT_DOGFOOD',
+    });
+    assert.equal(status.mission_id, missionId);
+    assert.equal(status.clean_chat_loops, 50);
+    assert.equal(status.target_met, true);
+    assert.equal(status.overnight_proven, true);
+    assert.equal(status.clean_tick_count, 2);
+    assert.equal(status.cron_runs, 1);
+    assert.match(ax.formatChatDogfoodStatusReport(status), /loops: 50\/25 clean/);
+    assert.match(ax.formatChatDogfoodStatusReport(status), /result: overnight 25-loop proof is complete/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test('ax routes workspace questions to local Atris 2 tools', () => {
   assert.equal(ax.resolveRoute('what files are here?'), 'local');
@@ -19,6 +278,28 @@ test('ax routes workspace questions to local Atris 2 tools', () => {
   assert.equal(payload.model, 'atris:fast');
   assert.equal(payload.workspace_path, '/tmp/project');
   assert.equal(payload.max_turns, 8);
+  assert.equal(payload.member_slug, 'ax');
+  assert.equal(payload.bypass_permissions, false);
+});
+
+test('ax routes greetings and no-intent snippets to cloud chat', () => {
+  assert.equal(ax.resolveRoute('hi'), 'cloud');
+  assert.equal(ax.resolveRoute('ax'), 'cloud');
+  assert.equal(ax.resolveRoute('pop'), 'cloud');
+  assert.equal(ax.resolveRoute('hello why'), 'cloud');
+  assert.equal(ax.resolveRoute('hello please'), 'cloud');
+  assert.equal(ax.resolveRoute('oj'), 'cloud');
+  assert.equal(ax.resolveRoute('fix'), 'local');
+  assert.equal(ax.resolveRoute('what files are here?'), 'local');
+
+  const payload = ax.buildPayload('hi', {
+    mode: 'fast',
+    cwd: '/tmp/project',
+  });
+
+  assert.equal(payload.model, 'atris:fast');
+  assert.equal(payload.workspace_path, undefined);
+  assert.equal(payload.max_turns, 1);
 });
 
 test('ax exposes Atris 2 Max as the highest-reasoning tier', () => {
@@ -35,10 +316,21 @@ test('ax exposes Atris 2 Max as the highest-reasoning tier', () => {
   const cloudWrite = ax.buildPayload('send a slack message to the team', {
     mode: 'max',
     route: 'cloud',
+    bypassPermissions: true,
   });
   assert.equal(cloudWrite.max_turns, 4);
+  assert.equal(cloudWrite.allow_external_actions, true);
 
-  assert.match(ax.formatHeader({ mode: 'max', cwd: '/tmp/project', chat: true }), /Atris 2 Max chat/);
+  const cloudSafe = ax.buildPayload('send a slack message to the team', {
+    mode: 'max',
+    route: 'cloud',
+    bypassPermissions: false,
+  });
+  assert.equal(cloudSafe.allow_external_actions, undefined);
+
+  assert.match(ax.formatHeader({ mode: 'max', cwd: '/tmp/project', chat: true }), /Atris 2 Max chat {2}· {2}\/tmp\/project/);
+  // permission state lives on the status line below the box, not the header
+  assert.doesNotMatch(ax.formatHeader({ mode: 'max', cwd: '/tmp/project', chat: true }), /permissions safe/);
 
   const profile = ax.buildRunProfile({ mode: 'max', cwd: '/tmp/project' });
   assert.equal(profile.model, 'atris:max');
@@ -46,12 +338,20 @@ test('ax exposes Atris 2 Max as the highest-reasoning tier', () => {
   assert.match(profile.reasoning, /high reasoning/);
 });
 
+test('ax defaults to fast tier when no mode flag is set', () => {
+  const profile = ax.buildRunProfile({ cwd: '/tmp/project' });
+  assert.equal(profile.mode, 'fast');
+  assert.equal(profile.model, 'atris:fast');
+  assert.equal(profile.max_turns, 8);
+  assert.match(ax.formatHeader({ cwd: '/tmp/project', chat: true }), /Atris 2 Fast chat/);
+});
+
 test('ax never shows model ids to the user and swaps tiers in chat', () => {
   const modelPattern = /atris:|composer-2-5|gpt-|kimi|fable|fireworks|openrouter/i;
   for (const mode of ['fast', 'pro', 'max', 'code-fast']) {
     assert.doesNotMatch(ax.formatHeader({ mode, cwd: '/tmp/project', chat: true }), modelPattern);
   }
-  assert.match(ax.formatHeader({ mode: 'pro', cwd: '/tmp/project', chat: true }), /\/fast \/pro \/max swap tiers/);
+  assert.match(ax.formatHeader({ mode: 'pro', cwd: '/tmp/project', chat: true }), /shift\+enter newline/);
 
   const profileText = ax.formatRunProfile(ax.buildRunProfile({ mode: 'max', cwd: '/tmp/project' }), { color: false });
   assert.doesNotMatch(profileText, modelPattern);
@@ -65,11 +365,118 @@ test('ax never shows model ids to the user and swaps tiers in chat', () => {
   assert.equal(ax.chatTierCommand('/max'), 'max');
   assert.equal(ax.chatTierCommand(' /FAST '), 'fast');
   assert.equal(ax.chatTierCommand('/pro'), 'pro');
+  assert.equal(ax.chatPermissionCommand('/bypass'), true);
+  assert.equal(ax.chatPermissionCommand('/safe'), false);
   assert.equal(ax.chatTierCommand('build /max speed'), null);
   assert.equal(ax.chatTierCommand('max'), null);
 
   assert.equal(ax.formatPrompt('max'), 'max › ');
   assert.equal(ax.formatPrompt(), '› ');
+  assert.match(ax.formatChatInputPrompt('fast', { color: false }), /^ {2}→ fast › /);
+  // Top/bottom are plain rules; the mode + shift+enter affordance is a status
+  // line below the box, and "enter send" is never shown.
+  assert.match(ax.formatInputBoxTop({ color: false }), /^╭─+╮$/);
+  assert.match(ax.formatInputBoxStatus({ color: false, bypassPermissions: false }), /^ {2}approve · shift\+enter$/);
+  assert.match(ax.formatInputBoxStatus({ color: false, bypassPermissions: true }), /^ {2}full access · shift\+enter$/);
+  assert.doesNotMatch(ax.formatInputBoxStatus({ color: false }), /enter send/);
+  assert.match(ax.formatInputBoxBottom({ color: false }), /^╰─+╯$/);
+  assert.equal(ax.buildInputBoxTopPlain({ columns: 80 }).length, 79);
+  assert.equal(ax.buildInputBoxBottomPlain({ columns: 80 }).length, 79);
+  assert.match(ax.formatInputBoxInputRow('│ → fast › ', 'hello', { color: false, columns: 40 }), /│ → fast › hello\s+│$/);
+  assert.equal(ax.isPermissionToggleKey({ shift: true, name: 'tab' }), true);
+  assert.equal(ax.isPermissionToggleKey({ name: 'tab' }), false);
+  assert.equal(ax.isPermissionToggleKey({ sequence: '\x1b[Z' }), true);
+  assert.equal(ax.isMultilineInsertKey('\n', { sequence: '\n' }), true);
+  assert.equal(ax.isMultilineInsertKey('', { shift: true, name: 'return' }), true);
+  assert.equal(ax.isMultilineInsertKey('', { name: 'return' }), false);
+  assert.match(ax.formatPermissionToggleMessage(false, { color: false }), /Approve mode.*ask before they run/);
+  assert.match(ax.formatPermissionToggleMessage(true, { color: false }), /Full access.*without approval/);
+  assert.deepEqual(ax.permissionAccentCodes({ bypassPermissions: false, color: false }), ['\x1b[2m', '\x1b[34m']);
+  assert.deepEqual(ax.permissionAccentCodes({ bypassPermissions: true, color: false }), ['\x1b[2m', '\x1b[33m']);
+});
+
+test('ax input box survives three ask cycles without stacked borders', () => {
+  const writes = [];
+  const out = { isTTY: true, columns: 80, write: (chunk) => writes.push(String(chunk)) };
+  const layout = (bypass) => ({ color: false, columns: 79, bypassPermissions: bypass });
+
+  for (let round = 0; round < 3; round += 1) {
+    out.write(`\n${ax.formatInputBoxTop(layout(round % 2 === 0))}\n`);
+    out.write(`${ax.formatChatInputPrompt('fast', layout(false))}hello\n`);
+    ax.closeInputBox(out, layout(false));
+  }
+
+  const joined = writes.join('');
+  assert.equal((joined.match(/╰─+╯/g) || []).length, 3);
+  assert.equal((joined.match(/╭/g) || []).length, 3);
+  assert.doesNotMatch(joined, /\x1b\[2A/);
+
+  const previousNoColor = process.env.NO_COLOR;
+  delete process.env.NO_COLOR;
+  try {
+    // mode color now lives on the status line below the box, not the plain top
+    assert.match(
+      ax.formatInputBoxStatus({ color: true, isTTY: true, bypassPermissions: false, columns: 80 }),
+      /\x1b\[34mapprove/,
+    );
+    assert.match(
+      ax.formatInputBoxStatus({ color: true, isTTY: true, bypassPermissions: true, columns: 80 }),
+      /\x1b\[33mfull access/,
+    );
+  } finally {
+    if (previousNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = previousNoColor;
+  }
+});
+
+test('ax repaintInputBoxBottom closes the box below single and multiline input', () => {
+  const readline = require('node:readline');
+  const { PassThrough } = require('node:stream');
+  const layout = { color: false, columns: 79, bypassPermissions: false };
+  const makeRl = (line, cursor) => {
+    const input = new PassThrough();
+    input.isTTY = true;
+    input.setRawMode = () => {};
+    const output = new PassThrough();
+    output.isTTY = true;
+    output.columns = 80;
+    const rl = readline.createInterface({ input, output, terminal: true, prompt: '│ → fast › ' });
+    rl.line = line;
+    rl.cursor = cursor;
+    return rl;
+  };
+  const capture = (line, cursor) => {
+    let writes = '';
+    ax.repaintInputBoxBottom(makeRl(line, cursor), { write: (c) => { writes += String(c); } }, layout);
+    return writes;
+  };
+
+  // cursor at end of a single-line input -> rule one row below, status under it,
+  // and the cursor returns up by rule-row + status-row (down + 1 = 2).
+  const single = capture('hi', 2);
+  assert.match(single, /╰─+╯/);
+  assert.match(single, /approve · shift\+enter/);
+  assert.doesNotMatch(single, /enter send/);
+  assert.match(single, /\x1b\[1B/);
+  assert.match(single, /\x1b\[2A/);
+
+  // cursor parked on the first row of a two-row input -> rule two rows below
+  const multi = capture('aaa\nbbb', 1);
+  assert.match(multi, /╰─+╯/);
+  assert.match(multi, /approve · shift\+enter/);
+  assert.match(multi, /\x1b\[2B/);
+  assert.match(multi, /\x1b\[3A/);
+
+  // missing readline cursor helpers must be a no-op, never throw
+  let safe = '';
+  ax.repaintInputBoxBottom({ line: 'x', _prompt: '> ' }, { write: (c) => { safe += String(c); } }, layout);
+  assert.equal(safe, '');
+
+  // input taller than the viewport must skip the rule (scroll would scramble it)
+  const tall = makeRl(Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n'), 0);
+  let tallOut = '';
+  ax.repaintInputBoxBottom(tall, { rows: 16, write: (c) => { tallOut += String(c); } }, layout);
+  assert.equal(tallOut, '');
 });
 
 test('ax chat renders claude-style blocks and a slash menu', () => {
@@ -101,14 +508,18 @@ test('ax chat renders claude-style blocks and a slash menu', () => {
   assert.equal(ax.summarizeToolResult({ content: 'first line\nsecond\nthird' }), 'first line  … +2 lines');
 
   const menu = ax.chatMenu({ color: false });
+  assert.match(menu, /\/goal/);
   assert.match(menu, /\/fast/);
   assert.match(menu, /\/pro/);
   assert.match(menu, /\/max/);
+  assert.match(menu, /\/bypass/);
+  assert.match(menu, /\/safe/);
+  assert.match(menu, /shift\+tab/);
   assert.match(menu, /\/help/);
   assert.doesNotMatch(menu, /atris:|gpt-|kimi|fable|composer/i);
 
   assert.deepEqual(ax.chatCompleter('/f'), [['/fast'], '/f']);
-  assert.deepEqual(ax.chatCompleter('/'), [['/fast', '/pro', '/max', '/help'], '/']);
+  assert.deepEqual(ax.chatCompleter('/'), [['/goal', '/fast', '/pro', '/max', '/bypass', '/safe', '/help'], '/']);
   assert.deepEqual(ax.chatCompleter('hello'), [[], 'hello']);
 });
 
@@ -126,13 +537,20 @@ test('ax shows credits, tier colors, spinner verbs, and clickable paths', () => 
   );
   assert.equal(ax.creditsFromState({ events: [] }), null);
 
-  assert.equal(ax.formatWorkingLine(2100), '• Working (2s • ctrl-c to interrupt)');
-  assert.equal(ax.formatWorkingLine(2100, 'Reading', '⠙'), '⠙ Reading… (2s · ctrl-c to interrupt)');
+  assert.equal(ax.formatWorkingLine(2100), '• Thinking… (2s · ctrl-c to interrupt)');
+  assert.equal(ax.formatWorkingLine(2100, 'Reading', '⠙'), '• Reading… (2s · ctrl-c to interrupt)');
 
   const colored = { color: true, isTTY: true };
   const previousNoColor = process.env.NO_COLOR;
   delete process.env.NO_COLOR;
   try {
+    assert.match(ax.formatWorkingLine(2100, 'Reading', { ...colored, frameChar: '⠙', tick: 3 }), /\x1b\[97m/);
+    assert.match(ax.formatWorkingLine(2100, 'Reading', { ...colored, frameChar: '⠙', tick: 3 }), /R.*e.*a.*d.*i.*n.*g/);
+    assert.doesNotMatch(ax.formatWorkingLine(2100, 'Reading', { ...colored, tick: 3 }), /\x1b\[1m/);
+    assert.notEqual(
+      ax.formatWorkingLine(2100, 'Reading', { ...colored, frameChar: '⠙', tick: 3 }),
+      ax.formatWorkingLine(2100, 'Reading', { ...colored, frameChar: '⠙', tick: 7 })
+    );
     assert.match(ax.formatPrompt('max', colored), /\x1b\[35m/);
     assert.match(ax.formatPrompt('fast', colored), /\x1b\[32m/);
     assert.match(ax.formatPrompt('pro', colored), /\x1b\[36m/);
@@ -166,6 +584,15 @@ test('ax routes connector reads to authenticated cloud context', () => {
   assert.equal(payload.workspace_path, undefined);
   assert.equal(payload.max_turns, 1);
   assert.equal(payload.connection_context.schema, 'atris.connection_capabilities.v1');
+});
+
+test('ax continuation wrapper marks current user message for backend connector routing', () => {
+  const wrapped = ax.buildMessage('check my slack messages', [
+    { role: 'user', content: 'what is on my calendar today' },
+    { role: 'assistant', content: 'Calendar today: standup' },
+  ]);
+  assert.match(wrapped, /# Current user message\ncheck my slack messages$/);
+  assert.doesNotMatch(wrapped, /Current user message: check my slack messages/);
 });
 
 test('ax routes GitHub repo mutations to local workspace tools', () => {
@@ -268,13 +695,17 @@ test('ax sends a no-op verify_command unless --verify opts in', () => {
   assert.equal(businessPayload.workspace_path, '/workspace/acme');
 
   assert.match(ax.formatUsage(), /--verify <cmd>/);
+  assert.match(ax.formatUsage(), /ax spawn <role> --task/);
+  assert.match(ax.formatUsage(), /atris agent spawn <role> --task/);
 });
 
 test('ax exposes Atris Code Fast as an explicit public lane', () => {
   const previousBackend = process.env.AX_CODE_FAST_BACKEND_URL;
   const previousApiBase = process.env.AX_CODE_FAST_API_BASE;
+  const previousAtrisApiBase = process.env.ATRIS_API_BASE;
   delete process.env.AX_CODE_FAST_BACKEND_URL;
   delete process.env.AX_CODE_FAST_API_BASE;
+  delete process.env.ATRIS_API_BASE;
 
   try {
     assert.equal(ax.modelForMode('code-fast'), 'composer-2-5-fast');
@@ -287,6 +718,12 @@ test('ax exposes Atris Code Fast as an explicit public lane', () => {
 
     process.env.AX_CODE_FAST_BACKEND_URL = 'http://127.0.0.1:8000';
     assert.equal(ax.codeFastUrl(), 'http://127.0.0.1:8000/api/cursor/turn');
+    assert.equal(ax.codeFastUrl({ route: 'local' }), 'http://127.0.0.1:8000/api/cursor/turn');
+    assert.equal(ax.codeFastUrl({ route: 'cloud' }), 'https://api.atris.ai/api/cursor/turn');
+    assert.equal(
+      ax.buildRunProfile({ mode: 'code-fast', route: 'cloud', cwd: '/tmp/project' }).endpoint,
+      'https://api.atris.ai/api/cursor/turn'
+    );
     assert.equal(
       ax.buildCodeFastPayload('say ok', { route: 'local', cwd: '/tmp/project' }).workspace_path,
       '/tmp/project'
@@ -304,18 +741,54 @@ test('ax exposes Atris Code Fast as an explicit public lane', () => {
     else process.env.AX_CODE_FAST_BACKEND_URL = previousBackend;
     if (previousApiBase === undefined) delete process.env.AX_CODE_FAST_API_BASE;
     else process.env.AX_CODE_FAST_API_BASE = previousApiBase;
+    if (previousAtrisApiBase === undefined) delete process.env.ATRIS_API_BASE;
+    else process.env.ATRIS_API_BASE = previousAtrisApiBase;
   }
 });
 
 test('ax backend URL is configurable', () => {
   const previous = process.env.AX_BACKEND_URL;
-  process.env.AX_BACKEND_URL = 'http://127.0.0.1:9001';
+  const previousCloud = process.env.OBELISK_ATRIS2_BACKEND_URL;
+  const previousApiBase = process.env.ATRIS_API_BASE;
+  delete process.env.AX_BACKEND_URL;
+  delete process.env.OBELISK_ATRIS2_BACKEND_URL;
+  delete process.env.ATRIS_API_BASE;
   try {
+    assert.equal(ax.backendUrl(), 'https://api.atris.ai/api/atris2/turn');
+
+    process.env.AX_BACKEND_URL = 'http://127.0.0.1:9001';
     assert.equal(ax.backendUrl(), 'http://127.0.0.1:9001/api/atris2/turn');
+    assert.equal(ax.backendUrl({ route: 'local' }), 'http://127.0.0.1:9001/api/atris2/turn');
+    assert.equal(ax.backendUrl({ route: 'cloud' }), 'https://api.atris.ai/api/atris2/turn');
+    assert.equal(
+      ax.buildRunProfile({ mode: 'fast', route: 'cloud', cwd: '/tmp/project' }).endpoint,
+      'https://api.atris.ai/api/atris2/turn'
+    );
   } finally {
     if (previous === undefined) delete process.env.AX_BACKEND_URL;
     else process.env.AX_BACKEND_URL = previous;
+    if (previousCloud === undefined) delete process.env.OBELISK_ATRIS2_BACKEND_URL;
+    else process.env.OBELISK_ATRIS2_BACKEND_URL = previousCloud;
+    if (previousApiBase === undefined) delete process.env.ATRIS_API_BASE;
+    else process.env.ATRIS_API_BASE = previousApiBase;
   }
+});
+
+test('ax backend hint points users to hosted or their own local backend', () => {
+  const writes = [];
+  const originalLog = console.log;
+  try {
+    console.log = (line = '') => writes.push(String(line));
+    ax.printBackendHint();
+  } finally {
+    console.log = originalLog;
+  }
+
+  const text = writes.join('\n');
+  assert.match(text, /ax --cloud "hello"/);
+  assert.match(text, /ATRIS_API_BASE=https:\/\/api\.atris\.ai/);
+  assert.match(text, /AX_BACKEND_URL=http:\/\/127\.0\.0\.1:8000/);
+  assert.doesNotMatch(text, /\/Users\/keshavrao\/arena\/atrisos-backend/);
 });
 
 test('ax formats paths with filename emphasis spacing', () => {
@@ -325,12 +798,21 @@ test('ax formats paths with filename emphasis spacing', () => {
 
 test('ax renders basic markdown for terminal output', () => {
   assert.equal(ax.renderTerminalMarkdown('## Heading\nUse **bold** and `code`.', { color: false }), 'Heading\nUse bold and code.');
+  assert.equal(ax.renderTerminalMarkdown('*hello* and _there_', { color: false }), 'hello and there');
+  assert.equal(ax.renderTerminalMarkdown('- one\n* two\n1. three', { color: false }), '• one\n• two\n• three');
+  assert.equal(ax.renderTerminalMarkdown('> quote line', { color: false }), '▏ quote line');
+  assert.equal(ax.renderTerminalMarkdown('~~gone~~', { color: false }), 'gone');
+  assert.equal(ax.renderTerminalMarkdown('[docs](https://example.com)', { color: false }), 'docs (https://example.com)');
   const previousNoColor = process.env.NO_COLOR;
   delete process.env.NO_COLOR;
   try {
     const rendered = ax.renderTerminalMarkdown('Use **bold** and `code`.', { color: true, isTTY: true });
     assert.match(rendered, /\x1b\[1mbold\x1b\[0m/);
     assert.match(rendered, /\x1b\[36mcode\x1b\[0m/);
+    const italic = ax.renderTerminalMarkdown('*hello*', { color: true, isTTY: true });
+    assert.match(italic, /\x1b\[3mhello\x1b\[0m/);
+    const strike = ax.renderTerminalMarkdown('~~nope~~', { color: true, isTTY: true });
+    assert.match(strike, /\x1b\[9mnope\x1b\[0m/);
   } finally {
     if (previousNoColor === undefined) delete process.env.NO_COLOR;
     else process.env.NO_COLOR = previousNoColor;
@@ -338,11 +820,62 @@ test('ax renders basic markdown for terminal output', () => {
 });
 
 test('ax streaming markdown handles split bold delimiters', () => {
-  const state = { markdownMode: 'normal', markdownBuffer: '', markdownCarry: '' };
+  const state = { markdownMode: 'normal', markdownBuffer: '', markdownCarry: '', markdownDelim: '', atLineStart: true };
   const options = { color: false, isTTY: true };
   assert.equal(ax.renderStreamingMarkdown(state, 'This is *', options), 'This is ');
   assert.equal(ax.renderStreamingMarkdown(state, '*bold', options), '');
   assert.equal(ax.renderStreamingMarkdown(state, '** now', options), 'bold now');
+});
+
+test('ax streaming markdown renders italic spans', () => {
+  const state = { markdownMode: 'normal', markdownBuffer: '', markdownCarry: '', markdownDelim: '', atLineStart: true };
+  const options = { color: true, isTTY: true };
+  const previousNoColor = process.env.NO_COLOR;
+  delete process.env.NO_COLOR;
+  try {
+    assert.equal(ax.renderStreamingMarkdown(state, 'Say *hel', options), 'Say ');
+    assert.match(ax.renderStreamingMarkdown(state, 'lo* friend', options), /\x1b\[3mhello\x1b\[0m friend/);
+  } finally {
+    if (previousNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = previousNoColor;
+  }
+});
+
+test('ax streaming markdown renders block lines and links', () => {
+  const state = { markdownMode: 'normal', markdownBuffer: '', markdownCarry: '', markdownDelim: '', atLineStart: true };
+  const options = { color: false, isTTY: true };
+  assert.equal(ax.renderStreamingMarkdown(state, '## Title\n', options), 'Title\n');
+  assert.equal(ax.renderStreamingMarkdown(state, '- item one\n', options), '• item one\n');
+  assert.equal(ax.renderStreamingMarkdown(state, '[link](https://example.com)', options), 'link (https://example.com)');
+});
+
+test('ax streaming markdown carries split heading markers instead of leaking ##', () => {
+  const state = { markdownMode: 'normal', markdownBuffer: '', markdownCarry: '', markdownDelim: '', atLineStart: true };
+  const options = { color: false, isTTY: true };
+  // "##" and " Sample" arrive in separate deltas — must not leak the hashes
+  let out = ax.renderStreamingMarkdown(state, '##', options);
+  out += ax.renderStreamingMarkdown(state, ' Sample\n', options);
+  out += ax.renderStreamingMarkdown(state, 'body\n', options);
+  assert.equal(out, 'Sample\nbody\n');
+});
+
+test('ax streaming markdown renders fenced code blocks (split across deltas)', () => {
+  const state = { markdownMode: 'normal', markdownBuffer: '', markdownCarry: '', markdownDelim: '', atLineStart: true };
+  const options = { color: false, isTTY: true };
+  // language label and the fences must be consumed, body indented two spaces
+  let out = '';
+  for (const delta of ['```py', 'thon\n', 'def greet():\n', '    return 1\n', '``', '`\n', 'after\n']) {
+    out += ax.renderStreamingMarkdown(state, delta, options);
+  }
+  assert.equal(out, '  def greet():\n      return 1\nafter\n');
+  assert.equal(state.markdownMode, 'normal');
+
+  // whole fence in one delta
+  const state2 = { markdownMode: 'normal', markdownBuffer: '', markdownCarry: '', markdownDelim: '', atLineStart: true };
+  assert.equal(
+    ax.renderStreamingMarkdown(state2, '```js\nconst a = 1;\n```\ndone\n', options),
+    '  const a = 1;\ndone\n',
+  );
 });
 
 test('ax renders connector result when no text delta was emitted', () => {
@@ -367,6 +900,8 @@ test('ax renders connector result when no text delta was emitted', () => {
     markdownMode: 'normal',
     markdownBuffer: '',
     markdownCarry: '',
+    markdownDelim: '',
+    atLineStart: true,
   };
 
   ax.handleEvent({ type: 'result', result: 'No Slack user matched jared.' }, state, output);
@@ -403,5 +938,64 @@ test('ax auto logger writes clean chat transcripts under atris/runs', () => {
     assert.match(chunks.join(''), /\x1b\[32matris text/);
   } finally {
     fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('ax manageTurnInterrupt routes abort through registerAbort or SIGINT', () => {
+  let registered = null;
+  let fired = false;
+  const cleanup = ax.manageTurnInterrupt(() => {
+    fired = true;
+  }, {
+    registerAbort(fn) {
+      registered = fn;
+    },
+  });
+  assert.equal(typeof registered, 'function');
+  registered();
+  assert.equal(fired, true);
+  cleanup();
+});
+
+test('postTurn aborts in-flight SSE turn on interrupt', async () => {
+  const http = require('http');
+  const originalRequest = http.request;
+  let destroyCalled = false;
+  http.request = (_opts, callback) => {
+    const req = {
+      on(event, handler) {
+        if (event === 'error') this._errorHandler = handler;
+      },
+      destroy() {
+        destroyCalled = true;
+        if (this._errorHandler) this._errorHandler(Object.assign(new Error('aborted'), { code: 'ABORT_ERR' }));
+      },
+      setTimeout() {},
+      write() {},
+      end() {
+        callback({
+          statusCode: 200,
+          setEncoding() {},
+          on() {},
+        });
+      },
+    };
+    return req;
+  };
+  try {
+    let abort = null;
+    const turn = ax.postTurn('hello', {
+      cwd: process.cwd(),
+      route: 'local',
+      registerAbort(fn) { abort = fn; },
+      showProgress: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    abort();
+    const result = await turn;
+    assert.equal(result.interrupted, true);
+    assert.equal(destroyCalled, true);
+  } finally {
+    http.request = originalRequest;
   }
 });

--- a/test/youtube.test.js
+++ b/test/youtube.test.js
@@ -1,0 +1,96 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  DEFAULT_QUERY,
+  parseYoutubeArgs,
+  buildYoutubePayload,
+  formatYoutubeResult,
+  youtubeCommand,
+} = require('../commands/youtube');
+
+test('parseYoutubeArgs accepts process form with query, storage, json, and timeout', () => {
+  const options = parseYoutubeArgs([
+    'process',
+    'https://youtu.be/abc123',
+    '--query',
+    'What changed?',
+    '--agent',
+    'agent-1',
+    '--store',
+    '--json',
+    '--timeout',
+    '12',
+  ]);
+
+  assert.equal(options.youtubeUrl, 'https://youtu.be/abc123');
+  assert.equal(options.query, 'What changed?');
+  assert.equal(options.agentId, 'agent-1');
+  assert.equal(options.storeAsKnowledge, true);
+  assert.equal(options.json, true);
+  assert.equal(options.timeoutMs, 12000);
+});
+
+test('buildYoutubePayload defaults to the documented takeaway query', () => {
+  const payload = buildYoutubePayload(parseYoutubeArgs(['https://youtube.com/watch?v=abc123']));
+  assert.deepEqual(payload, {
+    youtube_url: 'https://youtube.com/watch?v=abc123',
+    query: DEFAULT_QUERY,
+  });
+});
+
+test('youtubeCommand calls the process_youtube endpoint without curl', async () => {
+  const calls = [];
+  const output = [];
+
+  const status = await youtubeCommand([
+    'https://youtube.com/watch?v=abc123',
+    '--query',
+    'Extract lessons',
+  ], {
+    output: (line) => output.push(line),
+    ensureValidCredentials: async () => ({ credentials: { token: 'token-123' } }),
+    apiRequestJson: async (pathname, options) => {
+      calls.push({ pathname, options });
+      return {
+        ok: true,
+        status: 200,
+        data: {
+          status: 'success',
+          message: 'YouTube video processed successfully',
+          video_analysis: 'Main insight.',
+          credits_used: 5,
+          credits_remaining: 42,
+          metadata: { title: 'Video title', channel: 'Channel name' },
+        },
+      };
+    },
+  });
+
+  assert.equal(status, 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pathname, '/agent/process_youtube');
+  assert.deepEqual(calls[0].options.body, {
+    youtube_url: 'https://youtube.com/watch?v=abc123',
+    query: 'Extract lessons',
+  });
+  assert.equal(calls[0].options.method, 'POST');
+  assert.equal(calls[0].options.token, 'token-123');
+  assert.equal(calls[0].options.timeoutMs, 300000);
+  assert.match(output.join('\n'), /Video title/);
+  assert.match(output.join('\n'), /Main insight/);
+});
+
+test('formatYoutubeResult includes metadata, credits, and analysis', () => {
+  const text = formatYoutubeResult({
+    message: 'done',
+    video_analysis: 'Analysis text.',
+    credits_used: 5,
+    credits_remaining: 10,
+    metadata: { title: 'T', channel: 'C' },
+  });
+
+  assert.match(text, /Title: T/);
+  assert.match(text, /Channel: C/);
+  assert.match(text, /Credits: 5 used, 10 remaining/);
+  assert.match(text, /Analysis text/);
+});


### PR DESCRIPTION
## What changed

- Treat `ax chat ax --fast` as chat mode instead of sending `chat ax` as a local workspace prompt.
- Default auto backend URL selection to the hosted Atris API instead of empty localhost.
- Replace the hardcoded laptop backend hint with hosted-cloud and user-owned local backend guidance.
- Add regression coverage for the chat alias, default hosted endpoint, and no `/Users/keshavrao/arena/atrisos-backend` leak.

## Root cause

The CLI accepted `--chat`, but not the user-facing `chat ax` subcommand shape. That left `chat ax` in the prompt, which resolved to local workspace mode and exposed `workspace_path`. Separately, the auto backend URL fallback still preferred `127.0.0.1:8000`, and the catch-path hint printed a hardcoded local backend command.

## Proof

- `node --test test/ax.test.js test/ax-chat-input.test.js test/ax-goal.test.js test/ax-prefs.test.js test/ax-shimmer.test.js test/youtube.test.js` passed, 62/62.
- `node --check ax` passed.
- `AX_BACKEND_URL=http://127.0.0.1:1 ATRIS_SKIP_UPDATE_CHECK=1 node ax chat ax --fast` enters chat and exits cleanly on `/exit`.
- `require('./ax').backendUrl()` prints `https://api.atris.ai/api/atris2/turn` by default.
- `printBackendHint()` no longer contains `/Users/keshavrao/arena/atrisos-backend`.
