### PR TITLE
ship ax cloud default release

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,18 @@ Integrates with any agent.
 
 ## Chat With Atris 2
 
-`ax` is the local Atris 2 coding-agent CLI. It talks to a local AtrisOS backend (default `http://127.0.0.1:8000`), streams text, shows tool activity, and sends the current folder as the workspace.
+`ax` is the Atris 2 chat and coding-agent CLI. It uses the hosted Atris cloud by default, streams text, shows tool activity, and keeps fresh installs away from backend setup.
 
 ```bash
 cd your-project
-ax --pro "find the task system and explain it"
-ax --fast "what files are here?"
-ax --max "refactor this module and verify the tests"
-ax --pro --chat
+ax chat ax --fast
+ax --fast "hello"
+ax --pro "help me plan this task"
+ax --max "reason through this hard decision"
 ax --doctor
 ```
 
-Use Pro for agentic file work and edit/test loops. Use Fast for quick workspace search, short chats, and small edits. Use Max for the hardest jobs — it runs the highest-reasoning model and takes longer per turn.
+Use Fast for quick chat and low-latency Atris loops. Use Pro for deeper tool loops. Use Max for the hardest jobs — it runs the highest-reasoning model and takes longer per turn. Advanced local workspace mode is opt-in with `--local` plus `AX_BACKEND_URL`.
 
 ## Play AgentXP
 

--- a/ax
+++ b/ax
@@ -174,9 +174,9 @@ function formatUsage() {
     '  ax [--max|--fast] --benchmark',
     '',
     'Modes:',
-    '  --max   local workspace agent, highest reasoning, slowest turns',
-    '  --pro   local workspace agent, deeper tool loop',
-    '  --fast  local workspace agent, faster low-latency turns',
+    '  --max   hosted Atris 2, highest reasoning, slowest turns',
+    '  --pro   hosted Atris 2, deeper tool loop',
+    '  --fast  hosted Atris 2, faster low-latency turns',
     '  --code-fast  Atris Code Fast public lane',
     '  --local force local workspace tools',
     '  --cloud force authenticated cloud connectors/chat',
@@ -320,6 +320,15 @@ function isLoopbackUrl(value) {
   } catch (_) {
     return false;
   }
+}
+
+function configuredLocalBackendUrl() {
+  return process.env.AX_BACKEND_URL || process.env.OBELISK_LOCAL_ATRIS2_BACKEND_URL || '';
+}
+
+function hasLocalWorkspaceBackend(options = {}) {
+  if (options.localWorkspaceBackend === true) return true;
+  return Boolean(configuredLocalBackendUrl());
 }
 
 function isCodeFastLocal(options = {}) {
@@ -610,9 +619,11 @@ function casualChatIntent(message) {
 function resolveRoute(message, options = {}) {
   if (options.route === 'local' || options.forceLocal) return 'local';
   if (options.route === 'cloud' || options.forceCloud) return 'cloud';
-  if (githubWorkspaceIntent(message)) return 'local';
   if (casualChatIntent(message)) return 'cloud';
+  const localWorkspace = hasLocalWorkspaceBackend(options);
+  if (githubWorkspaceIntent(message) && localWorkspace) return 'local';
   if (mentionsConnector(message) && !workspaceIntent(message)) return 'cloud';
+  if (!localWorkspace) return 'cloud';
   return 'local';
 }
 
@@ -844,16 +855,16 @@ const CHAT_DOGFOOD_BASE_CASES = [
   { input: 'hi', kind: 'turn', expectRoute: 'cloud', coverage: 'small_talk' },
   { input: 'pop', kind: 'turn', expectRoute: 'cloud', coverage: 'short_noise' },
   { input: 'hello why', kind: 'turn', expectRoute: 'cloud', coverage: 'greeting_phrase' },
-  { input: 'what files are here?', kind: 'turn', expectRoute: 'local', coverage: 'workspace_read' },
-  { input: 'search src for the input component', kind: 'turn', expectRoute: 'local', coverage: 'workspace_search' },
-  { input: 'fix the xp game tests', kind: 'turn', expectRoute: 'local', coverage: 'workspace_fix' },
+  { input: 'what files are here?', kind: 'turn', expectRoute: 'cloud', coverage: 'workspace_read' },
+  { input: 'search src for the input component', kind: 'turn', expectRoute: 'cloud', coverage: 'workspace_search' },
+  { input: 'fix the xp game tests', kind: 'turn', expectRoute: 'cloud', coverage: 'workspace_fix' },
   { input: 'what is on my calendar today?', kind: 'turn', expectRoute: 'cloud', coverage: 'connector_read' },
   { input: 'which integrations are connected?', kind: 'turn', expectRoute: 'cloud', coverage: 'connector_status' },
   { input: 'what github repos do I have?', kind: 'turn', expectRoute: 'cloud', coverage: 'github_read' },
-  { input: 'push something to github', kind: 'turn', expectRoute: 'local', coverage: 'github_workspace_mutation' },
+  { input: 'push something to github', kind: 'turn', expectRoute: 'cloud', coverage: 'github_workspace_mutation' },
   { input: 'https://www.youtube.com/watch?v=gBukk9LIklc', kind: 'youtube', coverage: 'youtube_url' },
   { input: '/max', kind: 'command', coverage: 'tier_max' },
-  { input: 'refactor this module and verify the tests', kind: 'turn', expectRoute: 'local', expectMode: 'max', coverage: 'max_local' },
+  { input: 'refactor this module and verify the tests', kind: 'turn', expectRoute: 'cloud', expectMode: 'max', coverage: 'max_cloud' },
   { input: '/pro', kind: 'command', coverage: 'tier_pro' },
   { input: 'send a slack message to the team', kind: 'turn', expectRoute: 'cloud', expectMode: 'pro', coverage: 'connector_write_safe' },
   { input: '/bypass', kind: 'command', coverage: 'permission_bypass' },
@@ -863,7 +874,7 @@ const CHAT_DOGFOOD_BASE_CASES = [
   { input: '/wat', kind: 'command', coverage: 'unknown_slash' },
   { input: '/goal', kind: 'command', coverage: 'goal_status' },
   { input: 'oj', kind: 'turn', expectRoute: 'cloud', coverage: 'short_noise_repeat' },
-  { input: 'read MAP.md and do not edit', kind: 'turn', expectRoute: 'local', coverage: 'workspace_read_specific' },
+  { input: 'read MAP.md and do not edit', kind: 'turn', expectRoute: 'cloud', coverage: 'workspace_read_specific' },
 ];
 
 function buildChatDogfoodCases(loopCount = 25) {
@@ -2569,11 +2580,11 @@ function buildDogfoodChecklist({ cases, outputText, turnCalls, youtubeCalls, log
   const turnCases = cases.filter(item => item.kind === 'turn');
   const paired = turnCases.map((item, index) => ({ case: item, call: turnCalls[index] || null }));
   const smallTalk = paired.filter(item => /small_talk|short_noise|greeting/.test(item.case.coverage));
-  const local = paired.filter(item => item.case.expectRoute === 'local');
+  const workspace = paired.filter(item => /workspace_|github_workspace_mutation|max_cloud/.test(item.case.coverage));
   const cloud = paired.filter(item => item.case.expectRoute === 'cloud');
   const bypassCall = paired.find(item => item.case.coverage === 'connector_write_bypass')?.call;
   const safeCalls = paired.filter(item => /connector_write_(safe|resafe)/.test(item.case.coverage)).map(item => item.call);
-  const maxCall = paired.find(item => item.case.coverage === 'max_local')?.call;
+  const maxCall = paired.find(item => item.case.coverage === 'max_cloud')?.call;
   const firstHeader = outputText.split(/\r?\n/).slice(0, 4).map(stripAnsi);
   const longestHeader = firstHeader.reduce((max, line) => Math.max(max, line.length), 0);
   const modelPattern = /atris:|composer-2-5|gpt-|kimi|fable|fireworks|openrouter/i;
@@ -2584,7 +2595,7 @@ function buildDogfoodChecklist({ cases, outputText, turnCalls, youtubeCalls, log
     makeChecklistItem('header_compact', 'Chat header fits a small terminal', longestHeader <= 96 && /shift\+enter/.test(outputText), `longest header line ${longestHeader}`),
     makeChecklistItem('menu_discoverable', 'Slash menu exposes key controls', /\/goal/.test(outputText) && /\/fast/.test(outputText) && /\/safe/.test(outputText), 'menu printed by /help and unknown slash'),
     makeChecklistItem('small_talk_cloud', 'Greetings/noise avoid workspace listings', smallTalk.length >= 4 && smallTalk.every(item => item.call?.route === 'cloud' && !item.call?.workspace_path), smallTalk.map(item => `${item.case.input}:${item.call?.route}`).join(', ')),
-    makeChecklistItem('workspace_local', 'Workspace asks still use local tools', local.length >= 5 && local.every(item => item.call?.route === 'local' && item.call?.workspace_path), local.map(item => `${item.case.coverage}:${item.call?.route}`).join(', ')),
+    makeChecklistItem('workspace_cloud_default', 'Workspace/code asks stay hosted by default', workspace.length >= 5 && workspace.every(item => item.call?.route === 'cloud' && !item.call?.workspace_path), workspace.map(item => `${item.case.coverage}:${item.call?.route}`).join(', ')),
     makeChecklistItem('connectors_cloud', 'Connector reads/writes stay cloud by default', cloud.length >= 8 && cloud.every(item => item.call?.route === 'cloud'), cloud.map(item => `${item.case.coverage}:${item.call?.route}`).join(', ')),
     makeChecklistItem('tier_switches', 'Tier commands affect following turns', maxCall?.mode === 'max', `max turn mode ${maxCall?.mode || 'missing'}`),
     makeChecklistItem('permission_gates', 'Safe/bypass gates are visible in payloads', bypassCall?.allow_external_actions === true && safeCalls.every(call => call && call.allow_external_actions !== true), `bypass=${bypassCall?.allow_external_actions === true}; safe=${safeCalls.length}`),

--- a/lib/ax-prefs.js
+++ b/lib/ax-prefs.js
@@ -3,19 +3,25 @@ const os = require('os');
 const path = require('path');
 
 const MEMBER_SLUG = 'ax';
-const PREFS_PATH = path.join(os.homedir(), '.atris', 'ax.json');
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+function prefsPath() {
+  return path.join(process.env.HOME || os.homedir(), '.atris', 'ax.json');
+}
+
+const PREFS_PATH = prefsPath();
 
 function truthy(value) {
   return TRUTHY.has(String(value || '').trim().toLowerCase());
 }
 
 function loadAxPrefs() {
+  const filePath = prefsPath();
   try {
-    if (!fs.existsSync(PREFS_PATH)) {
+    if (!fs.existsSync(filePath)) {
       return { member_slug: MEMBER_SLUG, bypass_permissions: false };
     }
-    const parsed = JSON.parse(fs.readFileSync(PREFS_PATH, 'utf8'));
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     return {
       member_slug: MEMBER_SLUG,
       bypass_permissions: parsed.bypass_permissions === true,
@@ -26,8 +32,9 @@ function loadAxPrefs() {
 }
 
 function saveAxPrefs(prefs) {
-  fs.mkdirSync(path.dirname(PREFS_PATH), { recursive: true });
-  fs.writeFileSync(PREFS_PATH, `${JSON.stringify({
+  const filePath = prefsPath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify({
     member_slug: MEMBER_SLUG,
     bypass_permissions: prefs.bypass_permissions === true,
     updated_at: new Date().toISOString(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.16.0",
+  "version": "3.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.16.0",
+      "version": "3.25.0",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.16.1",
+  "version": "3.25.0",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/ax.test.js
+++ b/test/ax.test.js
@@ -204,7 +204,7 @@ test('ax dogfoods fast chat with a 25-loop checklist', async () => {
     assert.equal(report.checklist.every(item => item.passed), true);
     assert.ok(fs.existsSync(report.log_path));
     assert.equal(report.turn_calls.some(call => call.message === 'hi' && call.route === 'cloud' && !call.workspace_path), true);
-    assert.equal(report.turn_calls.some(call => call.message === 'what files are here?' && call.route === 'local' && call.workspace_path === dir), true);
+    assert.equal(report.turn_calls.some(call => call.message === 'what files are here?' && call.route === 'cloud' && !call.workspace_path), true);
     assert.equal(report.youtube_calls.length, 1);
     assert.match(ax.formatChatDogfoodReport(report), /loops: 25\/25/);
     assert.match(ax.formatChatDogfoodReport(report), /checklist: 12\/12 passed/);
@@ -265,10 +265,10 @@ test('ax dogfood status summarizes overnight mission proof', () => {
   }
 });
 
-test('ax routes workspace questions to local Atris 2 tools', () => {
-  assert.equal(ax.resolveRoute('what files are here?'), 'local');
-  assert.equal(ax.resolveRoute('search src for the input component'), 'local');
-  assert.equal(ax.resolveRoute('fix the xp game tests'), 'local');
+test('ax routes fresh-user workspace questions to hosted cloud by default', () => {
+  assert.equal(ax.resolveRoute('what files are here?'), 'cloud');
+  assert.equal(ax.resolveRoute('search src for the input component'), 'cloud');
+  assert.equal(ax.resolveRoute('fix the xp game tests'), 'cloud');
 
   const payload = ax.buildPayload('what files are here?', {
     mode: 'fast',
@@ -276,10 +276,24 @@ test('ax routes workspace questions to local Atris 2 tools', () => {
   });
 
   assert.equal(payload.model, 'atris:fast');
-  assert.equal(payload.workspace_path, '/tmp/project');
-  assert.equal(payload.max_turns, 8);
+  assert.equal(payload.workspace_path, undefined);
+  assert.equal(payload.max_turns, 1);
   assert.equal(payload.member_slug, 'ax');
   assert.equal(payload.bypass_permissions, false);
+});
+
+test('ax uses local workspace tools only when a local backend is configured or forced', () => {
+  assert.equal(ax.resolveRoute('what files are here?', { localWorkspaceBackend: true }), 'local');
+  assert.equal(ax.resolveRoute('search src for the input component', { localWorkspaceBackend: true }), 'local');
+
+  const payload = ax.buildPayload('what files are here?', {
+    mode: 'fast',
+    cwd: '/tmp/project',
+    localWorkspaceBackend: true,
+  });
+
+  assert.equal(payload.workspace_path, '/tmp/project');
+  assert.equal(payload.max_turns, 8);
 });
 
 test('ax routes greetings and no-intent snippets to cloud chat', () => {
@@ -289,8 +303,8 @@ test('ax routes greetings and no-intent snippets to cloud chat', () => {
   assert.equal(ax.resolveRoute('hello why'), 'cloud');
   assert.equal(ax.resolveRoute('hello please'), 'cloud');
   assert.equal(ax.resolveRoute('oj'), 'cloud');
-  assert.equal(ax.resolveRoute('fix'), 'local');
-  assert.equal(ax.resolveRoute('what files are here?'), 'local');
+  assert.equal(ax.resolveRoute('fix'), 'cloud');
+  assert.equal(ax.resolveRoute('what files are here?'), 'cloud');
 
   const payload = ax.buildPayload('hi', {
     mode: 'fast',
@@ -310,8 +324,8 @@ test('ax exposes Atris 2 Max as the highest-reasoning tier', () => {
     cwd: '/tmp/project',
   });
   assert.equal(payload.model, 'atris:max');
-  assert.equal(payload.workspace_path, '/tmp/project');
-  assert.equal(payload.max_turns, 14);
+  assert.equal(payload.workspace_path, undefined);
+  assert.equal(payload.max_turns, 1);
 
   const cloudWrite = ax.buildPayload('send a slack message to the team', {
     mode: 'max',
@@ -334,7 +348,8 @@ test('ax exposes Atris 2 Max as the highest-reasoning tier', () => {
 
   const profile = ax.buildRunProfile({ mode: 'max', cwd: '/tmp/project' });
   assert.equal(profile.model, 'atris:max');
-  assert.equal(profile.max_turns, 14);
+  assert.equal(profile.max_turns, 1);
+  assert.equal(profile.route, 'cloud');
   assert.match(profile.reasoning, /high reasoning/);
 });
 
@@ -342,7 +357,8 @@ test('ax defaults to fast tier when no mode flag is set', () => {
   const profile = ax.buildRunProfile({ cwd: '/tmp/project' });
   assert.equal(profile.mode, 'fast');
   assert.equal(profile.model, 'atris:fast');
-  assert.equal(profile.max_turns, 8);
+  assert.equal(profile.max_turns, 1);
+  assert.equal(profile.route, 'cloud');
   assert.match(ax.formatHeader({ cwd: '/tmp/project', chat: true }), /Atris 2 Fast chat/);
 });
 
@@ -595,10 +611,11 @@ test('ax continuation wrapper marks current user message for backend connector r
   assert.doesNotMatch(wrapped, /Current user message: check my slack messages/);
 });
 
-test('ax routes GitHub repo mutations to local workspace tools', () => {
-  assert.equal(ax.resolveRoute('push something to github'), 'local');
-  assert.equal(ax.resolveRoute('commit a tiny proof change and push to github'), 'local');
-  assert.equal(ax.resolveRoute('open a pull request for this branch on github'), 'local');
+test('ax routes GitHub repo mutations to cloud unless local workspace is configured', () => {
+  assert.equal(ax.resolveRoute('push something to github'), 'cloud');
+  assert.equal(ax.resolveRoute('commit a tiny proof change and push to github'), 'cloud');
+  assert.equal(ax.resolveRoute('open a pull request for this branch on github'), 'cloud');
+  assert.equal(ax.resolveRoute('push something to github', { localWorkspaceBackend: true }), 'local');
 });
 
 test('ax carries local connector lookup id only on cloud payloads', () => {
@@ -670,6 +687,7 @@ test('ax sends a no-op verify_command unless --verify opts in', () => {
     cwd: '/tmp/project',
   });
   assert.equal(defaultPayload.verify_command, 'true');
+  assert.equal(defaultPayload.workspace_path, undefined);
 
   const blankPayload = ax.buildPayload('what files are here?', {
     mode: 'fast',
@@ -677,9 +695,11 @@ test('ax sends a no-op verify_command unless --verify opts in', () => {
     verify: '   ',
   });
   assert.equal(blankPayload.verify_command, 'true');
+  assert.equal(blankPayload.workspace_path, undefined);
 
   const localPayload = ax.buildPayload('fix the failing suite', {
     mode: 'max',
+    route: 'local',
     cwd: '/tmp/project',
     verify: 'npm test',
   });


### PR DESCRIPTION
## What changed

- Make fresh-user `ax` default to hosted Atris cloud for chat, workspace prompts, and GitHub/code-ish prompts unless local workspace mode is explicitly configured.
- Keep local workspace mode available via `--local`, `AX_BACKEND_URL`, or `OBELISK_LOCAL_ATRIS2_BACKEND_URL`.
- Remove user-facing local-backend default language from README.
- Bump package to `3.25.0` for npm publish.
- Fix ax prefs tests by resolving the prefs path at call time, so tests do not inherit the operator's saved permission mode.

## Why

Fresh users should never see backend setup or a hardcoded laptop path. The CLI should feel like a hosted product by default; local backend mode is an advanced opt-in.

## Proof

- `node --test test/ax.test.js test/ax-chat-input.test.js test/ax-goal.test.js test/ax-prefs.test.js test/ax-shimmer.test.js test/youtube.test.js` passed, 63/63.
- `node --check ax` passed.
- `npm pack` built `atris-3.25.0.tgz`.
- Unpacked tarball: `backendUrl()` => `https://api.atris.ai/api/atris2/turn`.
- Unpacked tarball: `resolveRoute('what files are here?')` and `resolveRoute('push something to github')` => `cloud`.
- Unpacked tarball has `normalizeChatCommandArgs` and no `/Users/keshavrao/arena/atrisos-backend` or `Start backend` leak.
- `AX_BACKEND_URL=http://127.0.0.1:1 unpacked/package/ax chat ax --fast` enters chat and exits 0 on `/exit`.
- `unpacked/package/ax --fast --doctor` shows endpoint `https://api.atris.ai/api/atris2/turn`, route `cloud`, workspace `cloud`.
