### PR TITLE
Fix ax release test blockers

### DIFF
--- a/atris/skills/atris-feedback/SKILL.md
+++ b/atris/skills/atris-feedback/SKILL.md
@@ -52,9 +52,8 @@ Only use this path if the CLI is unavailable (stale install, broken login).
 
 ### Setup
 
-```bash
-cd ~/arena/atrisos-backend && source venv/bin/activate
-```
+Use this only from a trusted service workspace with AWS credentials already
+configured. Do not ask end users to clone or run backend services locally.
 
 ```python
 from dotenv import load_dotenv; load_dotenv('backend/.env')

--- a/atris/wiki/sources/atris-labs-2026-05-10.txt
+++ b/atris/wiki/sources/atris-labs-2026-05-10.txt
@@ -2,16 +2,13 @@ Source receipt for atris/wiki/systems/atris-labs.md
 Compiled: 2026-05-10
 
 Local evidence checked:
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/CLAUDE.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/context/STATUS.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/context/PIPELINE.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/team/keshav/MEMBER.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/team/justin/MEMBER.md
-- /Users/keshavrao/arena/empire/atris-business/atris-labs-1/apps/
-- /Users/keshavrao/arena/empire/atrisos-backend/backend/static/workspaces/atris-labs/instructions.md
-- /Users/keshavrao/arena/empire/atrisos-backend/backend/atris-labs-1/.atris/business.json
+- historical Atris Labs customer workspace docs
+- historical Atris Labs context status and pipeline notes
+- historical Atris Labs member profile notes
+- historical Atris Labs app workspace inventory
+- historical Atris Labs cloud workspace binding metadata
 
 Notes:
-- The previous wiki source /Users/keshavrao/arena/atris-business/atris-labs-1/atris/MEMBER.md is missing in this workspace.
+- The previous wiki source is missing in this workspace.
 - Available status/pipeline files are historical March 2026 artifacts.
 - Treat this page as orientation, not a live company operating report.

--- a/atris/wiki/sources/atris-labs-goals-2026-05-10.txt
+++ b/atris/wiki/sources/atris-labs-goals-2026-05-10.txt
@@ -4,12 +4,11 @@ Compiled: 2026-05-10
 Local evidence checked:
 - atris/wiki/concepts/atris-labs-goals.md before refresh
 - atris/wiki/log.md historical ingest notes for missing goals.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/context/STATUS.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/context/PIPELINE.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/fundraise/metrics.md
-- /Users/keshavrao/arena/empire/atris-customers/atris-labs/fundraise/story.md
+- historical Atris Labs context status and pipeline notes
+- historical Atris Labs fundraising metrics notes
+- historical Atris Labs fundraising story notes
 
 Notes:
-- The previous source /Users/keshavrao/arena/atris-business/atris-labs/goals.md is missing in this workspace.
+- The previous goals source is missing in this workspace.
 - The page is retained as historical direction only.
 - Revenue/customer counts require live verification before operational use.

--- a/commands/aeo.js
+++ b/commands/aeo.js
@@ -5,17 +5,17 @@
  *   atris aeo init                          # create entity-graph skeleton
  *   atris aeo draft "<topic>" [opts]        # generate citation-optimized article
  *
- * Local-read against ~/arena/atrisos-backend/atris/features/aeo/proof/:
+ * Local-read against a developer-provided AEO workspace:
  *   atris aeo log [--engine X] [--limit N]  # citation attempt log
  *   atris aeo status                        # engine + proof + buyer summary
  *   atris aeo packet <slug>                 # buyer packet for a surface
  *   atris aeo proofs [--filter X]           # list proof receipt categories
  *
- * Shell out to atrisos-backend/scripts/aeo_*.py:
+ * Shell out to the configured workspace scripts/aeo_*.py:
  *   atris aeo discover <source> [...]       # discovery audit
  *   atris aeo audit <source> [...]          # agent-usability audit
  *
- * Backend root resolution: $ATRIS_BACKEND_ROOT or ~/arena/atrisos-backend.
+ * Local workspace resolution: $ATRIS_AEO_ROOT or legacy $ATRIS_BACKEND_ROOT.
  */
 
 const fs = require('fs');
@@ -28,8 +28,8 @@ const { loadBusinesses, saveBusinesses } = require('./business');
 
 function resolveBackendRoot() {
   const candidates = [
+    process.env.ATRIS_AEO_ROOT,
     process.env.ATRIS_BACKEND_ROOT,
-    path.join(os.homedir(), 'arena', 'atrisos-backend'),
   ].filter(Boolean);
   for (const root of candidates) {
     if (fs.existsSync(path.join(root, 'atris', 'features', 'aeo'))) return root;
@@ -40,7 +40,7 @@ function resolveBackendRoot() {
 function requireBackendRoot() {
   const root = resolveBackendRoot();
   if (!root) {
-    console.error('Cannot find atrisos-backend. Set $ATRIS_BACKEND_ROOT or clone to ~/arena/atrisos-backend.');
+    console.error('Cannot find local AEO workspace. Set ATRIS_AEO_ROOT to a workspace containing atris/features/aeo.');
     process.exit(1);
   }
   return root;

--- a/commands/computer.js
+++ b/commands/computer.js
@@ -664,7 +664,6 @@ function findAtrisCodeTerminal() {
     envPath,
     path.join(__dirname, '..', 'cli', 'atris_code.py'),
     path.join(process.cwd(), 'cli', 'atris_code.py'),
-    path.join(os.homedir(), 'arena', 'atrisos-backend', 'cli', 'atris_code.py'),
   ].filter(Boolean);
 
   let dir = process.cwd();

--- a/commands/mission.js
+++ b/commands/mission.js
@@ -1627,8 +1627,9 @@ async function runMission(args) {
     process.exit(0);
   }
 
+  const preLockRunner = String(mission.runner || '').trim().toLowerCase();
   const preLockCallerSession = runnerUsesCallerSession(mission.runner);
-  if (!skipClaude && !preLockCallerSession) {
+  if (!skipClaude && !preLockCallerSession && preLockRunner !== 'atris2') {
     const probe = probeClaudeBinary();
     if (!probe.ok) {
       console.error(`[mission run] claude probe failed: ${probe.error}`);

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -1626,8 +1626,7 @@ async function executeAgentSDKFast(userInput) {
   } catch (error) {
     console.error(`✗ Error: ${error.message}`);
     console.log('');
-    console.log('💡 Make sure the AtrisOS backend is running on port 8000');
-    console.log('   Start it with: cd /Users/keshavrao/arena/atrisos-backend/backend && python -m uvicorn main:app --reload --port 8000');
+    console.log('💡 Hosted turns use https://api.atris.ai. For local development, set ATRIS_API_BASE to your own backend URL.');
     process.exit(1);
   }
 }

--- a/lib/context-gatherer.js
+++ b/lib/context-gatherer.js
@@ -25,6 +25,13 @@ function hasContextProfile(root = process.cwd()) {
   return Boolean(profile && String(profile.first_answer || '').trim());
 }
 
+function isAtrisMetaQuestion(value) {
+  const text = String(value || '').trim().toLowerCase().replace(/[?.!]+$/g, '');
+  if (!text) return false;
+  return /^(what is|what's|whats|who is|who's|whos|explain|tell me about)\s+atris\b/.test(text)
+    || /^atris\s+(help|overview|what is this|what are you)$/i.test(text);
+}
+
 function compactText(value, max = 160) {
   const text = String(value || '').replace(/\s+/g, ' ').trim();
   if (!text) return '';
@@ -138,6 +145,7 @@ module.exports = {
   saveContextProfile,
   createStarterTask,
   shouldGatherContext,
+  isAtrisMetaQuestion,
   renderPrompt,
   starterTaskTitle,
   inferDomain,

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -321,7 +321,7 @@ test('ax is a self-contained Atris2 local/cloud agent script', () => {
   assert.match(ax, /function modelForMode/);
   assert.match(ax, /function buildRunProfile/);
   assert.match(ax, /function formatSystemInit/);
-  assert.match(ax, /max_turns:\s*local \? \(mode === 'fast' \? 8 : 14\) : 1/);
+  assert.match(ax, /max_turns:\s*options\.goalEval \? 1 : \(local \? \(mode === 'fast' \? 8 : 14\) : 1\)/);
   assert.match(ax, /'atris:max'/);
   assert.match(ax, /Accept:\s*'text\/event-stream'/);
   assert.match(ax, /async function chat/);
@@ -344,8 +344,8 @@ test('ax help stays local and does not start an agent turn', () => {
 
   assert.equal(res.status, 0, res.stderr);
   assert.match(res.stdout, /ax - Atris local\/code agent/);
-  assert.match(res.stdout, /ax \[--max\|--pro\|--fast\|--code-fast\] \[--local\|--cloud\] <message>/);
-  assert.match(res.stdout, /--max {3}local workspace agent, highest reasoning/);
+  assert.match(res.stdout, /ax \[--fast\|--pro\|--max\|--code-fast\] \[--local\|--cloud\] \[--bypass\|--safe\] <message>/);
+  assert.match(res.stdout, /--max {3}hosted Atris 2, highest reasoning/);
   assert.match(res.stdout, /--code-fast  Atris Code Fast public lane/);
   assert.doesNotMatch(res.stdout, /run\s+local workspace/);
   assert.doesNotMatch(res.stdout, /Worked for/);
@@ -362,34 +362,36 @@ test('ax keeps chat context and file-operation proof readable', () => {
     ]
   });
 
-  assert.equal(payload.workspace_path, '/workspace/demo');
+  assert.equal(payload.workspace_path, undefined);
   assert.equal(payload.model, 'atris:pro');
-  assert.equal(payload.max_turns, 14);
-  assert.equal(ax.buildPayload('quick edit', { cwd: '/workspace/demo', mode: 'fast' }).max_turns, 8);
+  assert.equal(payload.max_turns, 1);
+  assert.equal(ax.buildPayload('quick edit', { cwd: '/workspace/demo', mode: 'fast' }).max_turns, 1);
   assert.match(payload.message, /Recent conversation/);
   assert.equal(ax.modelForMode('pro'), 'atris:pro');
   assert.equal(ax.modelForMode('fast'), 'atris:fast');
   assert.equal(ax.modelForMode('max'), 'atris:max');
   assert.equal(ax.modelForMode('code-fast'), 'composer-2-5-fast');
-  assert.equal(ax.backendUrl(), 'http://127.0.0.1:8000/api/atris2/turn');
+  assert.equal(ax.backendUrl(), 'https://api.atris.ai/api/atris2/turn');
   assert.equal(ax.formatPrompt('pro'), 'pro › ');
   assert.equal(ax.formatDuration(6197), '6s');
   assert.equal(ax.formatDoneLine(131000), '— Worked for 2m 11s —');
-  assert.equal(ax.formatWorkingLine(2100), '• Working (2s • ctrl-c to interrupt)');
+  assert.equal(ax.formatWorkingLine(2100), '• Thinking… (2s · ctrl-c to interrupt)');
   assert.equal(ax.formatStatusMessage('retrying_with_required_local_tool'), null);
   assert.equal(ax.formatStatusMessage('loading_workspace_context'), 'loading workspace context');
   assert.match(ax.formatHeader({ mode: 'pro', cwd: '/workspace/demo', chat: true }), /Atris 2 Pro chat/);
   assert.doesNotMatch(ax.formatHeader({ mode: 'pro', cwd: '/workspace/demo', chat: true }), /atris:pro/);
   assert.match(ax.formatHeader({ mode: 'pro', cwd: '/workspace/demo', chat: true }), /\/workspace\/demo/);
   assert.deepEqual(ax.buildRunProfile({ mode: 'pro', cwd: '/workspace/demo' }), {
-    endpoint: 'http://127.0.0.1:8000/api/atris2/turn',
+    endpoint: 'https://api.atris.ai/api/atris2/turn',
     mode: 'pro',
-    route: 'local',
+    route: 'cloud',
     model: 'atris:pro',
-    workspace_path: '/workspace/demo',
-    max_turns: 14,
+    workspace_path: 'cloud',
+    max_turns: 1,
+    member_slug: 'ax',
+    bypass_permissions: false,
     streaming: true,
-    runtime: 'local workspace',
+    runtime: 'authenticated cloud connectors/chat',
     reasoning: 'backend reports run row; Pro workspace tool loop uses API default medium'
   });
   assert.match(ax.formatRunProfile(ax.buildRunProfile({ mode: 'pro', cwd: '/workspace/demo' })), /thinking\s+backend reports run row/);

--- a/test/context-gatherer.test.js
+++ b/test/context-gatherer.test.js
@@ -10,6 +10,7 @@ const {
   createStarterTask,
   hasContextProfile,
   inferDomain,
+  isAtrisMetaQuestion,
   loadContextProfile,
   renderPrompt,
   saveContextProfile,
@@ -83,4 +84,10 @@ test('context gatherer only interrupts when first-contact context is missing', (
   } finally {
     cleanupTempDir(dir);
   }
+});
+
+test('context gatherer recognizes Atris overview questions', () => {
+  assert.equal(isAtrisMetaQuestion('what is atris?'), true);
+  assert.equal(isAtrisMetaQuestion('tell me about Atris'), true);
+  assert.equal(isAtrisMetaQuestion('help me organize college apps'), false);
 });


### PR DESCRIPTION
## Summary
- export the missing context-gatherer meta-question helper used by bin/atris.js
- skip the Claude binary preflight for runner=atris2 so missing Atris auth pauses as auth-required
- update ax smoke tests to assert the hosted cloud default
- remove shipped local-path/backend setup leaks from package-visible docs and fallback hints

## Proof
- node --test test/context-gatherer.test.js test/commands.test.js test/cli-smoke.test.js test/experiments.test.js test/agent-proof-only.test.js test/mission-atris2-runner.test.js (420/420)
- npm test (1256/1256)
- npm pack tarball smoke: backendUrl=https://api.atris.ai/api/atris2/turn, routeHello=cloud, routeWorkspace=cloud, hasNormalizer=function
- tarball leak scan clean for /Users/keshavrao, ~/arena/atrisos-backend, arena/atrisos-backend, Start backend