### PR TITLE
Remove backend wording from ax cloud UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Integrates with any agent.
 
 ## Chat With Atris 2
 
-`ax` is the Atris 2 chat and coding-agent CLI. It uses the hosted Atris cloud by default, streams text, shows tool activity, and keeps fresh installs away from backend setup.
+`ax` is the Atris 2 chat and coding-agent CLI. It uses the hosted Atris cloud by default, streams text, shows tool activity, and keeps fresh installs away from local setup.
 
 ```bash
 cd your-project

--- a/ax
+++ b/ax
@@ -349,7 +349,7 @@ function buildRunProfile(options = {}) {
       workspace_path: isCodeFastLocal(options) ? cwd : 'cloud scratch',
       max_turns: 1,
       streaming: false,
-      runtime: isCodeFastLocal(options) ? 'local Cursor SDK through backend' : 'authenticated Code Fast cloud scratch',
+      runtime: isCodeFastLocal(options) ? 'local Cursor SDK bridge' : 'authenticated Code Fast cloud scratch',
       reasoning: 'Composer 2.5 fast lane; charges 10 credits per public turn'
     };
   }
@@ -368,10 +368,10 @@ function buildRunProfile(options = {}) {
     streaming: true,
     runtime: route === 'cloud' ? 'authenticated cloud connectors/chat' : 'local workspace',
     reasoning: mode === 'max'
-      ? 'backend reports run row; Max workspace tool loop uses high reasoning effort'
+      ? 'Atris cloud service; Max workspace tool loop uses high reasoning effort'
       : mode === 'pro'
-        ? 'backend reports run row; Pro workspace tool loop uses API default medium'
-        : 'backend reports run row; Fast workspace tool loop uses provider default'
+        ? 'Atris cloud service; Pro workspace tool loop uses API default medium'
+        : 'Atris cloud service; Fast workspace tool loop uses provider default'
   };
 }
 
@@ -2872,16 +2872,18 @@ function formatChatDogfoodStatusReport(status) {
   return lines.join('\n');
 }
 
-function printBackendHint() {
+function printBackendHint(options = {}) {
   console.log('');
   console.log('Hosted lane:');
   console.log('ax --cloud "hello"');
   console.log('');
   console.log('Cloud API:');
   console.log(`ATRIS_API_BASE=${BACKEND.publicBase}`);
-  console.log('');
-  console.log('Local workspace lane:');
-  console.log(`Set AX_BACKEND_URL=http://${BACKEND.host}:${BACKEND.port} after starting a local Atris2 backend.`);
+  if (options.route === 'local' || options.forceLocal) {
+    console.log('');
+    console.log('Local developer lane:');
+    console.log(`Set AX_BACKEND_URL=http://${BACKEND.host}:${BACKEND.port} after starting your local Atris2 service.`);
+  }
 }
 
 function bufferedOutput() {
@@ -3243,7 +3245,7 @@ async function main() {
     console.log(formatDoneLine(result.durationMs, creditsFromState(result)));
   } catch (error) {
     console.error(`x ${error.message}`);
-    printBackendHint();
+    printBackendHint(runOptions);
     process.exit(1);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.25.0",
+      "version": "3.25.1",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/ax.test.js
+++ b/test/ax.test.js
@@ -351,6 +351,7 @@ test('ax exposes Atris 2 Max as the highest-reasoning tier', () => {
   assert.equal(profile.max_turns, 1);
   assert.equal(profile.route, 'cloud');
   assert.match(profile.reasoning, /high reasoning/);
+  assert.doesNotMatch(ax.formatRunProfile(profile, { color: false }), /\bbackend\b/i);
 });
 
 test('ax defaults to fast tier when no mode flag is set', () => {
@@ -794,7 +795,7 @@ test('ax backend URL is configurable', () => {
   }
 });
 
-test('ax backend hint points users to hosted or their own local backend', () => {
+test('ax backend hint defaults to hosted cloud without local setup instructions', () => {
   const writes = [];
   const originalLog = console.log;
   try {
@@ -807,6 +808,23 @@ test('ax backend hint points users to hosted or their own local backend', () => 
   const text = writes.join('\n');
   assert.match(text, /ax --cloud "hello"/);
   assert.match(text, /ATRIS_API_BASE=https:\/\/api\.atris\.ai/);
+  assert.doesNotMatch(text, /AX_BACKEND_URL=http:\/\/127\.0\.0\.1:8000/);
+  assert.doesNotMatch(text, /\blocal\b.*\bbackend\b/i);
+  assert.doesNotMatch(text, /\/Users\/keshavrao\/arena\/atrisos-backend/);
+});
+
+test('ax backend hint shows local developer lane only when local is requested', () => {
+  const writes = [];
+  const originalLog = console.log;
+  try {
+    console.log = (line = '') => writes.push(String(line));
+    ax.printBackendHint({ route: 'local' });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const text = writes.join('\n');
+  assert.match(text, /Local developer lane/);
   assert.match(text, /AX_BACKEND_URL=http:\/\/127\.0\.0\.1:8000/);
   assert.doesNotMatch(text, /\/Users\/keshavrao\/arena\/atrisos-backend/);
 });

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -392,9 +392,9 @@ test('ax keeps chat context and file-operation proof readable', () => {
     bypass_permissions: false,
     streaming: true,
     runtime: 'authenticated cloud connectors/chat',
-    reasoning: 'backend reports run row; Pro workspace tool loop uses API default medium'
+    reasoning: 'Atris cloud service; Pro workspace tool loop uses API default medium'
   });
-  assert.match(ax.formatRunProfile(ax.buildRunProfile({ mode: 'pro', cwd: '/workspace/demo' })), /thinking\s+backend reports run row/);
+  assert.match(ax.formatRunProfile(ax.buildRunProfile({ mode: 'pro', cwd: '/workspace/demo' })), /thinking\s+Atris cloud service/);
   assert.equal(
     ax.formatSystemInit({
       type: 'system_init',


### PR DESCRIPTION
## Summary
- remove end-user backend wording from ax doctor/cloud run profiles and cloud error hints
- keep local developer setup text only when the user explicitly routes local
- bump package to 3.25.1 and lock cloud UX assertions in tests

## Proof
- node --test test/ax.test.js test/cli-smoke.test.js
- git diff --check && node --check ax
- node ./ax --dogfood-chat --loops 25 --json
- npm test (1257 pass, 0 fail)
- npm pack smoke: 3.25.1, cloud route default, doctorHasBackend=false
- tarball leak scan clean for /Users/keshavrao, atrisos-backend, local backend, backend setup