### PR TITLE
fix: 3 live CLI paper-cuts (align/skill/ax) + 3.25.2

### DIFF
--- a/bin/atris.js
+++ b/bin/atris.js
@@ -1455,7 +1455,7 @@ if (command === 'init') {
       console.error(`✗ Chat failed: ${error.message || error}`);
       process.exit(1);
     });
-} else if (command === 'fast' || (command === 'ax' && process.argv[3] === 'fast')) {
+} else if (command === 'fast' || command === 'ax') {
   atrisFastChat()
     .then(() => process.exit(0))
     .catch((error) => {

--- a/commands/align.js
+++ b/commands/align.js
@@ -466,6 +466,26 @@ async function alignHardLocalToCloud(token, biz, localDir) {
 
 async function alignAtris() {
   // Parse args
+  const printUsage = () => {
+    console.log('Usage: atris align [business] [--fix] [--hard] [--from cloud|local] [--dry-run]');
+    console.log('');
+    console.log('  atris align                   Diff current workspace against cloud (auto-detect)');
+    console.log('  atris align example-co            Diff example-co workspace');
+    console.log('  atris align example-co --fix      Fix drift (local is canonical by default)');
+    console.log('  atris align example-co --fix --hard  Force-push: nuke cloud cruft, upload local. Skips diff. Fast.');
+    console.log('  atris align example-co --fix --from cloud  Cloud is canonical: pull EC2-only, delete local extras');
+    console.log('  atris align example-co --dry-run  Show what would change, do nothing');
+  };
+
+  // Explicit help must win before we try to auto-detect a business slug,
+  // otherwise `--help` gets overwritten by the .atris/business.json fallback
+  // and the command attempts a real align instead of printing usage.
+  const firstArg = process.argv[3];
+  if (firstArg === '--help' || firstArg === '-h' || firstArg === 'help') {
+    printUsage();
+    process.exit(0);
+  }
+
   let slug = process.argv[3];
   if (!slug || slug.startsWith('-')) {
     const bizFile = path.join(process.cwd(), '.atris', 'business.json');
@@ -475,15 +495,8 @@ async function alignAtris() {
     if (!slug || slug.startsWith('-')) slug = null;
   }
 
-  if (!slug || slug === '--help' || slug === '-h' || slug === 'help') {
-    console.log('Usage: atris align [business] [--fix] [--hard] [--from cloud|local] [--dry-run]');
-    console.log('');
-    console.log('  atris align                   Diff current workspace against cloud (auto-detect)');
-    console.log('  atris align example-co            Diff example-co workspace');
-    console.log('  atris align example-co --fix      Fix drift (local is canonical by default)');
-    console.log('  atris align example-co --fix --hard  Force-push: nuke cloud cruft, upload local. Skips diff. Fast.');
-    console.log('  atris align example-co --fix --from cloud  Cloud is canonical: pull EC2-only, delete local extras');
-    console.log('  atris align example-co --dry-run  Show what would change, do nothing');
+  if (!slug) {
+    printUsage();
     process.exit(0);
   }
 

--- a/commands/skill.js
+++ b/commands/skill.js
@@ -622,15 +622,19 @@ curl -s "https://api.atris.ai/api/integrations/YOUR_INTEGRATION/items" \\
 // --- CREATE subcommand ---
 
 function skillCreate(nameArg, ...flags) {
-  if (!nameArg) {
-    console.error('Usage: atris skill create <name> [--integration] [--description="..."] [--local]');
-    console.error('');
-    console.error('Examples:');
-    console.error('  atris skill create daily-standup');
-    console.error('  atris skill create email-outreach --integration');
-    console.error('  atris skill create example-co/bol-processor --integration');
-    console.error('  atris skill create my-skill --local     # project only, skip system dirs');
-    process.exit(1);
+  // A flag-shaped first arg is not a skill name (e.g. `skill create --help`);
+  // show usage instead of creating a junk folder named "--help".
+  const wantsHelp = nameArg === '--help' || nameArg === '-h' || nameArg === 'help';
+  if (!nameArg || nameArg.startsWith('-')) {
+    const out = wantsHelp ? console.log : console.error;
+    out('Usage: atris skill create <name> [--integration] [--description="..."] [--local]');
+    out('');
+    out('Examples:');
+    out('  atris skill create daily-standup');
+    out('  atris skill create email-outreach --integration');
+    out('  atris skill create example-co/bol-processor --integration');
+    out('  atris skill create my-skill --local     # project only, skip system dirs');
+    process.exit(wantsHelp ? 0 : 1);
   }
 
   const isIntegration = flags.includes('--integration');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.25.1",
+  "version": "3.25.2",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -595,6 +595,44 @@ test('default entry routes active work before completed history', () => {
   }
 });
 
+test('skill create rejects flag-shaped names instead of making a junk folder', () => {
+  const dir = makeTempDir();
+  try {
+    const res = runCli(['skill', 'create', '--help'], { cwd: dir });
+    assert.match(res.stdout + res.stderr, /Usage: atris skill create/);
+    // The bug: it used to create atris/skills/--help/SKILL.md.
+    assert.ok(!fs.existsSync(path.join(dir, 'atris', 'skills', '--help')), 'must not create a "--help" skill folder');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('align --help prints usage even when a business is bound', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, '.atris'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.atris', 'business.json'), JSON.stringify({ slug: 'test-co' }), 'utf8');
+    const res = runCli(['align', '--help'], { cwd: dir });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Usage: atris align/);
+    // The bug: --help got overwritten by the bound slug and it tried a real align.
+    assert.doesNotMatch(res.stdout + res.stderr, /Aligning test-co/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('bare ax shows usage instead of "Unknown command"', () => {
+  const dir = makeTempDir();
+  try {
+    const res = runCli(['ax'], { cwd: dir });
+    assert.doesNotMatch(res.stdout + res.stderr, /Unknown command/);
+    assert.match(res.stdout + res.stderr, /atris ax fast/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('help lists essential commands', () => {
   const dir = makeTempDir();
   try {


### PR DESCRIPTION
## What

Three user-facing bugs are live in shipped 3.25.1. This fixes all three and bumps to 3.25.2.

| command | before | after |
|---|---|---|
| `atris align --help` | tried a real align and exited 1 when a business was bound (`--help` got overwritten by the auto-detected slug) | prints usage |
| `atris skill create --help` | created a junk `atris/skills/--help/SKILL.md` folder | prints usage, creates nothing |
| `atris ax` (bare) | `Unknown command: ax` (the usage branch was unreachable dead code) | prints `Usage: atris ax fast "message"` |

## Proof

- Added cli-smoke regression tests for all three (they fail on master, pass here).
- Full suite green in a clean CI env: **1260 / 1260 pass**.

## Notes

The crash fix for `isAtrisMetaQuestion` (which broke `atris "<plain English>"`) already landed on master in 3.25.x; this PR is only the three remaining paper-cuts.