### PR TITLE
fix: stop publish.yml false-failing on npm latest propagation lag

### DIFF
--- a/scripts/publish-atris-release.js
+++ b/scripts/publish-atris-release.js
@@ -158,8 +158,11 @@ function sleepMs(ms) {
 }
 
 function verifyPublishedVersionWithRetry(version, runner = spawnSync, options = {}) {
-  const attempts = Math.max(1, Number(options.attempts || 6));
-  const delayMs = Math.max(0, Number(options.delayMs ?? 2000));
+  // npm's `latest` dist-tag is eventually consistent: the read CDN can lag the
+  // publish by well over a minute. Give it a realistic window (~60s) before we
+  // fall back to confirming the exact version landed.
+  const attempts = Math.max(1, Number(options.attempts || 12));
+  const delayMs = Math.max(0, Number(options.delayMs ?? 5000));
   let verification = null;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     verification = {
@@ -178,6 +181,15 @@ function renderPublishVerification(verification) {
     return `Verified npm latest: atris@${verification.actual} gitHead ${verification.gitHead || 'unknown'}\n`;
   }
   return `npm latest verification failed: expected ${verification.expected || 'unknown'}, got ${verification.actual || verification.error || 'unknown'}\n`;
+}
+
+function renderPublishLatestLag(version, verification) {
+  return [
+    `Published atris@${version} to npm (confirmed on the registry).`,
+    `The "latest" dist-tag still reads ${verification.actual || 'an older version'}; it is propagating and will catch up.`,
+    'Treating the release as successful: npm publish already succeeded and the version is live.',
+    '',
+  ].join('\n');
 }
 
 function publishAtrisRelease(args = process.argv.slice(2), runner = spawnSync, options = {}) {
@@ -213,10 +225,20 @@ function publishAtrisRelease(args = process.argv.slice(2), runner = spawnSync, o
       attempts: options.verificationAttempts,
       delayMs: options.verificationDelayMs,
     });
-    const output = renderPublishVerification(verification);
-    if (verification.ok) process.stdout.write(output);
-    else process.stderr.write(output);
-    return verification.ok ? 0 : 1;
+    if (verification.ok) {
+      process.stdout.write(renderPublishVerification(verification));
+      return 0;
+    }
+    // npm publish already succeeded; the latest read-back just lagged. Confirm the
+    // exact version actually landed before failing the job — a red CI for a release
+    // that is live on the registry is a false negative, and you cannot un-publish.
+    const landed = checkVersionAvailability(version, runner);
+    if (landed.reason === 'version_exists') {
+      process.stdout.write(renderPublishLatestLag(version, verification));
+      return 0;
+    }
+    process.stderr.write(renderPublishVerification(verification));
+    return 1;
   }
   return typeof result.status === 'number' ? result.status : 1;
 }
@@ -234,6 +256,7 @@ module.exports = {
   publishAtrisRelease,
   renderOtpHelp,
   renderPublishVerification,
+  renderPublishLatestLag,
   renderTrustedPublishHelp,
   renderVersionAvailabilityFailure,
   verifyPublishedVersion,

--- a/test/publish-release.test.js
+++ b/test/publish-release.test.js
@@ -14,6 +14,7 @@ const {
   publishAtrisRelease,
   renderOtpHelp,
   renderPublishVerification,
+  renderPublishLatestLag,
   renderTrustedPublishHelp,
   renderVersionAvailabilityFailure,
   verifyPublishedVersion,
@@ -289,6 +290,66 @@ test('publish helper retries registry lag after a successful publish run', () =>
   } finally {
     process.stdout.write = originalStdoutWrite;
   }
+});
+
+test('publish helper treats a lagging npm latest as success once the version is confirmed live', () => {
+  const stdout = [];
+  const originalStdoutWrite = process.stdout.write;
+  process.stdout.write = chunk => { stdout.push(String(chunk)); return true; };
+  try {
+    let atrisAtCalls = 0;
+    const status = publishAtrisRelease([], (cmd, args) => {
+      if (args[0] === 'publish') return { status: 0, stdout: 'published\n', stderr: '' };
+      if (args[0] === 'view' && String(args[1] || '').startsWith('atris@')) {
+        atrisAtCalls += 1;
+        // 1st call is the preflight (must be unpublished to proceed);
+        // 2nd is the post-publish confirmation (now live on the registry).
+        if (atrisAtCalls === 1) return { status: 1, stderr: 'npm error code E404\n' };
+        return { status: 0, stdout: JSON.stringify({ version: packageVersion, gitHead: 'abc123' }) };
+      }
+      if (args[0] === 'view') {
+        // The latest dist-tag never catches up during this run.
+        return { status: 0, stdout: JSON.stringify({ version: '3.0.0', gitHead: 'old' }) };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
+    }, { verificationAttempts: 2, verificationDelayMs: 0 });
+    assert.equal(status, 0);
+    assert.match(stdout.join(''), /confirmed on the registry/);
+    assert.match(stdout.join(''), /propagating/);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+  }
+});
+
+test('publish helper still fails when latest lags and the version is not on the registry', () => {
+  const stderr = [];
+  const originalStderrWrite = process.stderr.write;
+  const originalStdoutWrite = process.stdout.write;
+  process.stderr.write = chunk => { stderr.push(String(chunk)); return true; };
+  process.stdout.write = () => true;
+  try {
+    const status = publishAtrisRelease([], (cmd, args) => {
+      if (args[0] === 'publish') return { status: 0, stdout: 'published\n', stderr: '' };
+      if (args[0] === 'view' && String(args[1] || '').startsWith('atris@')) {
+        return { status: 1, stderr: 'npm error code E404\n' };
+      }
+      if (args[0] === 'view') {
+        return { status: 0, stdout: JSON.stringify({ version: '3.0.0', gitHead: 'old' }) };
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
+    }, { verificationAttempts: 2, verificationDelayMs: 0 });
+    assert.equal(status, 1);
+    assert.match(stderr.join(''), /npm latest verification failed/);
+  } finally {
+    process.stderr.write = originalStderrWrite;
+    process.stdout.write = originalStdoutWrite;
+  }
+});
+
+test('renderPublishLatestLag explains the release succeeded despite the lag', () => {
+  const text = renderPublishLatestLag('9.9.9', { actual: '3.0.0' });
+  assert.match(text, /Published atris@9\.9\.9 to npm/);
+  assert.match(text, /successful/);
 });
 
 test('trusted publish workflow uses OIDC without npm token secrets', () => {


### PR DESCRIPTION
## Problem

The v3.25.2 release **published successfully** but CI went red:
```
npm latest verification failed: expected 3.25.2, got 3.25.1
```
The post-publish step reads the npm `latest` dist-tag and asserts it matches the just-published version. That read is eventually consistent and can lag the CDN by over a minute, so the existing ~10s retry window lost the race. Net effect: every release risks a false-negative red even when it shipped fine, and you cannot un-publish.

## Fix

- Widen the latest-tag retry window (~10s → ~60s).
- If `latest` still lags, confirm the **exact version** is live on the registry (reusing `checkVersionAvailability`). If it is, treat the release as successful with a clear warning and exit 0. Only a genuinely missing version fails the job.
- Regression tests for both the lag-but-live (exit 0) and lag-and-missing (exit 1) cases.

## Proof

Full suite green in a clean CI env: **1263 / 1263**. No version bump; this is release tooling and takes effect on the next release.