### PR TITLE
test: gate against imported-but-not-exported local names

### DIFF
--- a/test/import-integrity.test.js
+++ b/test/import-integrity.test.js
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Guards the exact class of bug that shipped a crash once: a destructured import
+// of a name the target module no longer exports. `const { foo } = require('./x')`
+// silently yields `undefined`, then `foo(...)` throws "foo is not a function" at
+// runtime — invisible to module-load and to any test that does not hit that path.
+// This walks the local source surface and asserts every destructured local import
+// actually resolves to a defined export. Pure introspection: no command is run.
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function listFiles(relDir, ext = '.js') {
+  const abs = path.join(repoRoot, relDir);
+  if (!fs.existsSync(abs)) return [];
+  return fs.readdirSync(abs)
+    .filter((f) => f.endsWith(ext))
+    .map((f) => path.join(relDir, f));
+}
+
+function sourceFiles() {
+  return [
+    'bin/atris.js',
+    'ax',
+    ...listFiles('commands'),
+    ...listFiles('lib'),
+    ...listFiles('utils'),
+    ...listFiles('scripts'),
+  ].filter((rel) => fs.existsSync(path.join(repoRoot, rel)));
+}
+
+// const { a, b: c } = require('./x')  /  require('../x')  — local modules only.
+const DESTRUCTURE_REQUIRE = /const\s*\{([^}]+)\}\s*=\s*require\(\s*['"](\.[^'"]+)['"]\s*\)/g;
+
+function importedNames(group) {
+  return group
+    .split(',')
+    .map((piece) => piece.trim().split(':')[0].trim()) // `a: b` -> exported key `a`
+    .filter((name) => name && !name.startsWith('...'));
+}
+
+function scanFile(rel) {
+  const abs = path.join(repoRoot, rel);
+  const src = fs.readFileSync(abs, 'utf8');
+  const dir = path.dirname(abs);
+  const problems = [];
+  let match;
+  DESTRUCTURE_REQUIRE.lastIndex = 0;
+  while ((match = DESTRUCTURE_REQUIRE.exec(src))) {
+    const names = importedNames(match[1]);
+    const relRequire = match[2];
+    let mod;
+    try {
+      mod = require(path.resolve(dir, relRequire));
+    } catch (error) {
+      problems.push(`${rel}: require('${relRequire}') throws on load -> ${error.message}`);
+      continue;
+    }
+    for (const name of names) {
+      if (mod[name] === undefined) {
+        problems.push(`${rel}: imports { ${name} } from '${relRequire}', but that module does not export it`);
+      }
+    }
+  }
+  return problems;
+}
+
+test('every destructured local import resolves to a real export', () => {
+  const files = sourceFiles();
+  assert.ok(files.length > 50, `expected to scan the source surface, only found ${files.length} files`);
+  const problems = files.flatMap(scanFile);
+  assert.deepEqual(
+    problems,
+    [],
+    `Found ${problems.length} broken local import(s) (imported name not exported -> latent runtime crash):\n  ${problems.join('\n  ')}`
+  );
+});


### PR DESCRIPTION
## Why

A refactor on a feature branch dropped `isAtrisMetaQuestion` from `lib/context-gatherer.js` while `bin/atris.js` still imported and called it. Result: `atris "<plain English>"` (the most-used entry path) crashed with `isAtrisMetaQuestion is not a function`. Module-load tests miss this (the destructured name is just `undefined`); only a test that exercises that exact path would catch it.

## What

A deterministic gate that walks the whole local source surface (bin, ax, commands, lib, utils, scripts — 111 files), finds every `const { ... } = require('./local')`, and asserts each imported name is a defined export. Pure introspection: **no command is executed**, no env, no network, no flakiness.

## Proof

- Green on master today: the entire surface resolves cleanly (this is a safe add, not a fix-then-add).
- Fails correctly when the bug is reintroduced: removing the `isAtrisMetaQuestion` export makes the test fail and name the exact broken import.
- Full suite green: **1264 / 1264**.

This is the cheapest verification gate that locks out an entire class of latent runtime crash.