### PR TITLE
feat: executable, gated proof for `atris task ready --verify`

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const os = require('os');
-const { taskProofState } = require('../lib/task-proof');
+const { taskProofState, buildVerifiedProof } = require('../lib/task-proof');
 const { evaluateAutoAccept, parseVerifyCommand } = require('../lib/auto-accept-certified');
 const { extractReceiptEvidence } = require('../lib/receipt-evidence');
 const escapeRegExp = require('../lib/escape-regexp');
@@ -96,6 +96,7 @@ atris task - durable local task state (SQLite, gitignored)
   atris task say <id> "<message>"         Add context to a task
   atris task chat <id> "<message>" [--goal "..."]  Refine a task chat + working goal
   atris task ready <id> --proof "..."      Agent proof ready; native goal can complete
+  atris task ready <id> --verify "<cmd>"   Run <cmd>; only ready if it exits 0 (executed proof)
   atris task review-chat <id> [--as <owner>]  Start a task-owned /codex verification chat
   atris task accept <id> [--proof "..."]   Human accepts proof, marks done
   atris task auto-accept-certified --dry-run [--strict-verify] [--limit <n>]
@@ -6317,12 +6318,29 @@ function cmdReady(args) {
     console.error('atris task ready: id required');
     process.exit(2);
   }
-  const proof = flag(args, '--proof');
-  if (!proof || proof === true) {
-    console.error('atris task ready: --proof required');
+  // Two ways to prove: --proof "<note>" (claimed, pattern-checked, unchanged) or
+  // --verify "<command>" which actually RUNS the command and gates ready on exit 0,
+  // turning a claim into executed evidence. --verify can carry an optional --proof note.
+  const proofFlag = flag(args, '--proof');
+  const verifyFlag = flag(args, '--verify');
+  let proof = typeof proofFlag === 'string' ? proofFlag : '';
+  if (typeof verifyFlag === 'string' && verifyFlag.trim()) {
+    const verified = buildVerifiedProof(verifyFlag, proof, undefined, { cwd: process.cwd() });
+    if (!verified.ok) {
+      const detail = verified.exit != null ? ` (exit ${verified.exit})` : (verified.signal ? ` (signal ${verified.signal})` : '');
+      console.error(`atris task ready: verifier failed${detail}: ${verifyFlag}`);
+      if (verified.output) console.error(verified.output);
+      else if (verified.error) console.error(verified.error);
+      process.exit(1);
+    }
+    proof = verified.proof;
+    if (!wantsJson(args)) console.log(`✓ verified: \`${verifyFlag}\` exited 0`);
+  }
+  if (!proof) {
+    console.error('atris task ready: --proof or --verify required');
     process.exit(2);
   }
-  requireMeaningfulTaskProof('atris task ready', String(proof));
+  requireMeaningfulTaskProof('atris task ready', proof);
   const lesson = flag(args, '--lesson') || '';
   const nextTaskInput = normalizeReviewNextTaskInput(typeof flag(args, '--next') === 'string' ? flag(args, '--next') : '');
   const actor = String(flag(args, '--as') || DEFAULT_OWNER);

--- a/lib/task-proof.js
+++ b/lib/task-proof.js
@@ -37,7 +37,42 @@ function taskProofLooksMeaningful(proof) {
   return taskProofState(proof).ok;
 }
 
+function tailText(text, max = 400) {
+  const trimmed = String(text || '').trim();
+  if (trimmed.length <= max) return trimmed;
+  return `...${trimmed.slice(-max)}`;
+}
+
+// Run a verifier command and turn its real result into proof. This is the
+// difference between a CLAIMED proof ("npm test passed", which taskProofState
+// happily pattern-matches even if nothing ran) and a VERIFIED proof: the command
+// actually executed and exited 0. On failure it returns ok:false so the caller
+// can refuse to mark the task ready. The returned proof string is prefixed
+// `[verified]` and names the command + exit, so it also passes taskProofState.
+function buildVerifiedProof(verifyCmd, baseProof = '', runner, options = {}) {
+  const cmd = String(verifyCmd || '').trim();
+  if (!cmd) return { ok: false, reason: 'verify_command_required' };
+  const run = runner || require('child_process').spawnSync;
+  const result = run('bash', ['-lc', cmd], {
+    cwd: options.cwd || process.cwd(),
+    encoding: 'utf8',
+    timeout: options.timeoutMs || 120000,
+  });
+  if (result.error) {
+    return { ok: false, reason: 'verifier_spawn_failed', error: result.error.message, cmd };
+  }
+  const output = tailText(`${result.stdout || ''}${result.stderr || ''}`);
+  if (result.status !== 0) {
+    return { ok: false, reason: 'verifier_failed', exit: result.status, signal: result.signal || null, output, cmd };
+  }
+  const base = compactWhitespace(baseProof);
+  // Phrase so the result also satisfies taskProofState ("verified ... passed").
+  const proof = `[verified] \`${cmd}\` passed (exit 0)${base ? ` — ${base}` : ''}${output ? `\n${output}` : ''}`;
+  return { ok: true, exit: 0, output, cmd, proof };
+}
+
 module.exports = {
   taskProofLooksMeaningful,
   taskProofState,
+  buildVerifiedProof,
 };

--- a/test/task-proof.test.js
+++ b/test/task-proof.test.js
@@ -4,7 +4,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const { spawnSync } = require('node:child_process');
-const { taskProofLooksMeaningful, taskProofState } = require('../lib/task-proof');
+const { taskProofLooksMeaningful, taskProofState, buildVerifiedProof } = require('../lib/task-proof');
 const { scrubAgentEnv } = require('./helpers/agent-env');
 
 const CLI = path.join(__dirname, '..', 'bin', 'atris.js');
@@ -52,6 +52,59 @@ test('task proof helper accepts commands, verifier results, receipts, and human 
     'Human approved: reviewed by keshavrao',
   ]) {
     assert.equal(taskProofLooksMeaningful(proof), true, `${JSON.stringify(proof)} should be accepted`);
+  }
+});
+
+test('buildVerifiedProof turns a passing command into executed proof', () => {
+  const calls = [];
+  const result = buildVerifiedProof('npm test', 'fixed the parser', (cmd, args, opts) => {
+    calls.push([cmd, args]);
+    return { status: 0, stdout: 'ok 42 passed\n', stderr: '' };
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.exit, 0);
+  assert.match(result.proof, /^\[verified\] `npm test` passed \(exit 0\)/);
+  assert.match(result.proof, /fixed the parser/);
+  // The synthesized proof must itself satisfy the proof gate.
+  assert.equal(taskProofLooksMeaningful(result.proof), true);
+  // It actually ran the command via bash.
+  assert.deepEqual(calls[0][0], 'bash');
+  assert.deepEqual(calls[0][1], ['-lc', 'npm test']);
+});
+
+test('buildVerifiedProof refuses to vouch for a failing or empty command', () => {
+  const failing = buildVerifiedProof('npm test', '', () => ({ status: 1, stdout: '', stderr: '3 failing\n' }));
+  assert.equal(failing.ok, false);
+  assert.equal(failing.reason, 'verifier_failed');
+  assert.equal(failing.exit, 1);
+
+  const empty = buildVerifiedProof('', 'note', () => ({ status: 0 }));
+  assert.equal(empty.ok, false);
+  assert.equal(empty.reason, 'verify_command_required');
+});
+
+test('task ready --verify runs the command and gates on its exit code', () => {
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, 'tasks.db');
+  const env = { ATRIS_TASKS_DB: dbPath, ATRIS_AGENT_ID: 'codex' };
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    // Failing verifier must block ready (no --proof escape hatch was given).
+    const failAdd = runCli(['task', 'add', 'Verify must run', '--json'], { cwd: dir, env });
+    assert.equal(failAdd.status, 0, failAdd.stderr);
+    const failRef = JSON.parse(failAdd.stdout).task.display_id;
+    const failReady = runCli(['task', 'ready', failRef, '--verify', 'exit 3'], { cwd: dir, env });
+    assert.equal(failReady.status, 1);
+    assert.match(failReady.stderr, /verifier failed/);
+
+    // Passing verifier marks ready with executed proof.
+    const okReady = runCli(['task', 'ready', failRef, '--verify', 'true', '--json'], { cwd: dir, env });
+    assert.equal(okReady.status, 0, okReady.stderr);
+    const okTask = JSON.parse(okReady.stdout).task;
+    assert.match(okTask.review.proof, /\[verified\] `true` passed \(exit 0\)/);
+  } finally {
+    cleanupTempDir(dir);
   }
 });
 


### PR DESCRIPTION
## Why (Phase 1 of the foundation roadmap)

Proof was only **pattern-matched**: `atris task ready --proof "npm test passed"` was accepted even if npm test never ran. Durable "done" was a claim, not evidence — the core verification-gate leak.

## What

`atris task ready <id> --verify "<command>"` now **runs the command** and marks the task ready only if it exits 0. The stored proof becomes executed evidence, prefixed `[verified]`, so reviewers / auto-accept can distinguish a verified proof from a claimed one. `--verify` can carry an optional `--proof` note.

**Fully backward compatible:** `--proof` alone behaves exactly as before; `--verify` is purely additive. The live fleet is unaffected until it opts in.

## Proof

- `buildVerifiedProof` in `lib/task-proof.js` with unit tests (passing cmd -> executed proof that itself satisfies the proof gate; failing/empty cmd -> refused).
- End-to-end: `task ready --verify "exit 3"` blocks ready; `--verify "true"` stores executed proof.
- Full suite green: **1267 / 1267**.

Next on the roadmap: make verified proof the default the loop requires (a deliberate fleet-coordination step), then close the loop receipt.