### PR TITLE
feat: close the loop receipt + make loop-health honest (Phase 2)

### DIFF
--- a/commands/brain.js
+++ b/commands/brain.js
@@ -32,13 +32,15 @@ const CORE_STATE_FILES = [
   'agents.jsonl',
   'approvals.jsonl',
 ];
+// Loop health measures loops that actually emit receipts. Channels with no writer
+// anywhere in the codebase were dropped so the dashboard reports real failures, not
+// never-built aspirations: "Overnight RL" duplicated the active Pulse AGI loop, and
+// "Company YC" had no data source. "Master loop" is now emitted by `atris run`.
 const LOOP_HEALTH_CHANNELS = [
   { label: 'Task plane', files: ['task_events.jsonl', 'tasks.projection.json'] },
-  { label: 'Overnight RL', files: ['overnight_rl_self_heal.jsonl'] },
   { label: 'Career XP', files: ['career_xp_receipts.jsonl', 'career_xp.projection.json', 'gm_xp.projection.json'] },
   { label: 'Master loop', files: ['master_loop_events.jsonl'] },
   { label: 'Missions', files: ['mission_events.jsonl', 'missions.jsonl'] },
-  { label: 'Company YC', files: ['company_yc_wow_events.jsonl', 'company_yc_wow_latest.json'] },
   { label: 'Codex goal', files: ['codex_goal.json'] },
   { label: 'Pulse AGI', files: ['pulse_agi_loop_receipts.jsonl'] },
 ];

--- a/commands/run.js
+++ b/commands/run.js
@@ -281,6 +281,35 @@ function hasWork(atrisDir) {
 }
 
 /**
+ * Append a durable Master-loop receipt for one cycle's review verdict.
+ *
+ * Closes the loop: until now the validator's pass/fail lived only in RAM
+ * (carried to the next cycle's plan), so a crash lost it and `atris brain`
+ * could never see that the review step ran. This persists the verdict to
+ * .atris/state/master_loop_events.jsonl, the channel the brain reads for
+ * loop health. Best-effort: telemetry must never fail the run.
+ */
+function appendMasterLoopReceipt(receipt, stateDir = path.join(process.cwd(), '.atris', 'state')) {
+  try {
+    fs.mkdirSync(stateDir, { recursive: true });
+    const row = {
+      ts: new Date().toISOString(),
+      run_stamp: receipt.runStamp || null,
+      cycle: receipt.cycle,
+      verdict: receipt.verdict,
+      plan_ms: receipt.timing ? receipt.timing.plan : null,
+      do_ms: receipt.timing ? receipt.timing.do : null,
+      review_ms: receipt.timing ? receipt.timing.review : null,
+      review_summary: String(receipt.reviewOutput || '').replace(/\s+/g, ' ').trim().slice(0, 280),
+    };
+    fs.appendFileSync(path.join(stateDir, 'master_loop_events.jsonl'), JSON.stringify(row) + '\n');
+    return row;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
  * Log completion to journal
  */
 function logRunCompletion(cycles, startTime, cycleTimings = []) {
@@ -452,6 +481,10 @@ async function runAtris(options = {}) {
 
       // Carry the review output into the next cycle's plan — closes the loop
       lastReviewOutput = reviewOutput;
+
+      // Persist the verdict durably so the brain can see the review actually ran.
+      const verdict = reviewOutput.includes('[REVIEW_FAILED]') ? 'fail' : 'pass';
+      appendMasterLoopReceipt({ runStamp, cycle, verdict, timing, reviewOutput });
 
       if (reviewOutput.includes('[REVIEW_FAILED]')) {
         console.log(verbose
@@ -989,4 +1022,4 @@ function diffRunLogs(args = []) {
   }
 }
 
-module.exports = { runAtris, getRunLogDir, getRunLogPath, writePhaseToRunLog, listRunLogs, pruneRunLogs, searchRunLogs, statsRunLogs, exportRunLogs, diffRunLogs, buildRunPrompt };
+module.exports = { runAtris, getRunLogDir, getRunLogPath, writePhaseToRunLog, appendMasterLoopReceipt, listRunLogs, pruneRunLogs, searchRunLogs, statsRunLogs, exportRunLogs, diffRunLogs, buildRunPrompt };

--- a/test/run-glass-logs.test.js
+++ b/test/run-glass-logs.test.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { getRunLogDir, getRunLogPath, writePhaseToRunLog, listRunLogs, pruneRunLogs, searchRunLogs, statsRunLogs, exportRunLogs, diffRunLogs, buildRunPrompt } = require('../commands/run');
+const { getRunLogDir, getRunLogPath, writePhaseToRunLog, appendMasterLoopReceipt, listRunLogs, pruneRunLogs, searchRunLogs, statsRunLogs, exportRunLogs, diffRunLogs, buildRunPrompt } = require('../commands/run');
 
 // --- Source-level: glass run log helpers exist and are wired ---
 
@@ -783,4 +783,61 @@ test('run.js carries lastReviewOutput across cycles in the loop', () => {
   assert.match(RUN_SRC, /let lastReviewOutput = null/);
   assert.match(RUN_SRC, /priorCycleReview: lastReviewOutput/);
   assert.match(RUN_SRC, /lastReviewOutput = reviewOutput/);
+});
+
+// --- Master-loop receipt: the review verdict is now durable, not RAM-only ---
+
+test('run.js persists each cycle review verdict after carrying it forward', () => {
+  assert.match(RUN_SRC, /appendMasterLoopReceipt\(\{ runStamp, cycle, verdict, timing, reviewOutput \}\)/);
+  assert.match(RUN_SRC, /const verdict = reviewOutput\.includes\('\[REVIEW_FAILED\]'\) \? 'fail' : 'pass'/);
+});
+
+test('appendMasterLoopReceipt writes a durable jsonl row the brain can read', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-master-loop-'));
+  try {
+    const stateDir = path.join(dir, '.atris', 'state');
+    const row = appendMasterLoopReceipt(
+      { runStamp: 'abc123', cycle: 2, verdict: 'pass', timing: { plan: 1000, do: 2000, review: 3000 }, reviewOutput: '[REVIEW_COMPLETE] tests green' },
+      stateDir
+    );
+    assert.equal(row.verdict, 'pass');
+    assert.equal(row.cycle, 2);
+    assert.equal(row.review_ms, 3000);
+    const file = path.join(stateDir, 'master_loop_events.jsonl');
+    assert.ok(fs.existsSync(file), 'master_loop_events.jsonl should exist');
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean);
+    assert.equal(lines.length, 1);
+    const parsed = JSON.parse(lines[0]);
+    assert.equal(parsed.run_stamp, 'abc123');
+    assert.equal(parsed.verdict, 'pass');
+    assert.match(parsed.review_summary, /tests green/);
+    assert.ok(parsed.ts, 'row carries a timestamp');
+    // A second cycle appends, not overwrites.
+    appendMasterLoopReceipt({ runStamp: 'abc123', cycle: 3, verdict: 'fail', timing: { plan: 1, do: 1, review: 1 }, reviewOutput: '[REVIEW_FAILED] broke' }, stateDir);
+    const after = fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean);
+    assert.equal(after.length, 2);
+    assert.equal(JSON.parse(after[1]).verdict, 'fail');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('appendMasterLoopReceipt never throws on a bad state dir (best-effort telemetry)', () => {
+  // Point at a path under a regular file so mkdir fails; must return null, not throw.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-ml-bad-'));
+  const fileAsDir = path.join(tmp, 'blocker');
+  fs.writeFileSync(fileAsDir, 'x');
+  try {
+    const result = appendMasterLoopReceipt({ cycle: 1, verdict: 'pass' }, path.join(fileAsDir, 'state'));
+    assert.equal(result, null);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('brain.js loop health drops writer-less channels and keeps the wired master loop', () => {
+  const BRAIN_SRC = fs.readFileSync(path.join(__dirname, '..', 'commands', 'brain.js'), 'utf8');
+  assert.doesNotMatch(BRAIN_SRC, /label: 'Overnight RL'/);
+  assert.doesNotMatch(BRAIN_SRC, /label: 'Company YC'/);
+  assert.match(BRAIN_SRC, /label: 'Master loop'/);
 });


### PR DESCRIPTION
## Why (Phase 2 of the foundation roadmap)

Two cracks in the closed loop:
1. `atris run`'s review verdict lived only in RAM (carried to the next cycle's plan). A crash lost it, and `atris brain` could never see that the review step ran.
2. 3 of 8 loop-health channels had **no writer anywhere in the repo** — the brain reported never-built aspirations as failures (false negatives).

## What

- `atris run` appends a durable receipt per cycle to `.atris/state/master_loop_events.jsonl` (cycle, verdict, phase timings, summary). Best-effort: telemetry never fails the run.
- Loop-health drops the two genuinely writer-less channels — **Overnight RL** (a duplicate of the active Pulse AGI loop) and **Company YC** (no data source) — and keeps **Master loop**, which is now actually emitted.

## Proof

- `appendMasterLoopReceipt` unit-tested: writes a valid jsonl row, appends (not overwrites), never throws on a bad dir.
- Source + behavior tests: run.js persists the verdict after carrying it forward; brain drops the dead channels, keeps Master loop.
- `atris brain` compiles cleanly with the honest channel list. Full suite green: **1271 / 1271**.