### PR TITLE
test: make completed-history default-entry test hermetic (Phase 3)

### DIFF
--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -554,6 +554,13 @@ test('default entry treats completed-only TODO rows as history', () => {
     runCli(['init'], { cwd: dir, input: '\n' });
     fs.writeFileSync(path.join(dir, 'atris', 'MAP.md'), '# MAP.md\n\n## By-Feature\n- example: bin/atris.js:1\n', 'utf8');
 
+    // Mark first-contact done so the default entry renders the history view
+    // instead of the (correct, but unrelated) onboarding gatherer that fires
+    // for a profile-less workspace with no active work. Keeps this test hermetic.
+    const profilePath = path.join(dir, '.atris', 'state', 'context_profile.json');
+    fs.mkdirSync(path.dirname(profilePath), { recursive: true });
+    fs.writeFileSync(profilePath, JSON.stringify({ first_answer: 'coding', source: 'first_contact' }), 'utf8');
+
     const todoPath = path.join(dir, 'atris', 'TODO.md');
     fs.writeFileSync(
       todoPath,


### PR DESCRIPTION
## Why (Phase 3 of the foundation roadmap: tests that don't lie)

`default entry treats completed-only TODO rows as history` passed in the full suite but **failed in isolation and inside an agent session**. With no context profile and no active work, bare `atris` correctly shows the first-contact onboarding gatherer, not the history view. The test never established "not first-contact", so its pass/fail depended on ambient state — a test that lies about isolation.

## What

Seed a context profile (`first_answer`) in the test's temp workspace so it deterministically exercises the history-view rendering it actually checks. **Product behavior is unchanged** — only the test's setup.

## Proof

Full suite is now **1271 / 1271 with agent markers present**, identical to clean CI (was 1270/1271). The CLI's agent-proof-only tests were already robust; this was the last env/isolation-fragile test.