### PR TITLE
fix: recover deck/card/reel/slop/site/theme dropped by the 3.25 release lineage (3.26.0)

### DIFF
--- a/bin/atris.js
+++ b/bin/atris.js
@@ -826,7 +826,7 @@ if (command === '2' && ['fast', 'pro'].includes(String(firstCommandArg || '').to
 const knownCommands = ['init', 'log', 'now', 'radar', 'ctop', 'status', 'analytics', 'visualize', 'brain', 'brainstorm', 'autopilot', 'run', 'plan', 'do', 'review', 'release',
                        'activate', '_activate', 'agent', 'chat', 'fast', 'ax', 'console', 'serve', 'login', 'logout', 'whoami', 'switch', 'use', 'accounts', '_resolve', '_profile-email', '_switch-session', 'shell-init', 'update', 'upgrade', 'version', 'help', 'next', 'atris',
                        'clean', 'verify', 'search', 'skill', 'member', 'codex-goal', 'app', 'apps', 'learn', 'lesson', 'plugin', 'experiments', 'receipt', 'proof', 'openclaw', 'pull', 'push', 'live', 'align', 'terminal', 'computer', 'diff', 'business', 'sync', 'youtube',
-                       'ingest', 'query', 'lint', 'loop', 'pulse', 'task', 'mission', 'probe', 'worktree', 'aeo', 'improve', 'xp', 'play', 'gm', 'x', 'recap',
+                       'ingest', 'query', 'lint', 'loop', 'pulse', 'task', 'mission', 'probe', 'worktree', 'aeo', 'slop', 'deck', 'site', 'theme', 'card', 'reel', 'improve', 'xp', 'play', 'gm', 'x', 'recap',
                        'gmail', 'calendar', 'twitter', 'slack', 'imessage', 'integrations', 'setup', 'clean-workspace', 'cw',
                        'fork', 'browse', 'publish', 'sleep', 'wake', 'feedback', 'errors', 'wiki', 'code-review', 'cr', 'soul', 'fleet', 'compile', 'spaceship'];
 
@@ -2058,6 +2058,36 @@ if (command === 'init') {
   const args = process.argv.slice(4);
   Promise.resolve(require('../commands/compile').compileCommand(subcommand, ...args))
     .then(() => process.exit(process.exitCode || 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'slop') {
+  // Slop: deterministic frontend-slop detector (no LLM). Exit 1 = slop found, for CI + the autopilot gate.
+  Promise.resolve(require('../commands/slop').slopCommand(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'deck') {
+  // Deck: premium Google Slides from a plain content spec, via the Atris deck engine (anti-slop design system).
+  Promise.resolve(require('../commands/deck').run(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'site') {
+  // Site: beautiful static site from a folder of markdown, in the anti-slop design system.
+  Promise.resolve(require('../commands/site').run(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'theme') {
+  // Theme: brand themes (.atris/theme.json) for the whole design system (deck/html/site).
+  Promise.resolve(require('../commands/theme').run(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'card') {
+  // Card: one line of text into an on-brand image (uses your theme + the design system).
+  Promise.resolve(require('../commands/card').run(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'reel') {
+  // Reel: one line of text into a short on-brand video (an animated card; frames via Chrome + ffmpeg).
+  Promise.resolve(require('../commands/reel').run(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'receipt' || command === 'proof' || command === 'openclaw') {
   const subcommand = process.argv[3];

--- a/commands/card.js
+++ b/commands/card.js
@@ -1,0 +1,121 @@
+// atris card — one line of text -> a beautiful, on-brand image (your theme).
+//
+//   atris card "Ship faster" --kind statement --theme brand --size og
+//   atris card "It just works" --kind quote --by "a happy user"
+//   atris card --kind stat --number "10x" --label "faster reviews"
+//
+// Writes an .html (always) and a .png (when headless Chrome is available).
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync, spawnSync } = require('child_process');
+const { buildCard, SIZES, KINDS } = require('../lib/card');
+
+function parseFlags(argv) {
+  const flags = {}; const pos = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--html-only') { flags.htmlOnly = true; continue; }
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next != null && !next.startsWith('--')) { flags[key] = next; i++; } else flags[key] = true;
+      continue;
+    }
+    pos.push(a);
+  }
+  return { flags, pos };
+}
+
+// find an installed Chrome/Chromium without adding a dependency
+function findChrome() {
+  if (process.env.CHROME_PATH && fs.existsSync(process.env.CHROME_PATH)) return process.env.CHROME_PATH;
+  const macApps = [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+  ];
+  for (const p of macApps) if (fs.existsSync(p)) return p;
+  for (const name of ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser', 'chrome']) {
+    const r = spawnSync('command', ['-v', name], { shell: true, encoding: 'utf8' });
+    if (r.status === 0 && r.stdout.trim()) return r.stdout.trim();
+  }
+  return null;
+}
+
+function renderPng(chrome, html, width, height, outPng) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-card-'));
+  const htmlFile = path.join(tmp, 'card.html');
+  fs.writeFileSync(htmlFile, html);
+  const args = [
+    '--headless=new', '--disable-gpu', '--hide-scrollbars',
+    '--force-device-scale-factor=2',
+    `--window-size=${width},${height}`,
+    '--virtual-time-budget=4000',
+    `--screenshot=${outPng}`,
+    `file://${htmlFile}`,
+  ];
+  execFileSync(chrome, args, { stdio: 'ignore', timeout: 60000 });
+  return fs.existsSync(outPng);
+}
+
+function run(argv) {
+  const { flags, pos } = parseFlags(argv);
+
+  if (pos[0] === 'help' || flags.help) {
+    console.log(`\n  atris card — one line of text into an on-brand image\n
+  atris card "Your headline" [--kind statement|quote|stat] [--theme <name>] [--size og|wide|square|story]
+  flags: --sub --kicker --by --number --label --brand --version --out <file.png> --html-only\n
+  examples:
+    atris card "Design that builds itself" --kicker "Atris v3.23.0" --theme brand
+    atris card "It just works." --kind quote --by "a founder" --size square
+    atris card --kind stat --number "1260" --label "tests, all green"\n`);
+    return 0;
+  }
+
+  const text = pos.join(' ').trim();
+  const kind = flags.kind || 'statement';
+  if (!KINDS.includes(kind)) { console.error(`  unknown kind "${kind}". try: ${KINDS.join(', ')}`); return 2; }
+  if (flags.size && !SIZES[flags.size]) { console.error(`  unknown size "${flags.size}". try: ${Object.keys(SIZES).join(', ')}`); return 2; }
+  if (kind === 'stat' && !flags.number && !text) { console.error('  stat cards need --number (e.g. --number "10x")'); return 2; }
+  if (kind !== 'stat' && !text) { console.error('  give the card some text: atris card "Your headline"'); return 2; }
+
+  const spec = {
+    kind, text, headline: text,
+    theme: flags.theme, size: flags.size,
+    sub: flags.sub, kicker: flags.kicker, by: flags.by,
+    number: flags.number, label: flags.label,
+    brand: flags.brand, version: flags.version,
+  };
+
+  let card;
+  try { card = buildCard(spec); }
+  catch (e) { console.error(`  could not build card: ${e.message}`); return 1; }
+
+  const base = (flags.out ? String(flags.out).replace(/\.png$/i, '') : `card-${kind}-${card.theme}-${card.size}`);
+  const outPng = path.resolve(`${base}.png`);
+  const outHtml = path.resolve(`${base}.html`);
+  fs.writeFileSync(outHtml, card.html);
+
+  if (flags.htmlOnly) {
+    console.log(`\n  ✓ ${card.kind} card (${card.width}x${card.height}, theme ${card.theme})\n    html: ${outHtml}\n    open it, or render a png with Chrome installed.\n`);
+    return 0;
+  }
+
+  const chrome = findChrome();
+  if (!chrome) {
+    console.log(`\n  ✓ wrote html: ${outHtml}\n    no Chrome found for png. open the html, or set CHROME_PATH and re-run.\n`);
+    return 0;
+  }
+  try {
+    renderPng(chrome, card.html, card.width, card.height, outPng);
+    console.log(`\n  ✓ ${card.kind} card, ${card.width}x${card.height}, theme ${card.theme}\n    ${outPng}\n`);
+    return 0;
+  } catch (e) {
+    console.log(`\n  ! png render failed (${e.message.split('\n')[0]})\n    html is ready: ${outHtml}\n`);
+    return 0;
+  }
+}
+
+module.exports = { run };

--- a/commands/deck.js
+++ b/commands/deck.js
@@ -1,0 +1,184 @@
+// atris deck — generate a premium, on-brand Google Slides deck from a plain
+// content spec, using the Atris deck engine (lib/slides-deck.js). The pitch:
+// describe the deck, get the design system for free. No Arial-on-white slop.
+//
+// Usage:
+//   atris deck themes                         list design themes
+//   atris deck build <spec.json> [--title T] [--theme terminal|paper] [--update ID]
+//   atris deck sample [--theme paper]         print a starter spec to stdout
+//
+// A spec is JSON: { theme, brand:{name,accent}, slides:[ {type,...} ] }.
+// Slide types: title, statement, columns, panel, chips, bignumber, close.
+
+const fs = require('fs');
+const https = require('https');
+const os = require('os');
+const { buildDeck, THEMES } = require('../lib/slides-deck');
+const { parseMarkdownToSpec } = require('../lib/deck-from-md');
+const { mergedThemes } = require('../lib/theme');
+
+const BASE = 'api.atris.ai';
+const PFX = '/api/integrations/google-slides';
+
+function token() {
+  try { return require(os.homedir() + '/.atris/credentials.json').token; }
+  catch { return null; }
+}
+function api(method, path, body, tok) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : null;
+    const req = https.request({ host: BASE, path: PFX + path, method,
+      headers: { Authorization: 'Bearer ' + tok, 'Content-Type': 'application/json',
+        ...(data ? { 'Content-Length': Buffer.byteLength(data) } : {}) } },
+      (res) => { let b = ''; res.on('data', (c) => (b += c)); res.on('end', () => {
+        let j; try { j = JSON.parse(b); } catch { j = b; }
+        if (res.statusCode >= 300) reject(new Error('HTTP ' + res.statusCode + ': ' + (typeof j === 'string' ? j : JSON.stringify(j)).slice(0, 600)));
+        else resolve(j); }); });
+    req.on('error', reject); if (data) req.write(data); req.end();
+  });
+}
+
+const SAMPLE = {
+  theme: 'terminal',
+  brand: { name: 'Sentinel', accent: '.' },
+  slides: [
+    { type: 'title', headline: 'Read your incidents in the **dark.**',
+      sub: "On-call shouldn't mean panic. Every alert ranked by blast radius, in one calm view.",
+      panel: { header: { title: 'Active incidents', meta: 'updated 12s ago' },
+        rows: [
+          { title: 'Checkout latency spike', sub: 'api-gateway · us-east-1', value: '42%', valueSub: 'of traffic', sev: 0, active: true },
+          { title: 'Stale read replica', sub: 'orders-db · eu-west-2', value: '8%', valueSub: 'of traffic', sev: 1 },
+          { title: 'Elevated 4xx on search', sub: 'search-svc · global', value: '1.2%', valueSub: 'of traffic', sev: 2 },
+        ], footer: { left: '3 active, 1 worth a page', right: 'View all' } } },
+    { type: 'statement', text: "On-call shouldn't mean **panic.**",
+      sub: 'So the console is calm by default. One screen, ranked by real impact.' },
+    { type: 'columns', heading: 'What makes it calm', columns: [
+      { h: 'Ranked by impact', b: 'Severity comes from real blast radius, so the top of the list is the thing to fix.' },
+      { h: 'Quiet by default', b: 'One page-worthy signal per incident. The rest stays in the log until you ask.' },
+      { h: 'Built for 3am', b: 'High contrast, keyboard-first, and readable before you are fully awake.' } ] },
+    { type: 'bignumber', number: '11 min', label: 'median time to first action', sub: 'down from 47 minutes before Sentinel.' },
+    { type: 'close', tagline: 'Read your incidents in the dark.',
+      buttons: [{ label: 'Open the console', primary: true }, { label: 'Read the docs' }], footer: 'sentinel.sh · 2026' },
+  ],
+};
+
+// shared: spec -> live deck. Returns the URL.
+async function publishDeck(spec, { title, updateId, tok }) {
+  const { requests } = buildDeck(spec, { themes: mergedThemes(THEMES) });
+  let id, firstSlide;
+  if (updateId) {
+    id = updateId;
+    const got = await api('GET', `/presentations/${id}`, null, tok);
+    const slides = got.slides || (got.presentation && got.presentation.slides) || [];
+    firstSlide = slides[0] && slides[0].objectId;
+  } else {
+    const pres = await api('POST', '/presentations', { title }, tok);
+    id = pres.presentationId || pres.id || (pres.presentation && pres.presentation.presentationId);
+    const slides = pres.slides || (pres.presentation && pres.presentation.slides) || [];
+    firstSlide = slides[0] && slides[0].objectId;
+  }
+  const reqs = firstSlide ? [...requests, { deleteObject: { objectId: firstSlide } }] : requests;
+  console.log(`  building ${spec.slides.length} slides (${spec.theme}) · ${reqs.length} ops...`);
+  await api('POST', `/presentations/${id}/batch-update`, { requests: reqs }, tok);
+  return `https://docs.google.com/presentation/d/${id}/edit`;
+}
+
+// beautiful HTML output (page or AppBlock JSON) from a content spec
+function outputHtml(spec, argv, srcLabel) {
+  const { renderHtml, renderBlock, THEMES: HTML_THEMES } = require('../lib/html-render');
+  const themes = mergedThemes(HTML_THEMES);
+  if (!themes[spec.theme]) spec.theme = 'atris';
+  const title = flag(argv, '--title');
+  if (hasFlag(argv, '--block')) {
+    console.log(JSON.stringify(renderBlock(spec, { title, themes }), null, 2));
+    return 0;
+  }
+  const html = renderHtml(spec, { title, themes });
+  const out = flag(argv, '--out');
+  if (out) { fs.writeFileSync(out, html); console.log(`\n  ✓ html written: ${out}${srcLabel ? ` (from ${srcLabel})` : ''}\n`); }
+  else process.stdout.write(html + '\n');
+  return 0;
+}
+
+async function run(argv) {
+  const sub = argv[0];
+
+  if (sub === 'from') {
+    const docPath = argv.slice(1).find((a) => !a.startsWith('-'));
+    if (!docPath) { console.error('  usage: atris deck from <doc.md> [--theme x] [--brand Name] [--build] [--title T]'); return 2; }
+    let md;
+    try { md = fs.readFileSync(docPath, 'utf8'); }
+    catch (e) { console.error(`  cannot read doc: ${e.message}`); return 2; }
+    const spec = parseMarkdownToSpec(md, { theme: flag(argv, '--theme'), brandName: flag(argv, '--brand') });
+    if (hasFlag(argv, '--html') || hasFlag(argv, '--block')) return outputHtml(spec, argv, docPath);
+    { const dt = mergedThemes(THEMES); if (!dt[spec.theme]) { console.error(`  unknown theme "${spec.theme}". try: ${Object.keys(dt).join(', ')}`); return 2; } }
+    if (!hasFlag(argv, '--build')) {
+      // default: print the spec so the PM can tweak before building
+      console.log(JSON.stringify(spec, null, 2));
+      return 0;
+    }
+    const tok = token();
+    if (!tok) { console.error('  no credentials at ~/.atris/credentials.json — run `atris login` and connect Google Drive.'); return 1; }
+    const title = flag(argv, '--title') || `${(spec.brand && spec.brand.name) || 'Atris'} deck`;
+    const url = await publishDeck(spec, { title, updateId: flag(argv, '--update'), tok });
+    console.log(`\n  ✓ deck from ${docPath} ready: ${url}\n`);
+    return 0;
+  }
+
+  if (sub === 'themes') {
+    console.log('\n  atris deck themes:\n');
+    for (const [name, t] of Object.entries(THEMES)) {
+      console.log(`  ${name.padEnd(10)} ${t.fonts.display} + ${t.fonts.body}  ·  accent ${t.color.accent}  bg ${t.color.bg}`);
+    }
+    console.log('\n  slide types: title, statement, columns, panel, chips, bignumber, close\n');
+    return 0;
+  }
+
+  if (sub === 'sample') {
+    const theme = flag(argv, '--theme') || 'terminal';
+    console.log(JSON.stringify({ ...SAMPLE, theme }, null, 2));
+    return 0;
+  }
+
+  if (sub === 'build') {
+    const specPath = argv.slice(1).find((a) => !a.startsWith('-'));
+    if (!specPath) { console.error('  usage: atris deck build <spec.json> [--title T] [--theme x] [--update ID]'); return 2; }
+    let spec;
+    try { spec = JSON.parse(fs.readFileSync(specPath, 'utf8')); }
+    catch (e) { console.error(`  cannot read spec: ${e.message}`); return 2; }
+    const themeOverride = flag(argv, '--theme'); if (themeOverride) spec.theme = themeOverride;
+    if (hasFlag(argv, '--html') || hasFlag(argv, '--block')) return outputHtml(spec, argv, specPath);
+    { const dt = mergedThemes(THEMES); if (!dt[spec.theme]) { console.error(`  unknown theme "${spec.theme}". try: ${Object.keys(dt).join(', ')}`); return 2; } }
+    const title = flag(argv, '--title') || `${(spec.brand && spec.brand.name) || 'Atris'} deck`;
+
+    const tok = token();
+    if (!tok) { console.error('  no credentials at ~/.atris/credentials.json — run `atris login` and connect Google Drive.'); return 1; }
+
+    const url = await publishDeck(spec, { title, updateId: flag(argv, '--update'), tok });
+    console.log(`\n  ✓ deck ready: ${url}\n`);
+    return 0;
+  }
+
+  console.log(`
+  atris deck — premium Google Slides from a plain content spec or a markdown doc
+
+    atris deck from doc.md [--build] [--title T]   turn a markdown doc into a deck
+    atris deck from doc.md --html --out page.html  beautiful HTML page (theme: atris|terminal|paper)
+    atris deck from doc.md --block                 emit the AppBlock JSON for a web app
+    atris deck sample [--theme paper] > my.json    start from a sample spec
+    atris deck build my.json [--title "Q3 review"] create the deck, print the URL
+    atris deck build my.json --html --out p.html   render the spec as HTML instead of slides
+    atris deck themes                              list design themes
+
+  'from' maps headings to slides (## with bullets -> columns, "**X** label" -> a
+  big number, Close -> a closing slide). Without --build it prints the spec to tweak.
+  Design system is baked in: distinctive fonts, one accent, real data panels, and
+  no AI tells (em dashes sanitized, sentence-case labels, no gradient text).
+`);
+  return 0;
+}
+
+function flag(argv, name) { const i = argv.indexOf(name); return i !== -1 ? argv[i + 1] : null; }
+function hasFlag(argv, name) { return argv.includes(name); }
+
+module.exports = { run, SAMPLE, publishDeck };

--- a/commands/reel.js
+++ b/commands/reel.js
@@ -1,0 +1,128 @@
+// atris reel — one line of text into a short, on-brand video (an animated card).
+//
+//   atris reel "Ship faster" --theme brand --size square
+//   atris reel "It just works." --kind quote --by "a founder" --seconds 3
+//
+// Renders frames with headless Chrome (the same one `atris card` uses) and encodes
+// with ffmpeg. No new dependency. Falls back to a card image if either is missing.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFile, spawnSync } = require('child_process');
+const { promisify } = require('util');
+const pexec = promisify(execFile);
+const { buildReelFrame, reelFrames } = require('../lib/reel');
+const { SIZES, KINDS } = require('../lib/card');
+
+function parseFlags(argv) {
+  const flags = {}; const pos = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const key = a.slice(2); const next = argv[i + 1];
+      if (next != null && !next.startsWith('--')) { flags[key] = next; i++; } else flags[key] = true;
+      continue;
+    }
+    pos.push(a);
+  }
+  return { flags, pos };
+}
+
+function findBin(macApps, names) {
+  for (const p of macApps) if (fs.existsSync(p)) return p;
+  for (const name of names) {
+    const r = spawnSync('command', ['-v', name], { shell: true, encoding: 'utf8' });
+    if (r.status === 0 && r.stdout.trim()) return r.stdout.trim();
+  }
+  return null;
+}
+const findChrome = () => (process.env.CHROME_PATH && fs.existsSync(process.env.CHROME_PATH))
+  ? process.env.CHROME_PATH
+  : findBin([
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    ], ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser', 'chrome']);
+const findFfmpeg = () => findBin(['/opt/homebrew/bin/ffmpeg', '/usr/local/bin/ffmpeg', '/usr/bin/ffmpeg'], ['ffmpeg']);
+
+async function renderFrames(chrome, ts, spec, dir, w, h, onDone) {
+  const pad = (i) => String(i).padStart(4, '0');
+  let idx = 0; let done = 0;
+  async function worker() {
+    while (idx < ts.length) {
+      const i = idx++;
+      const { html } = buildReelFrame(spec, ts[i]);
+      const hf = path.join(dir, `f-${pad(i)}.html`);
+      const pf = path.join(dir, `f-${pad(i)}.png`);
+      fs.writeFileSync(hf, html);
+      await pexec(chrome, [
+        '--headless=new', '--disable-gpu', '--hide-scrollbars', '--force-device-scale-factor=1',
+        `--window-size=${w},${h}`, '--virtual-time-budget=2200',
+        `--user-data-dir=${path.join(dir, 'ud-' + i)}`,
+        `--screenshot=${pf}`, `file://${hf}`,
+      ], { timeout: 60000 });
+      onDone && onDone(++done, ts.length);
+    }
+  }
+  const conc = Math.min(5, ts.length);
+  await Promise.all(Array.from({ length: conc }, worker));
+}
+
+async function run(argv) {
+  const { flags, pos } = parseFlags(argv);
+  if (pos[0] === 'help' || flags.help) {
+    console.log(`\n  atris reel — one line of text into a short on-brand video\n
+  atris reel "Your headline" [--kind statement|quote|stat] [--theme <name>] [--size square|og|wide|story] [--seconds 2.6]
+  flags: --sub --kicker --by --number --label --brand --version --out <file.mp4>\n`);
+    return 0;
+  }
+
+  const text = pos.join(' ').trim();
+  const kind = flags.kind || 'statement';
+  if (!KINDS.includes(kind)) { console.error(`  unknown kind "${kind}". try: ${KINDS.join(', ')}`); return 2; }
+  const size = flags.size || 'square';
+  if (!SIZES[size]) { console.error(`  unknown size "${size}". try: ${Object.keys(SIZES).join(', ')}`); return 2; }
+  if (kind === 'stat' && !flags.number && !text) { console.error('  stat reels need --number'); return 2; }
+  if (kind !== 'stat' && !text) { console.error('  give the reel some text: atris reel "Your headline"'); return 2; }
+
+  const seconds = Math.max(1, Math.min(8, parseFloat(flags.seconds) || 2.6));
+  const fps = 20;
+  const spec = {
+    kind, text, headline: text, theme: flags.theme, size,
+    sub: flags.sub, kicker: flags.kicker, by: flags.by,
+    number: flags.number, label: flags.label, brand: flags.brand, version: flags.version,
+  };
+  const { w, h } = SIZES[size];
+  const base = flags.out ? String(flags.out).replace(/\.mp4$/i, '') : `reel-${kind}-${flags.theme || 'atris'}-${size}`;
+  const outMp4 = path.resolve(`${base}.mp4`);
+
+  const chrome = findChrome();
+  if (!chrome) { console.error('\n  no Chrome found to render frames. install Chrome or set CHROME_PATH.\n'); return 1; }
+  const ffmpeg = findFfmpeg();
+  if (!ffmpeg) { console.error('\n  no ffmpeg found to encode the video. install ffmpeg (brew install ffmpeg).\n'); return 1; }
+
+  const ts = reelFrames(seconds, fps);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-reel-'));
+  console.log(`\n  rendering ${ts.length} frames (${seconds}s, ${size})...`);
+  try {
+    await renderFrames(chrome, ts, spec, dir, w, h, (d, n) => {
+      if (d === n || d % 10 === 0) process.stdout.write(`\r  frames ${d}/${n}   `);
+    });
+    process.stdout.write('\n  encoding...\n');
+    await pexec(ffmpeg, [
+      '-y', '-framerate', String(fps), '-i', path.join(dir, 'f-%04d.png'),
+      '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-movflags', '+faststart', outMp4,
+    ]);
+  } catch (e) {
+    console.error(`\n  render failed: ${String(e.message).split('\n')[0]}`); return 1;
+  } finally {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+
+  if (!fs.existsSync(outMp4)) { console.error('  no video produced'); return 1; }
+  console.log(`\n  ✓ ${kind} reel, ${w}x${h}, ${seconds}s, theme ${flags.theme || 'atris'}\n    ${outMp4}\n`);
+  return 0;
+}
+
+module.exports = { run, findChrome, findFfmpeg };

--- a/commands/site.js
+++ b/commands/site.js
@@ -1,0 +1,48 @@
+// atris site — turn a folder of markdown (docs, your wiki, memory) into a
+// beautiful, navigable static site in the design system. Built on lib/site.js.
+//
+//   atris site <dir|doc.md> [--out dist] [--theme atris|terminal|paper] [--title T] [--serve]
+
+const { buildSite, serveSite } = require('../lib/site');
+
+function flag(argv, name) { const i = argv.indexOf(name); return i !== -1 ? argv[i + 1] : null; }
+function hasFlag(argv, name) { return argv.includes(name); }
+
+async function run(argv) {
+  const input = argv.find((a) => !a.startsWith('-'));
+  if (!input || input === 'help' || hasFlag(argv, '--help')) {
+    console.log(`
+  atris site — a beautiful static site from a folder of markdown
+
+    atris site <dir|doc.md> [--out dist] [--theme atris|terminal|paper] [--title T]
+    atris site atris/wiki --title "Atris Wiki" --serve
+
+  Each .md becomes a page; an index links them all. Same anti-slop design system,
+  semantic data-atris-block sections, ready for the web app. --serve previews it.
+`);
+    return input === 'help' || hasFlag(argv, '--help') ? 0 : 2;
+  }
+
+  let res;
+  try {
+    res = buildSite(input, {
+      out: flag(argv, '--out') || 'dist',
+      theme: flag(argv, '--theme'),
+      title: flag(argv, '--title'),
+      brand: flag(argv, '--brand'),
+    });
+  } catch (e) { console.error(`  ${e.message}`); return 2; }
+
+  console.log(`\n  ✓ site built: ${res.pages.length} page${res.pages.length === 1 ? '' : 's'} + index -> ${res.outDir}/`);
+  console.log(`    open ${res.indexPath}`);
+
+  if (hasFlag(argv, '--serve')) {
+    const port = Number(flag(argv, '--port')) || 4321;
+    const { url } = await serveSite(res.outDir, port);
+    console.log(`\n  serving at ${url} (ctrl-c to stop)\n`);
+    await new Promise(() => {}); // keep alive until killed
+  }
+  return 0;
+}
+
+module.exports = { run };

--- a/commands/slop.js
+++ b/commands/slop.js
@@ -1,0 +1,307 @@
+// atris slop — deterministic frontend-slop detector (no LLM).
+//
+// Steal-from-Impeccable, the Atris way: makes "looks AI-generated" concrete and
+// CHECKABLE. A failure is a fact (file:line + rule), not a taste opinion — so it
+// drops straight into the autopilot/review verification gate and CI. Each finding
+// is the seed of a typed lesson; the ruleset is meant to GROW from lessons.md
+// rather than be hand-curated forever.
+//
+// Zero external deps (Node built-ins only) — repo contract.
+//
+// Usage:
+//   atris slop detect [path]        # scan a file or dir (default: .)
+//   atris slop detect src/ --json   # machine output for CI / the loop
+//   atris slop detect src/ --quiet  # only print the summary line
+//
+// Exit code: 0 = clean, 1 = slop found, 2 = bad usage. CI/PR gates read this.
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCAN_EXTS = new Set(['.css', '.scss', '.sass', '.less', '.tsx', '.jsx', '.ts', '.js', '.mjs', '.html', '.vue', '.svelte', '.astro',
+  '.md', '.mdx', '.txt']); // prose too: the voice doctrine (em-dash, hype-copy) is enforceable, not just advice
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.next', '.astro', 'coverage', '.cache', 'out', 'vendor']);
+
+// Each rule is deterministic: a regex + a one-line why. severity drives the icon.
+// Kept high-precision on purpose — a noisy gate gets muted, and a muted gate is dead.
+const RULES = [
+  { id: 'ai-gradient-text', sev: 'error',
+    re: /(text-transparent[^"'`]{0,40}bg-clip-text|bg-clip-text[^"'`]{0,40}text-transparent|-webkit-text-fill-color:\s*transparent|background-clip:\s*text)/i,
+    why: 'gradient-filled text headline: the #1 generated-look tell' },
+  { id: 'ai-purple-gradient', sev: 'error',
+    re: /((from|via|to)-(purple|violet|indigo|fuchsia)-\d{2,3}\b|linear-gradient\([^)]*(#6366f1|#8b5cf6|#a855f7|#7c3aed|#4f46e5|\bpurple\b|\bviolet\b|\bindigo\b))/i,
+    why: 'purple/indigo gradient: default "AI startup" palette' },
+  { id: 'ai-indigo-brand', sev: 'warn',
+    re: /(#6366f1|#4f46e5|#4338ca|(?:bg|text|border|from|to|ring)-indigo-(?:500|600|700)\b)/i,
+    why: 'canonical AI indigo used as brand color' },
+  { id: 'glassmorphism', sev: 'warn',
+    re: /(backdrop-blur(?:-\w+)?\b|backdrop-filter:\s*blur)/i,
+    why: 'glassmorphism (frosted blur): overused default' },
+  { id: 'over-rounding', sev: 'warn',
+    re: /(rounded-(?:3xl|\[(?:[2-9]\d?|1\d\d)(?:px|rem)\])|border-radius:\s*(?:2[4-9]|[3-9]\d|\d{3})px|border-radius:\s*(?:[2-9](?:\.\d+)?)rem)/i,
+    why: 'over-rounded corners (>=24px / rounded-3xl)' },
+  { id: 'mega-shadow', sev: 'warn',
+    re: /(shadow-2xl\b|box-shadow:\s*0\s+\d{2,}px)/i,
+    why: 'oversized generic drop shadow (depth-by-blur)' },
+  { id: 'side-stripe-card', sev: 'warn',
+    re: /border-(?:left|l)-(?:4|8|\[\d+px\])\b|border-left:\s*[3-9]px\s+solid/i,
+    why: 'accent side-stripe on a card: generated layout reflex' },
+  { id: 'transition-all', sev: 'warn',
+    re: /\btransition-all\b|transition:\s*all\b/i,
+    why: 'transition-all: animate-everything laziness, not intent' },
+  { id: 'pulse-animation', sev: 'warn',
+    re: /animation:[^;]*\binfinite\b|@keyframes\s+(pulse|ping|blink|glow|throb)\b|\banimate-(pulse|ping|bounce)\b/i,
+    why: 'looping pulse/ping/glow animation: distracting live-status reflex' },
+  { id: 'eyebrow-caps', sev: 'warn',
+    re: /text-transform:\s*uppercase\b|\buppercase\b[^"'`]{0,30}tracking-|tracking-[^"'`]{0,30}\buppercase\b/i,
+    why: 'tracked all-caps eyebrow/label: dated reflex; use sentence case' },
+  { id: 'decorative-emoji', sev: 'warn',
+    re: /[✨\u{1F680}\u{1F4A1}\u{1F525}\u{1F389}⚡\u{1F31F}\u{1FA84}\u{1F4AB}\u{1F44B}]/u,
+    why: 'decorative emoji in UI copy' },
+  { id: 'em-dash', sev: 'warn',
+    re: /—/,
+    fix: (s) => s.replace(/\s*—\s*/g, ', '), // safe deterministic repair (prose)
+    why: 'em dash: a top AI-writing tell; use a comma, colon, or period' },
+  { id: 'hype-copy', sev: 'error',
+    re: /\b(boost your productivity|supercharge|unleash|game[- ]?chang(?:er|ing)|seamlessly|effortlessly|revolutioniz(?:e|ing)|take your .{1,30} to the next level|elevate your|cutting[- ]edge|powered by ai|next[- ]generation)\b/i,
+    why: 'hype/marketing slop phrase: say the specific thing instead' },
+];
+
+const ICON = { error: '✗', warn: '⚠' }; // ✗  ⚠
+
+const PROJECT_RULES_FILE = path.join('.atris', 'slop.rules.json');
+
+// Compounding: projects grow their own anti-slop ruleset in .atris/slop.rules.json.
+// Each entry: { id, pattern, flags?, why?, sev? }. Loaded on top of the built-ins.
+function loadProjectRules(root = process.cwd()) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(root, PROJECT_RULES_FILE), 'utf8'));
+    const arr = Array.isArray(raw) ? raw : (raw.rules || []);
+    return arr.map((r) => {
+      if (!r || !r.id || !r.pattern) return null;
+      let re; try { re = new RegExp(r.pattern, r.flags || 'i'); } catch { return null; }
+      return { id: r.id, sev: r.sev === 'error' ? 'error' : 'warn', re, why: r.why || r.id, project: true };
+    }).filter(Boolean);
+  } catch { return []; }
+}
+
+function addProjectRule(rule, root = process.cwd()) {
+  const file = path.join(root, PROJECT_RULES_FILE);
+  let arr = [];
+  try { const raw = JSON.parse(fs.readFileSync(file, 'utf8')); arr = Array.isArray(raw) ? raw : (raw.rules || []); } catch {}
+  arr = arr.filter((r) => r.id !== rule.id);
+  arr.push(rule);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(arr, null, 2) + '\n');
+  return file;
+}
+
+// Map<absFile, Set<changedLineNumber>> from the working-tree (or --cached) git diff.
+function gitChangedLines(staged, cwd = process.cwd()) {
+  const map = new Map();
+  let out;
+  try { out = execFileSync('git', ['diff', '--unified=0', ...(staged ? ['--cached'] : [])], { encoding: 'utf8', cwd }); }
+  catch { return map; }
+  let cur = null;
+  for (const line of out.split('\n')) {
+    const f = line.match(/^\+\+\+ b\/(.+)$/);
+    if (f) { cur = path.resolve(cwd, f[1]); map.set(cur, map.get(cur) || new Set()); continue; }
+    const h = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (h && cur) { const start = +h[1], count = h[2] != null ? +h[2] : 1; for (let i = 0; i < count; i++) map.get(cur).add(start + i); }
+  }
+  return map;
+}
+
+// Install a pre-commit hook that gates staged changes through `atris slop detect --staged`.
+// Idempotent and non-destructive: appends a marked block, skips gracefully if atris is absent.
+function installHook(root = process.cwd()) {
+  if (!fs.existsSync(path.join(root, '.git'))) throw new Error('not a git repo (no .git here)');
+  const hookDir = path.join(root, '.git', 'hooks');
+  fs.mkdirSync(hookDir, { recursive: true });
+  const hookPath = path.join(hookDir, 'pre-commit');
+  const marker = '# atris slop gate';
+  let content = '';
+  try { content = fs.readFileSync(hookPath, 'utf8'); } catch {}
+  if (content.includes(marker)) return { hookPath, already: true };
+  if (!content) content = '#!/bin/sh\n';
+  if (!content.endsWith('\n')) content += '\n';
+  content += `\n${marker}\nif command -v atris >/dev/null 2>&1; then atris slop detect --staged --quiet || exit 1; fi\n`;
+  fs.writeFileSync(hookPath, content);
+  fs.chmodSync(hookPath, 0o755);
+  return { hookPath, already: false };
+}
+
+// Apply every fixable rule's safe transform in place. Returns { fixedCount, fixedFiles }.
+function applyFixes(files, rules) {
+  const fixable = rules.filter((r) => typeof r.fix === 'function');
+  let fixedCount = 0; const fixedFiles = [];
+  for (const file of files) {
+    let text; try { text = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    const lines = text.split('\n');
+    let touched = false;
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i];
+      for (const r of fixable) { if (r.re.test(line)) { const nl = r.fix(line); if (nl !== line) { line = nl; fixedCount++; } } }
+      if (line !== lines[i]) { lines[i] = line; touched = true; }
+    }
+    if (touched) { fs.writeFileSync(file, lines.join('\n')); fixedFiles.push(file); }
+  }
+  return { fixedCount, fixedFiles };
+}
+
+function walk(target, out) {
+  let stat;
+  try { stat = fs.statSync(target); } catch { return out; }
+  if (stat.isFile()) {
+    if (SCAN_EXTS.has(path.extname(target))) out.push(target);
+    return out;
+  }
+  if (stat.isDirectory()) {
+    if (SKIP_DIRS.has(path.basename(target))) return out;
+    for (const name of fs.readdirSync(target)) {
+      if (name.startsWith('.') && name !== '.') continue;
+      walk(path.join(target, name), out);
+    }
+  }
+  return out;
+}
+
+function scanFile(file, rules = RULES) {
+  const findings = [];
+  let text;
+  try { text = fs.readFileSync(file, 'utf8'); } catch { return findings; }
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const rule of rules) {
+      const m = rule.re.exec(line);
+      if (m) {
+        findings.push({
+          file, line: i + 1, rule: rule.id, sev: rule.sev, why: rule.why,
+          snippet: m[0].trim().slice(0, 48),
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+function detect(argv) {
+  const json = argv.includes('--json');
+  const quiet = argv.includes('--quiet');
+  const doFix = argv.includes('--fix');
+  const staged = argv.includes('--staged');
+  const diffMode = staged || argv.includes('--diff');
+  const rules = RULES.concat(loadProjectRules());
+
+  // pick the file set: a git diff (changed files) or a path walk
+  let files, changed = null;
+  if (diffMode) {
+    changed = gitChangedLines(staged);
+    files = [...changed.keys()].filter((f) => SCAN_EXTS.has(path.extname(f)) && fs.existsSync(f));
+  } else {
+    const target = argv.find((a) => !a.startsWith('-')) || '.';
+    files = walk(path.resolve(target), []);
+  }
+
+  let fixed = null;
+  if (doFix) {
+    fixed = applyFixes(files, rules);
+    if (!json && fixed.fixedCount) {
+      console.log(`\n  ✎ fixed ${fixed.fixedCount} tell${fixed.fixedCount === 1 ? '' : 's'} in ${fixed.fixedFiles.length} file${fixed.fixedFiles.length === 1 ? '' : 's'}`);
+    }
+  }
+
+  let findings = files.flatMap((f) => scanFile(f, rules));
+  if (diffMode && changed) findings = findings.filter((f) => changed.get(f.file) && changed.get(f.file).has(f.line));
+  const errors = findings.filter((f) => f.sev === 'error').length;
+
+  if (json) {
+    console.log(JSON.stringify({
+      ok: findings.length === 0, scanned: files.length,
+      mode: diffMode ? (staged ? 'staged' : 'diff') : 'path',
+      fixed: fixed ? fixed.fixedCount : 0,
+      slop: findings.length, errors,
+      findings: findings.map((f) => ({ ...f, file: path.relative(process.cwd(), f.file) })),
+    }, null, 2));
+    return findings.length ? 1 : 0;
+  }
+
+  const rel = (f) => path.relative(process.cwd(), f);
+  if (!quiet) {
+    if (!findings.length) {
+      console.log(`\n  ✓ clean — no slop tells in ${files.length} file${files.length === 1 ? '' : 's'}`);
+    } else {
+      console.log('');
+      const w = Math.max(...findings.map((f) => `${rel(f.file)}:${f.line}`.length));
+      for (const f of findings) {
+        const loc = `${rel(f.file)}:${f.line}`.padEnd(w);
+        console.log(`  ${ICON[f.sev]} ${loc}  ${f.rule.padEnd(20)} ${f.why}`);
+      }
+    }
+  }
+  if (findings.length) {
+    console.log(`\n  ${findings.length} slop tell${findings.length === 1 ? '' : 's'} (${errors} error) · exit 1\n`);
+  } else if (quiet) {
+    console.log(`  ✓ clean · exit 0`);
+  }
+  return findings.length ? 1 : 0;
+}
+
+function slopCommand(argv) {
+  const sub = argv[0];
+  if (!sub || sub === 'detect' || sub.startsWith('-') || !['detect', 'rules', 'help', 'hook', 'install-hook'].includes(sub)) {
+    // default + `detect`: scan. Bare `atris slop` scans cwd too.
+    const rest = sub === 'detect' ? argv.slice(1) : argv;
+    return detect(rest);
+  }
+  if (sub === 'hook' || sub === 'install-hook') {
+    try {
+      const { hookPath, already } = installHook();
+      console.log(already
+        ? `\n  already installed: ${path.relative(process.cwd(), hookPath)}\n`
+        : `\n  ✓ slop pre-commit gate installed: ${path.relative(process.cwd(), hookPath)}\n    every commit now runs: atris slop detect --staged\n`);
+      return 0;
+    } catch (e) { console.error(`  ${e.message}`); return 2; }
+  }
+
+  if (sub === 'rules') {
+    if (argv.includes('--add')) {
+      const rest = argv.slice(argv.indexOf('--add') + 1).filter((a) => !a.startsWith('-'));
+      const [id, pattern, ...whyParts] = rest;
+      if (!id || !pattern) { console.error('  usage: atris slop rules --add <id> <regex-pattern> <why...> [--sev error|warn]'); return 2; }
+      let valid = true; try { new RegExp(pattern, 'i'); } catch { valid = false; }
+      if (!valid) { console.error(`  invalid regex: ${pattern}`); return 2; }
+      const sev = (argv[argv.indexOf('--sev') + 1] === 'error') ? 'error' : 'warn';
+      const file = addProjectRule({ id, pattern, why: whyParts.join(' ') || id, sev });
+      console.log(`  ✓ added project rule "${id}" to ${path.relative(process.cwd(), file)}`);
+      return 0;
+    }
+    const project = loadProjectRules();
+    console.log('\n  atris slop — deterministic rules:\n');
+    for (const r of RULES) console.log(`  ${ICON[r.sev]} ${r.id.padEnd(20)} ${r.why}`);
+    for (const r of project) console.log(`  ${ICON[r.sev]} ${r.id.padEnd(20)} ${r.why}  (project)`);
+    console.log(`\n  ${RULES.length} built-in${project.length ? ` + ${project.length} project` : ''} rule${RULES.length + project.length === 1 ? '' : 's'}\n`);
+    return 0;
+  }
+  // help
+  console.log(`
+  atris slop — deterministic slop detector + repairer (no LLM)
+
+    atris slop detect [path]      scan a file or dir (default: .)
+    atris slop detect --diff      scan only changed lines (commit/PR gate)
+    atris slop detect --staged    scan only staged changes (pre-commit hook)
+    atris slop detect --fix       auto-repair the safe tells (em dashes), report the rest
+    atris slop detect [path] --json   machine output for CI / the loop
+    atris slop rules              list active rules (built-in + project)
+    atris slop rules --add <id> <pattern> <why>   grow the project ruleset
+    atris slop hook               install a pre-commit gate (runs --staged)
+
+  Project rules live in .atris/slop.rules.json and compound over time.
+  exit 0 = clean, 1 = slop found. Wire into PR checks and the autopilot gate.
+`);
+  return 0;
+}
+
+module.exports = { slopCommand, detect, scanFile, RULES, loadProjectRules, addProjectRule, gitChangedLines, applyFixes, installHook };

--- a/commands/theme.js
+++ b/commands/theme.js
@@ -1,0 +1,217 @@
+// atris theme — brand themes for the whole design system. Define your colors and
+// fonts once in .atris/theme.json; every deck, HTML page, and site uses them.
+//
+//   atris theme create        guided interview -> your own theme (alias: new)
+//   atris theme edit <name>   re-run the interview to tweak an existing theme
+//   atris theme init          scaffold a starter .atris/theme.json
+//   atris theme list          list built-in + project themes
+//   atris theme show <name>   print a resolved theme
+
+const readline = require('readline');
+const {
+  mergedThemes, writeStarterTheme, loadProjectThemes, loadThemeRecipe, PROJECT_THEME_FILE,
+  MOODS, MOOD_NAMES, FONT_PERSONALITIES, buildTheme, themeWarnings, upsertProjectTheme,
+  resolveMode, isHex, normHex, hexToRgb,
+} = require('../lib/theme');
+const { THEMES: HTML_THEMES } = require('../lib/html-render');
+
+// ---------- small terminal helpers ----------
+function parseFlags(argv) {
+  const flags = {}; const pos = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '-y' || a === '--yes') { flags.yes = true; continue; }
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next != null && !next.startsWith('--')) { flags[key] = next; i++; }
+      else flags[key] = true;
+      continue;
+    }
+    pos.push(a);
+  }
+  return { flags, pos };
+}
+
+// a colored block when we're on a real terminal, two blank cells otherwise (clean pipes)
+function sw(hex) {
+  const c = hexToRgb(hex);
+  if (!c || !process.stdout.isTTY) return '  ';
+  return `\x1b[48;2;${c.r};${c.g};${c.b}m  \x1b[0m`;
+}
+
+function printPreview(name, answers, theme) {
+  const c = theme.color;
+  const mode = resolveMode(answers.mood || 'editorial', answers.mode);
+  console.log(`\n  ${name}  ·  ${answers.mood || 'editorial'} ${mode}`);
+  const row = (label, hex) => console.log(`   ${sw(hex)} ${label.padEnd(8)} ${hex}`);
+  row('bg', c.bg);
+  row('ink', c.ink);
+  row('accent', c.accent);
+  row('accent2', c.accent2);
+  console.log(`      ${theme.fonts.display} display, ${theme.fonts.body} body`);
+}
+
+// ---------- the guided interview (tasteful vocabulary) ----------
+async function interview(defaults = {}) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (q) => new Promise((res) => rl.question(q, res));
+  const ans = {};
+  try {
+    console.log('\n  let\'s make your theme. five quick choices, all changeable later.\n');
+
+    const dn = defaults.name || 'brand';
+    ans.name = (await ask(`  1/5  name it [${dn}]: `)).trim() || dn;
+
+    console.log('\n  2/5  what should it feel like?');
+    MOOD_NAMES.forEach((m, i) => console.log(`     ${i + 1}. ${m.padEnd(10)} ${MOODS[m].blurb}`));
+    const dmIdx = Math.max(0, MOOD_NAMES.indexOf(defaults.mood || 'editorial'));
+    const moodPick = (await ask(`     pick 1-${MOOD_NAMES.length} [${dmIdx + 1}]: `)).trim();
+    ans.mood = MOOD_NAMES[(parseInt(moodPick, 10) - 1)] || MOOD_NAMES[dmIdx];
+    const mood = MOODS[ans.mood];
+
+    if (mood.forceMode) {
+      ans.mode = mood.forceMode;
+      console.log(`     (${ans.mood} is ${mood.forceMode}-only)`);
+    } else {
+      const dmode = defaults.mode || mood.defaultMode;
+      const mp = (await ask(`\n  3/5  light or dark? [${dmode[0]}]: `)).trim().toLowerCase();
+      ans.mode = mp.startsWith('l') ? 'light' : mp.startsWith('d') ? 'dark' : dmode;
+    }
+
+    console.log('\n  4/5  your accent — the one color that is unmistakably yours:');
+    mood.swatches.forEach((s, i) => console.log(`     ${i + 1}. ${sw(s)} ${s}`));
+    const dac = normHex(defaults.accent) || mood.swatches[0];
+    const ap = (await ask(`     pick 1-${mood.swatches.length}, or paste a hex [${dac}]: `)).trim();
+    if (!ap) ans.accent = dac;
+    else if (/^[1-9]$/.test(ap) && mood.swatches[parseInt(ap, 10) - 1]) ans.accent = mood.swatches[parseInt(ap, 10) - 1];
+    else if (isHex(ap)) ans.accent = normHex(ap);
+    else { console.log(`     '${ap}' is not 1-${mood.swatches.length} or a hex, keeping ${dac}`); ans.accent = dac; }
+
+    console.log('\n  5/5  type personality:');
+    const fontKeys = Object.keys(FONT_PERSONALITIES);
+    fontKeys.forEach((k, i) => console.log(`     ${i + 1}. ${k.padEnd(15)} ${FONT_PERSONALITIES[k].display} / ${FONT_PERSONALITIES[k].body}`));
+    const dfIdx = fontKeys.indexOf(typeof defaults.fonts === 'string' ? defaults.fonts : mood.fonts);
+    const fp = (await ask(`     pick 1-${fontKeys.length} [${(dfIdx < 0 ? 0 : dfIdx) + 1}]: `)).trim();
+    ans.fonts = fontKeys[(parseInt(fp, 10) - 1)] || fontKeys[dfIdx < 0 ? 0 : dfIdx];
+  } finally {
+    rl.close();
+  }
+  return ans;
+}
+
+function confirmSync(q) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((res) => rl.question(q, (a) => { rl.close(); res(!String(a).trim().toLowerCase().startsWith('n')); }));
+}
+
+// shared create/edit flow. defaults seed an edit; flags override anything; interactive
+// only when there's a TTY and no defining flags.
+async function createFlow({ name, defaults = {}, flags }) {
+  const answers = { ...defaults };
+  if (flags.mood) answers.mood = flags.mood;
+  if (flags.mode) answers.mode = flags.mode;
+  if (flags.accent) answers.accent = flags.accent;
+  if (flags.accent2) answers.accent2 = flags.accent2;
+  if (flags.fonts) answers.fonts = flags.fonts;
+  let themeName = name || flags.name || defaults.name || 'brand';
+
+  const hasDefiningFlag = Boolean(flags.mood || flags.mode || flags.accent || flags.accent2 || flags.fonts || flags.name);
+  const interactive = Boolean(process.stdin.isTTY) && !flags.yes && !hasDefiningFlag;
+
+  if (interactive) {
+    const r = await interview({ name: themeName, ...answers });
+    Object.assign(answers, r);
+    themeName = r.name || themeName;
+  }
+  themeName = String(themeName).trim() || 'brand';
+
+  if (answers.mood && !MOODS[answers.mood]) { console.error(`  unknown mood "${answers.mood}". try: ${MOOD_NAMES.join(', ')}`); return 2; }
+  if (answers.accent && !isHex(answers.accent)) { console.error(`  not a hex color: ${answers.accent}`); return 2; }
+  if (answers.accent2 && !isHex(answers.accent2)) { console.error(`  not a hex color: ${answers.accent2}`); return 2; }
+  if (answers.fonts && typeof answers.fonts === 'string' && !FONT_PERSONALITIES[answers.fonts]) {
+    console.error(`  unknown font personality "${answers.fonts}". try: ${Object.keys(FONT_PERSONALITIES).join(', ')}`); return 2;
+  }
+
+  const theme = buildTheme(answers);
+  printPreview(themeName, answers, theme);
+  const warns = themeWarnings(theme);
+  if (warns.length) { console.log('\n  heads up:'); warns.forEach((w) => console.log(`   ! ${w}`)); }
+
+  if (interactive) {
+    const ok = await confirmSync('\n  save this theme? [enter = yes, n = cancel] ');
+    if (!ok) { console.log('  cancelled, nothing written.\n'); return 0; }
+  }
+
+  const recipe = {
+    mood: answers.mood || 'editorial',
+    mode: resolveMode(answers.mood || 'editorial', answers.mode),
+    accent: theme.color.accent,
+    accent2: theme.color.accent2,
+    fonts: typeof answers.fonts === 'string' ? answers.fonts : (MOODS[answers.mood || 'editorial'].fonts),
+  };
+
+  let res;
+  try { res = upsertProjectTheme(themeName, theme, process.cwd(), recipe); }
+  catch (e) { console.error(`  ${e.message}`); return 1; }
+
+  console.log(`\n  ✓ ${res.action} theme "${res.name}" in ${PROJECT_THEME_FILE}  (${res.count} theme${res.count === 1 ? '' : 's'})`);
+  console.log('    use it anywhere:');
+  console.log(`      atris deck from doc.md --html --theme ${res.name}`);
+  console.log(`      atris site ./docs --theme ${res.name}`);
+  console.log(`    tweak it later:  atris theme edit ${res.name}\n`);
+  return 0;
+}
+
+async function run(argv) {
+  const sub = argv[0];
+  const rest = argv.slice(1);
+
+  if (sub === 'create' || sub === 'new') {
+    const { flags, pos } = parseFlags(rest);
+    return createFlow({ name: pos[0], flags });
+  }
+
+  if (sub === 'edit') {
+    const { flags, pos } = parseFlags(rest);
+    const name = pos[0] || flags.name;
+    if (!name) { console.error('  usage: atris theme edit <name>'); return 2; }
+    const existing = loadProjectThemes()[name];
+    if (!existing) { console.error(`  no project theme "${name}". make one with: atris theme create ${name}`); return 2; }
+    // prefer the saved recipe; otherwise seed from the resolved colors/fonts
+    const recipe = loadThemeRecipe(name);
+    const defaults = recipe || { accent: existing.color.accent, accent2: existing.color.accent2, fonts: existing.fonts };
+    defaults.name = name;
+    return createFlow({ name, defaults, flags });
+  }
+
+  if (sub === 'init') {
+    const { file, already } = writeStarterTheme();
+    console.log(already
+      ? `\n  already exists: ${file}\n  customize it with: atris theme edit brand\n`
+      : `\n  ✓ brand theme scaffolded: ${file}\n    or build one by feel:  atris theme create\n`);
+    return 0;
+  }
+
+  if (sub === 'show') {
+    const name = rest[0];
+    const t = mergedThemes(HTML_THEMES)[name];
+    if (!t) { console.error(`  unknown theme "${name}"`); return 2; }
+    console.log(JSON.stringify(t, null, 2));
+    return 0;
+  }
+
+  // list (default)
+  const project = loadProjectThemes();
+  const all = mergedThemes(HTML_THEMES);
+  console.log('\n  atris themes:\n');
+  for (const name of Object.keys(all)) {
+    const tag = project[name] ? 'project' : 'built-in';
+    console.log(`  ${sw(all[name].color.accent)} ${name.padEnd(12)} accent ${all[name].color.accent}  bg ${all[name].color.bg}  (${tag})`);
+  }
+  console.log(`\n  make your own by feel:  atris theme create`);
+  console.log(`  themes live in ${PROJECT_THEME_FILE}. Used by deck, html, and site.\n`);
+  return 0;
+}
+
+module.exports = { run };

--- a/lib/card.js
+++ b/lib/card.js
@@ -1,0 +1,120 @@
+// atris card — turn one line of text into a beautiful, on-brand image.
+// Pure: spec -> self-contained HTML string. Reuses the design system: the same
+// themes as deck/site/html (incl. your .atris/theme.json brand), one accent,
+// Fraunces display, restraint. Render to PNG with headless Chrome (commands/card.js).
+//
+// Kinds: statement (kicker + headline + sub), quote (quote + attribution),
+//        stat (big number + label). Sizes: og, wide, square, story.
+
+const { mergedThemes } = require('./theme');
+const { THEMES: HTML_THEMES, rich, esc } = require('./html-render');
+
+const SIZES = {
+  og: { w: 1200, h: 630 },      // OpenGraph / link card
+  wide: { w: 1920, h: 1080 },   // slide / banner
+  square: { w: 1080, h: 1080 }, // feed
+  story: { w: 1080, h: 1920 },  // story / reel
+};
+const KINDS = ['statement', 'quote', 'stat'];
+
+const plainLen = (s) => String(s == null ? '' : s).replace(/\*\*/g, '').length;
+const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
+
+// shrink a display line so long text still fits the card
+function fit(base, text, refChars) {
+  return Math.round(base * clamp(refChars / Math.max(plainLen(text), 1), 0.5, 1));
+}
+
+function fontStack(name, fallback) {
+  return `'${String(name || fallback).replace(/'/g, '')}', '${fallback}', ${fallback === 'Fraunces' ? 'Georgia, serif' : 'system-ui, sans-serif'}`;
+}
+
+function buildCard(spec = {}, opts = {}) {
+  const size = SIZES[spec.size] || SIZES.og;
+  const themes = opts.themes || mergedThemes(HTML_THEMES, opts.root || process.cwd());
+  const theme = themes[spec.theme] || HTML_THEMES.atris;
+  const c = theme.color;
+  const f = theme.fonts || {};
+  const kind = KINDS.includes(spec.kind) ? spec.kind : 'statement';
+  const u = Math.min(size.w, size.h);
+
+  const pad = Math.round(u * 0.088);
+  const px = {
+    kicker: Math.round(u * 0.030),
+    sub: Math.round(u * 0.040),
+    foot: Math.round(u * 0.028),
+    rule: Math.round(u * 0.010),
+    gap: Math.round(u * 0.030),
+  };
+
+  const brand = spec.brand || 'Atris';
+  const version = spec.version || '';
+  const display = fontStack(f.display, 'Fraunces');
+  const body = fontStack(f.body, 'Outfit');
+  const grotesk = "'Space Grotesk', system-ui, sans-serif";
+  const monoFont = "'IBM Plex Mono', ui-monospace, monospace";
+
+  const foot = `<div class="foot"><span class="mark">${esc(brand)}</span>${version ? `<span class="ver">${esc(version)}</span>` : ''}</div>`;
+  const kickerHtml = spec.kicker ? `<div class="kicker">${rich(spec.kicker)}</div>` : '';
+  const subHtml = spec.sub ? `<p class="sub">${rich(spec.sub)}</p>` : '';
+
+  let main = '';
+  let extraCss = '';
+  if (kind === 'quote') {
+    const text = spec.text || spec.headline || 'Your quote here';
+    const qSize = fit(Math.round(u * 0.090), text, 64);
+    main = `<div class="rule"></div>
+      <div class="qmark">&ldquo;</div>
+      <blockquote class="qtext">${rich(text)}</blockquote>
+      ${spec.by ? `<div class="by">${rich(spec.by)}</div>` : ''}`;
+    extraCss = `
+      .qmark{font-family:${display};color:${c.accent};font-size:${Math.round(u * 0.20)}px;line-height:.6;height:${Math.round(u * 0.10)}px}
+      .qtext{font-family:${display};font-weight:600;font-size:${qSize}px;line-height:1.08;letter-spacing:-1px;margin:${px.gap}px 0}
+      .by{font-family:${monoFont};font-size:${px.foot}px;color:${c.soft}}`;
+  } else if (kind === 'stat') {
+    const number = spec.number || spec.headline || '42';
+    const numSize = fit(Math.round(u * 0.34), number, 6);
+    main = `<div class="rule"></div>
+      ${kickerHtml}
+      <div class="big">${rich(number)}</div>
+      ${spec.label ? `<div class="statlabel">${rich(spec.label)}</div>` : ''}
+      ${subHtml}`;
+    extraCss = `
+      .big{font-family:${grotesk};font-weight:600;color:${c.accent};font-size:${numSize}px;line-height:.92;letter-spacing:-2px}
+      .statlabel{font-family:${display};font-weight:600;font-size:${Math.round(u * 0.058)}px;color:${c.ink};margin-top:${Math.round(px.gap * 0.5)}px}`;
+  } else {
+    const headline = spec.headline || spec.text || 'Your headline here';
+    const hSize = fit(Math.round(u * 0.135), headline, 34);
+    main = `<div class="rule"></div>
+      ${kickerHtml}
+      <h1 class="headline">${rich(headline)}</h1>
+      ${subHtml}`;
+    extraCss = `
+      .headline{font-family:${display};font-weight:600;font-size:${hSize}px;line-height:1.02;letter-spacing:-1.5px}`;
+  }
+
+  const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600&family=Outfit:wght@400;500;600&family=Space+Grotesk:wght@500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *{margin:0;padding:0;box-sizing:border-box}
+  html,body{width:${size.w}px;height:${size.h}px;overflow:hidden}
+  body{background:${c.bg};color:${c.ink};font-family:${body};-webkit-font-smoothing:antialiased}
+  .card{width:${size.w}px;height:${size.h}px;padding:${pad}px;display:flex;flex-direction:column;justify-content:center;position:relative}
+  .rule{width:${Math.round(u * 0.085)}px;height:${px.rule}px;background:${c.accent};border-radius:${px.rule}px;margin-bottom:${Math.round(px.gap * 0.9)}px}
+  .kicker{font-family:${monoFont};font-size:${px.kicker}px;letter-spacing:2px;color:${c.soft};margin-bottom:${Math.round(px.gap * 0.6)}px}
+  .sub{font-size:${px.sub}px;line-height:1.4;color:${c.soft};margin-top:${px.gap}px;max-width:88%}
+  .foot{position:absolute;left:${pad}px;right:${pad}px;bottom:${pad}px;display:flex;align-items:baseline;justify-content:space-between}
+  .mark{font-family:${display};font-weight:600;font-size:${Math.round(u * 0.034)}px}
+  .ver{font-family:${monoFont};font-size:${px.foot}px;color:${c.soft};letter-spacing:1px}
+  .accent{color:${c.accent}}
+  ${extraCss}
+</style></head>
+<body><div class="card">${main}${foot}</div></body></html>`;
+
+  return { html, width: size.w, height: size.h, kind, theme: spec.theme || 'atris', size: spec.size || 'og' };
+}
+
+module.exports = { buildCard, SIZES, KINDS };

--- a/lib/deck-from-md.js
+++ b/lib/deck-from-md.js
@@ -1,0 +1,110 @@
+// Markdown -> deck spec. Lets a PM write an ordinary doc and get a designed deck.
+// Pure: a markdown string in, a { theme, brand, slides } spec out (fed to buildDeck).
+//
+// Mapping (predictable on purpose):
+//   --- front matter ---   theme / brand / accent
+//   # H1 (first)           -> title slide (sub = the paragraph under it)
+//   ## H2 with 2-4 bullets -> columns slide (each bullet "**Lead** rest" -> a column)
+//   ## H2 with "**X** label" only -> bignumber slide
+//   ## H2 titled Close/CTA/Thanks -> close slide
+//   ## H2 otherwise        -> statement slide (sub = the paragraph under it)
+// Emphasis (**bold**) is preserved and rendered in the accent by the engine.
+
+function parseFrontMatter(md) {
+  const out = { theme: null, brand: null, accent: null };
+  const m = md.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) return { body: md, fm: out };
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z_]+):\s*(.+?)\s*$/);
+    if (!kv) continue;
+    const k = kv[1].toLowerCase();
+    const v = kv[2].trim().replace(/^["']|["']$/g, '');
+    if (k === 'theme') out.theme = v;
+    else if (k === 'brand') out.brand = v;
+    else if (k === 'accent') out.accent = v;
+  }
+  return { body: md.slice(m[0].length), fm: out };
+}
+
+// group a section's lines into bullets[] and paragraphs[]
+function splitBody(lines) {
+  const bullets = [];
+  const paras = [];
+  let buf = [];
+  const flush = () => { if (buf.length) { paras.push(buf.join(' ').trim()); buf = []; } };
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+    if (/^\s*[-*+]\s+/.test(line)) { flush(); bullets.push(line.replace(/^\s*[-*+]\s+/, '').trim()); }
+    else if (/^\s*$/.test(line)) flush();
+    else if (/^\s*>\s+/.test(line)) { flush(); paras.push(line.replace(/^\s*>\s+/, '').trim()); }
+    else buf.push(line.trim());
+  }
+  flush();
+  return { bullets, paras: paras.filter(Boolean) };
+}
+
+// "**Lead** rest" / "Lead: rest" / "Lead - rest" -> { h, b }
+function toColumn(bullet) {
+  let m = bullet.match(/^\*\*(.+?)\*\*[\s:.-]*(.*)$/);
+  if (m) return { h: m[1].trim(), b: m[2].trim() };
+  m = bullet.match(/^([^:]{2,48}):\s+(.+)$/);
+  if (m) return { h: m[1].trim(), b: m[2].trim() };
+  return { h: bullet.trim(), b: '' };
+}
+
+// a single "**value** label" paragraph -> big number slide
+function asBigNumber(paras, bullets) {
+  if (bullets.length || paras.length !== 1) return null;
+  const m = paras[0].match(/^\*\*([^*]{1,18})\*\*\s+(.+)$/);
+  if (!m) return null;
+  return { type: 'bignumber', number: m[1].trim(), label: m[2].trim() };
+}
+
+const CLOSE_TITLES = /^(close|thanks|thank you|cta|call to action|get started|wrap up|next steps?)$/i;
+
+function parseMarkdownToSpec(md, opts = {}) {
+  const { body, fm } = parseFrontMatter(String(md || ''));
+  const theme = opts.theme || fm.theme || 'terminal';
+  const brand = {
+    name: opts.brandName || fm.brand || 'Atris',
+    accent: opts.accent || fm.accent || '.',
+  };
+
+  // collect sections by heading
+  const sections = [];
+  let cur = null;
+  for (const raw of body.split(/\r?\n/)) {
+    const h1 = raw.match(/^#\s+(.+)/);
+    const h2 = raw.match(/^##\s+(.+)/);
+    if (h1) { cur = { level: 1, title: h1[1].trim(), lines: [] }; sections.push(cur); }
+    else if (h2) { cur = { level: 2, title: h2[1].trim(), lines: [] }; sections.push(cur); }
+    else if (cur) cur.lines.push(raw);
+  }
+
+  const slides = [];
+  sections.forEach((sec, idx) => {
+    const { bullets, paras } = splitBody(sec.lines);
+    const firstPara = paras[0] || '';
+
+    if (sec.level === 1 && slides.length === 0) {
+      slides.push({ type: 'title', headline: sec.title, sub: firstPara || undefined });
+      return;
+    }
+    if (CLOSE_TITLES.test(sec.title)) {
+      slides.push({ type: 'close', tagline: firstPara || sec.title, footer: bullets[0] || undefined });
+      return;
+    }
+    const big = asBigNumber(paras, bullets);
+    if (big) { slides.push(big); return; }
+    if (bullets.length >= 2 && bullets.length <= 4 && bullets.every((b) => b.length <= 160)) {
+      slides.push({ type: 'columns', heading: sec.title, columns: bullets.map(toColumn) });
+      return;
+    }
+    slides.push({ type: 'statement', text: sec.title, sub: firstPara || undefined });
+  });
+
+  if (!slides.length) slides.push({ type: 'statement', text: brand.name });
+  return { theme, brand, slides };
+}
+
+module.exports = { parseMarkdownToSpec, parseFrontMatter, splitBody, toColumn };

--- a/lib/html-render.js
+++ b/lib/html-render.js
@@ -1,0 +1,257 @@
+// Atris HTML renderer — same content model as the deck engine, rendered to
+// beautiful, anti-slop HTML made of semantic blocks. Pure: spec -> HTML string.
+//
+// Connects with the web apps: the `atris` theme matches atrisos-web tokens
+// (amber #f59e0b on warm dark, --brand-* CSS variables), every section carries
+// data-atris-block="<type>", and renderBlock() emits the AppBlock html shape
+// ({ type:'html', config:{ html } }) so the output drops into an Atris app.
+//
+// Anti-slop by construction: one accent, fluid type, restraint, no gradient
+// text, no glassmorphism, em dashes sanitized (shares slides-deck helpers).
+
+const { THEMES: DECK_THEMES, sanitize, parseEmph } = require('./slides-deck');
+
+// HTML themes reuse the deck design-system shape, plus `atris` (matches the web app).
+const THEMES = {
+  atris: { // warm dark, amber accent, matches atrisos-web (--brand-* tokens, TWKLausanne)
+    fonts: { display: 'TWKLausanne', body: 'TWKLausanne', mono: 'ui-monospace, SFMono-Regular, monospace' },
+    color: { bg: '#141110', panel: '#1E1915', panelAlt: '#2C2520', line: '#3D332D',
+      ink: '#EAE3D9', soft: '#A39B92', faint: '#7C736B',
+      accent: '#F59E0B', accent2: '#FBBF24', onAccent: '#141110',
+      sev: ['#F59E0B', '#FBBF24', '#7F97A4'] },
+  },
+  terminal: DECK_THEMES.terminal,
+  paper: DECK_THEMES.paper,
+};
+
+function esc(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// **emphasis** -> <span class="accent">; everything else escaped. Sanitized first.
+function rich(markup) {
+  const { plain, ranges } = parseEmph(sanitize(markup));
+  if (!ranges.length) return esc(plain);
+  let out = '', i = 0;
+  for (const r of ranges) {
+    out += esc(plain.slice(i, r.start));
+    out += `<span class="accent">${esc(plain.slice(r.start, r.end))}</span>`;
+    i = r.end;
+  }
+  out += esc(plain.slice(i));
+  return out;
+}
+
+function wordmark(brand) {
+  const name = esc((brand && brand.name) || 'Atris');
+  const ac = (brand && brand.accent) || '';
+  return `<div class="mark">${name}${ac ? `<b>${esc(ac)}</b>` : ''}</div>`;
+}
+
+function panelHtml(p) {
+  const rows = (p.rows || []).map((r, i) => `
+        <div class="row${r.active ? ' active' : ''}">
+          <span class="sev s${(r.sev != null ? r.sev : 0) % 3}"></span>
+          <div class="name">${rich(r.title || '')}${r.sub ? `<small>${rich(r.sub)}</small>` : ''}</div>
+          ${r.value != null ? `<div class="val"><b>${rich(String(r.value))}</b>${r.valueSub ? `<small>${rich(r.valueSub)}</small>` : ''}</div>` : ''}
+        </div>`).join('');
+  return `<div class="panel">
+        ${p.header ? `<div class="panel-head"><span>${rich(p.header.title || '')}</span>${p.header.meta ? `<span class="meta">${rich(p.header.meta)}</span>` : ''}</div>` : ''}
+        ${rows}
+        ${p.footer ? `<div class="panel-foot"><span>${rich(p.footer.left || '')}</span>${p.footer.right ? `<a>${rich(p.footer.right)}</a>` : ''}</div>` : ''}
+      </div>`;
+}
+
+const BLOCKS = {
+  title(s, spec) {
+    return `<section class="block hero" data-atris-block="hero">
+      <div class="lede">
+        ${wordmark(spec.brand)}
+        <div class="rule"></div>
+        <h1>${rich(s.headline || s.title || '')}</h1>
+        ${s.sub ? `<p class="sub">${rich(s.sub)}</p>` : ''}
+      </div>
+      ${s.panel ? panelHtml(s.panel) : ''}
+    </section>`;
+  },
+  statement(s) {
+    return `<section class="block statement" data-atris-block="statement">
+      <h2 class="big">${rich(s.text || s.headline || '')}</h2>
+      ${s.sub ? `<p class="sub">${rich(s.sub)}</p>` : ''}
+    </section>`;
+  },
+  columns(s) {
+    const cols = (s.columns || []).map((c) => `
+        <div class="col"><h3>${rich(c.h || c.title || '')}</h3>${(c.b || c.body) ? `<p>${rich(c.b || c.body)}</p>` : ''}</div>`).join('');
+    return `<section class="block columns" data-atris-block="columns">
+      ${s.heading ? `<h2 class="heading">${rich(s.heading)}</h2>` : ''}
+      <div class="cols c${Math.min((s.columns || []).length, 4)}">${cols}</div>
+    </section>`;
+  },
+  panel(s) {
+    return `<section class="block panel-block" data-atris-block="panel">
+      <div class="panel-lede">${s.heading ? `<h2>${rich(s.heading)}</h2>` : ''}${s.sub ? `<p>${rich(s.sub)}</p>` : ''}</div>
+      ${panelHtml(s.panel || { rows: [] })}
+    </section>`;
+  },
+  bignumber(s) {
+    return `<section class="block bignumber" data-atris-block="bignumber">
+      <div class="num">${rich(String(s.number || s.value || ''))}</div>
+      ${s.label ? `<div class="num-label">${rich(s.label)}</div>` : ''}
+      ${s.sub ? `<p class="sub">${rich(s.sub)}</p>` : ''}
+    </section>`;
+  },
+  quote(s) {
+    return `<section class="block quote" data-atris-block="quote">
+      <blockquote>${rich(s.text || s.quote || '')}</blockquote>
+      ${s.by ? `<cite>${rich(s.by)}</cite>` : ''}
+    </section>`;
+  },
+  toc(s) {
+    const items = (s.items || []).map((it) =>
+      `<a class="toc-item" href="${esc(it.href)}"><h3>${rich(it.title || it.href)}</h3>${it.summary ? `<p>${rich(it.summary)}</p>` : ''}</a>`).join('');
+    return `<section class="block toc" data-atris-block="toc">
+      ${s.heading ? `<h2 class="heading">${rich(s.heading)}</h2>` : ''}
+      <div class="toc-grid">${items}</div>
+    </section>`;
+  },
+  close(s, spec) {
+    const btns = (s.buttons || []).map((b) => `<a class="btn${b.primary ? ' primary' : ''}">${rich(b.label || 'Open')}</a>`).join('');
+    return `<section class="block close" data-atris-block="close">
+      <div class="rule center"></div>
+      ${wordmark(spec.brand)}
+      ${s.tagline ? `<p class="tagline">${rich(s.tagline)}</p>` : ''}
+      ${btns ? `<div class="btns">${btns}</div>` : ''}
+      ${s.footer ? `<p class="footer">${rich(s.footer)}</p>` : ''}
+    </section>`;
+  },
+};
+
+function css(theme) {
+  const c = theme.color, f = theme.fonts;
+  const gFonts = (f.display === 'Fraunces' || f.body === 'Outfit')
+    ? `<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500&family=Outfit:wght@300;400;500;600&display=swap" rel="stylesheet">`
+    : '';
+  const style = `:root{
+  --brand-bg:${c.bg};--brand-card:${c.panel};--brand-surface:${c.panelAlt || c.panel};--brand-line:${c.line};
+  --brand-text:${c.ink};--brand-text-secondary:${c.soft};--brand-faint:${c.faint};
+  --brand-primary:${c.accent};--brand-primary-2:${c.accent2};
+  --font-display:${f.display === 'TWKLausanne' ? "'TWKLausanne',system-ui,sans-serif" : `'${f.display}',serif`};
+  --font-body:${f.body === 'TWKLausanne' ? "'TWKLausanne',system-ui,sans-serif" : `'${f.body}',sans-serif`};
+  --ease:cubic-bezier(.25,1,.5,1);--measure:60ch;
+}
+*{margin:0;box-sizing:border-box}
+html{-webkit-font-smoothing:antialiased}
+body{font-family:var(--font-body);color:var(--brand-text);background:
+  radial-gradient(120% 80% at 88% -8%, ${c.accent}1f, transparent 56%),
+  radial-gradient(70% 60% at -6% 4%, ${c.soft}14, transparent 52%), var(--brand-bg);
+  line-height:1.5;font-variant-numeric:tabular-nums}
+.wrap{max-width:1140px;margin:0 auto;padding:clamp(28px,5vw,72px) clamp(20px,5vw,56px)}
+.block{padding:clamp(40px,7vw,96px) 0;border-bottom:1px solid var(--brand-line)}
+.block:last-child{border-bottom:0}
+.mark{font-family:var(--font-display);font-weight:500;font-size:20px;letter-spacing:-.01em}
+.mark b{color:var(--brand-primary);font-weight:500}
+.rule{width:40px;height:2px;background:var(--brand-primary);margin:22px 0}.rule.center{margin:0 auto 22px}
+.hero{display:grid;grid-template-columns:1.05fr .95fr;gap:clamp(32px,6vw,80px);align-items:center;border-bottom:0;padding-top:clamp(24px,4vw,48px)}
+@media(max-width:860px){.hero{grid-template-columns:1fr}}
+h1{font-family:var(--font-display);font-weight:300;font-size:clamp(2.6rem,6vw,4.6rem);line-height:.99;letter-spacing:-.02em}
+.accent{color:var(--brand-primary-2);font-style:italic}
+.sub{max-width:var(--measure);color:var(--brand-text-secondary);font-size:clamp(1rem,1.4vw,1.15rem);margin-top:22px}
+.big{font-family:var(--font-display);font-weight:300;font-size:clamp(2.2rem,5vw,3.6rem);line-height:1.02;letter-spacing:-.02em}
+.heading{font-family:var(--font-display);font-weight:400;font-size:clamp(1.6rem,3vw,2rem);margin-bottom:34px}
+.cols{display:grid;gap:clamp(20px,4vw,48px)}.cols.c2{grid-template-columns:repeat(2,1fr)}.cols.c3{grid-template-columns:repeat(3,1fr)}.cols.c4{grid-template-columns:repeat(4,1fr)}
+@media(max-width:720px){.cols{grid-template-columns:1fr!important}}
+.col{border-top:1px solid var(--brand-line);padding-top:18px}
+.col h3{font-family:var(--font-display);font-weight:400;font-size:1.25rem;margin-bottom:8px}
+.col p{color:var(--brand-text-secondary);font-size:.97rem;max-width:36ch}
+.panel-block{display:grid;grid-template-columns:.85fr 1.15fr;gap:clamp(24px,5vw,64px);align-items:center}
+@media(max-width:760px){.panel-block{grid-template-columns:1fr}}
+.panel-lede h2{font-family:var(--font-display);font-weight:400;font-size:1.7rem;margin-bottom:14px}
+.panel-lede p{color:var(--brand-text-secondary);max-width:34ch}
+.panel{background:var(--brand-card);border:1px solid var(--brand-line);border-radius:14px;overflow:hidden;box-shadow:0 1px 2px rgba(0,0,0,.18)}
+.panel-head{display:flex;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--brand-line);font-size:14px}
+.panel-head .meta{color:var(--brand-faint);font-size:12.5px}
+.row{display:grid;grid-template-columns:auto 1fr auto;gap:14px;align-items:center;padding:14px 18px;border-bottom:1px solid var(--brand-surface)}
+.row:last-child{border-bottom:0}.row.active{border-left:2px solid var(--brand-primary);padding-left:16px}
+.sev{width:8px;height:8px;border-radius:50%}.sev.s0{background:var(--brand-primary)}.sev.s1{background:var(--brand-primary-2)}.sev.s2{background:#7f97a4}
+.name{font-size:14.5px}.name small{display:block;color:var(--brand-faint);font-size:12.5px;margin-top:3px}
+.val{text-align:right;font-size:12.5px;color:var(--brand-faint)}.val b{display:block;color:var(--brand-text);font-size:15px}
+.panel-foot{display:flex;justify-content:space-between;padding:13px 18px;font-size:13px;color:var(--brand-faint)}
+.panel-foot a{color:var(--brand-primary-2);text-decoration:none}
+.bignumber .num{font-family:var(--font-display);font-weight:300;font-size:clamp(3.5rem,11vw,7rem);line-height:1;color:var(--brand-primary-2)}
+.num-label{font-size:1.05rem;margin-top:18px}
+.quote blockquote{font-family:var(--font-display);font-weight:300;font-style:italic;font-size:clamp(1.6rem,3.4vw,2.4rem);line-height:1.25;max-width:24ch;quotes:'\\201C''\\201D'}
+.quote blockquote::before{content:open-quote;color:var(--brand-primary)}.quote blockquote::after{content:close-quote;color:var(--brand-primary)}
+.quote cite{display:block;margin-top:20px;color:var(--brand-text-secondary);font-style:normal;font-size:.95rem}
+.close{text-align:center;border-bottom:0}
+.close .mark{font-family:var(--font-display);font-size:clamp(2.4rem,6vw,3.4rem);font-weight:400}
+.tagline{color:var(--brand-text-secondary);margin-top:10px}
+.btns{display:flex;gap:12px;justify-content:center;margin-top:28px}
+.btn{padding:12px 22px;border-radius:11px;border:1px solid var(--brand-line);color:var(--brand-text);text-decoration:none;font-weight:500;font-size:15px;transition:transform 160ms var(--ease),background-color 160ms var(--ease)}
+.btn:hover{transform:translateY(-1px)}.btn.primary{background:var(--brand-text);color:var(--brand-bg);border-color:var(--brand-text)}
+.footer{margin-top:30px;color:var(--brand-faint);font-size:13px}
+.sitenav{display:flex;justify-content:space-between;align-items:baseline;max-width:1140px;margin:0 auto;padding:20px clamp(20px,5vw,56px);border-bottom:1px solid var(--brand-line)}
+.sitenav .mark{font-size:18px;text-decoration:none;color:var(--brand-text)}
+.sitenav .nav-links{display:flex;gap:24px;font-size:14px;color:var(--brand-text-secondary)}
+.sitenav .nav-links a{color:inherit;text-decoration:none;transition:color 160ms var(--ease)}
+.sitenav .nav-links a:hover{color:var(--brand-text)}
+.toc-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:clamp(16px,3vw,32px)}
+.toc-item{display:block;border-top:1px solid var(--brand-line);padding-top:16px;text-decoration:none;color:inherit;transition:border-color 160ms var(--ease)}
+.toc-item:hover{border-color:var(--brand-primary)}
+.toc-item h3{font-family:var(--font-display);font-weight:400;font-size:1.15rem;margin-bottom:6px}
+.toc-item p{color:var(--brand-text-secondary);font-size:.92rem;max-width:40ch}
+@media(prefers-reduced-motion:reduce){*{transition:none!important}}`;
+  return { gFonts, style };
+}
+
+function renderBody(spec, opts = {}) {
+  const themes = opts.themes || THEMES;
+  const theme = themes[spec.theme] || THEMES.atris;
+  const blocks = (spec.slides || spec.blocks || [])
+    .map((s) => (BLOCKS[s.type] || BLOCKS.statement)(s, spec))
+    .join('\n      ');
+  return { theme, html: `<div class="wrap">\n      ${blocks}\n    </div>` };
+}
+
+function renderNav(nav) {
+  const links = (nav.links || []).map((l) => `<a href="${esc(l.href)}">${esc(l.label)}</a>`).join('');
+  return `<nav class="sitenav"><a class="mark" href="${esc(nav.home || 'index.html')}">${esc(nav.label || 'Atris')}${nav.accent ? `<b>${esc(nav.accent)}</b>` : ''}</a>${links ? `<div class="nav-links">${links}</div>` : ''}</nav>`;
+}
+
+// full standalone page (opts.nav renders a site header, opts.themes injects brand themes)
+function renderHtml(spec, opts = {}) {
+  const { theme, html } = renderBody(spec, opts);
+  const { gFonts, style } = css(theme);
+  const title = esc(sanitize(opts.title || (spec.brand && spec.brand.name) || 'Atris'));
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+${gFonts}
+<style>${style}</style>
+</head>
+<body data-atris-theme="${esc(spec.theme || 'atris')}">
+    ${opts.nav ? renderNav(opts.nav) : ''}
+    ${html}
+</body>
+</html>`;
+}
+
+// AppBlock html shape, ready to embed in an Atris app (ui_template 'html'/'block')
+function renderBlock(spec, opts = {}) {
+  return {
+    type: 'html',
+    title: opts.title || (spec.brand && spec.brand.name) || 'Atris',
+    config: {
+      block_type: 'html',
+      title: opts.title || (spec.brand && spec.brand.name) || 'Atris',
+      html: renderHtml(spec, opts),
+      theme: spec.theme || 'atris',
+    },
+  };
+}
+
+module.exports = { renderHtml, renderBlock, renderBody, THEMES, BLOCKS, rich, esc };

--- a/lib/memory-view.js
+++ b/lib/memory-view.js
@@ -1,0 +1,95 @@
+// Memory view — another way to look at memory updates. Reads the workspace's
+// compounding memory (lessons.md, learnings.jsonl, task projection) and builds a
+// content spec rendered as a beautiful HTML page by lib/html-render.
+//
+// Pure-ish: file reads in, a { theme, brand, slides } spec out. Anti-slop by
+// construction (the renderer sanitizes, so em dashes in the raw lessons file
+// never reach the page).
+
+const fs = require('fs');
+const path = require('path');
+
+// "- **[2026-06-18] some-id** — pass — text..." -> { date, id, status, text }
+function parseLessons(text) {
+  const out = [];
+  for (const line of String(text || '').split('\n')) {
+    const m = line.match(/^-\s*\*\*\[([^\]]+)\]\s*([^*]+?)\*\*\s*[—:-]*\s*(pass|fail)?\s*[—:-]*\s*(.*)$/i);
+    if (!m) continue;
+    out.push({ date: m[1].trim(), id: m[2].trim(), status: (m[3] || '').toLowerCase(), text: m[4].trim() });
+  }
+  return out; // append-only file: oldest first
+}
+
+function parseLearnings(text) {
+  const out = [];
+  for (const line of String(text || '').split('\n')) {
+    if (!line.trim()) continue;
+    try { const j = JSON.parse(line); out.push({ ts: j.ts, type: j.type, key: j.key, insight: j.insight }); } catch {}
+  }
+  return out;
+}
+
+function readFileSafe(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+function readTaskCounts(root) {
+  try {
+    const j = JSON.parse(readFileSafe(path.join(root, '.atris', 'state', 'tasks.projection.json')));
+    const tasks = Array.isArray(j.tasks) ? j.tasks : [];
+    const by = (s) => tasks.filter((t) => (t.status || '').toLowerCase() === s).length;
+    return { total: tasks.length, done: by('done') + by('accepted'), active: by('active') + by('in_progress'), review: by('review') + by('ready') };
+  } catch { return null; }
+}
+
+function gatherMemory(root = process.cwd()) {
+  const lessons = parseLessons(readFileSafe(path.join(root, 'atris', 'lessons.md')));
+  const learnings = parseLearnings(readFileSafe(path.join(root, 'atris', 'learnings.jsonl')));
+  const tasks = readTaskCounts(root);
+  return { lessons, learnings, tasks };
+}
+
+function clip(s, n) { s = String(s || ''); return s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s; }
+function titleize(id) { return String(id || '').replace(/[-_]+/g, ' ').trim(); }
+function plural(n, word) { return `${n} ${word}${n === 1 ? '' : 's'}`; }
+
+function buildMemorySpec(root = process.cwd(), opts = {}) {
+  const theme = opts.theme || 'atris';
+  const brand = { name: opts.brand || 'Atris', accent: '.' };
+  const { lessons, learnings, tasks } = gatherMemory(root);
+  const recent = lessons.slice(-8).reverse(); // newest first
+
+  const slides = [];
+  slides.push({
+    type: 'title',
+    headline: 'What the workspace **learned**',
+    sub: `${plural(lessons.length, 'lesson')} and ${plural(learnings.length, 'note')} compounded into memory${tasks ? `, ${plural(tasks.done, 'task')} done` : ''}.`,
+  });
+  slides.push({ type: 'bignumber', number: String(lessons.length), label: 'lessons compounded into the workspace' });
+
+  if (recent.length) {
+    slides.push({
+      type: 'columns', heading: 'Most recent lessons',
+      columns: recent.slice(0, 3).map((l) => ({ h: titleize(l.id), b: clip(l.text, 150) })),
+    });
+    slides.push({
+      type: 'panel', heading: 'Memory updates', sub: 'Lessons and notes, newest first.',
+      panel: {
+        header: { title: 'Recent updates', meta: `${recent.length} shown` },
+        rows: recent.map((l, i) => ({
+          title: titleize(l.id), sub: l.date,
+          value: l.status || 'note', sev: l.status === 'fail' ? 0 : (l.status === 'pass' ? 2 : 1),
+          active: i === 0,
+        })),
+      },
+    });
+  }
+  if (learnings.length) {
+    slides.push({
+      type: 'columns', heading: 'Notes from the field',
+      columns: learnings.slice(-3).reverse().map((n) => ({ h: titleize(n.key || n.type || 'note'), b: clip(n.insight, 150) })),
+    });
+  }
+  slides.push({ type: 'close', tagline: 'Memory lives in the filesystem, not the model.', footer: `${brand.name} workspace memory` });
+  return { theme, brand, slides };
+}
+
+module.exports = { buildMemorySpec, gatherMemory, parseLessons, parseLearnings, readTaskCounts };

--- a/lib/reel.js
+++ b/lib/reel.js
@@ -1,0 +1,52 @@
+// atris reel — a card, animated. A reel is the card from lib/card.js rendered at
+// progress t in [0,1]: each element fades and rises in on a staggered schedule.
+// Pure: (spec, t) -> HTML for that single frame. commands/reel.js screenshots the
+// frames (same Chrome as card) and ffmpeg-encodes them. No new dependency.
+
+const { buildCard } = require('./card');
+
+const clamp01 = (x) => Math.max(0, Math.min(1, x));
+const easeOutCubic = (p) => 1 - Math.pow(1 - clamp01(p), 3);
+// reveal progress of an element whose window is [a,b], at global time t
+const win = (t, a, b) => easeOutCubic((t - a) / (b - a));
+
+// staggered reveal windows by element class. A kind only has some of these;
+// overriding a class that isn't present is harmless.
+const STAGGER = [
+  ['.rule', 0.00, 0.16],
+  ['.kicker', 0.10, 0.30],
+  ['.qmark', 0.10, 0.30],
+  ['.headline', 0.18, 0.46],
+  ['.qtext', 0.20, 0.50],
+  ['.big', 0.16, 0.46],
+  ['.statlabel', 0.34, 0.58],
+  ['.sub', 0.40, 0.62],
+  ['.by', 0.46, 0.66],
+  ['.foot', 0.58, 0.80],
+];
+
+// CSS that places every element at its reveal state for time t (one-shot, no loops)
+function revealCss(t, dist = 16) {
+  const tt = clamp01(t);
+  let css = '';
+  for (const [sel, a, b] of STAGGER) {
+    const p = win(tt, a, b);
+    css += `${sel}{opacity:${p.toFixed(3)};transform:translateY(${((1 - p) * dist).toFixed(2)}px)}`;
+  }
+  return css;
+}
+
+// HTML for a single reel frame at time t. Reuses the card, appends the reveal styles.
+function buildReelFrame(spec, t, opts = {}) {
+  const card = buildCard(spec, opts);
+  const overrides = `<style id="reel">${revealCss(t)}</style>`;
+  return { html: card.html.replace('</head>', `${overrides}</head>`), width: card.width, height: card.height };
+}
+
+// the list of t values for a reel of `seconds` at `fps` (>=2 frames)
+function reelFrames(seconds = 2.6, fps = 20) {
+  const n = Math.max(2, Math.round(seconds * fps));
+  return Array.from({ length: n }, (_, i) => i / (n - 1));
+}
+
+module.exports = { buildReelFrame, revealCss, reelFrames, win, STAGGER };

--- a/lib/site.js
+++ b/lib/site.js
@@ -1,0 +1,114 @@
+// Static site generator — point it at a folder of markdown (docs, your wiki,
+// memory) and get a beautiful, navigable HTML site in the design system.
+// Builds on lib/deck-from-md (parse) + lib/html-render (render).
+//
+// buildSite(input, opts) -> { outDir, indexPath, pages }. Pure file I/O.
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { parseMarkdownToSpec } = require('./deck-from-md');
+const { renderHtml, THEMES: BUILTIN } = require('./html-render');
+const { mergedThemes } = require('./theme');
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'out', 'coverage', '.cache']);
+const MD_EXTS = new Set(['.md', '.mdx']);
+
+function collectMd(input) {
+  const stat = fs.statSync(input);
+  if (stat.isFile()) return MD_EXTS.has(path.extname(input)) ? [input] : [];
+  const out = [];
+  (function walk(dir) {
+    for (const name of fs.readdirSync(dir).sort()) {
+      if (name.startsWith('.')) continue;
+      const full = path.join(dir, name);
+      let st; try { st = fs.statSync(full); } catch { continue; }
+      if (st.isDirectory()) { if (!SKIP_DIRS.has(name)) walk(full); }
+      else if (MD_EXTS.has(path.extname(name))) out.push(full);
+    }
+  })(input);
+  return out;
+}
+
+function slugFor(file, root) {
+  // base = the dir the site was built from (root may be a dir or a single .md file)
+  const base = MD_EXTS.has(path.extname(root)) ? path.dirname(root) : root;
+  const rel = path.relative(base, file).replace(/\.[^.]+$/, '');
+  return rel.replace(/[\\/]+/g, '-').replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase() || 'page';
+}
+
+function firstHeading(md) {
+  const m = md.match(/^#{1,2}\s+(.+)$/m);
+  return m ? m[1].replace(/\*\*/g, '').trim() : null;
+}
+function firstParagraph(md) {
+  const body = md.replace(/^---\n[\s\S]*?\n---\n/, '');
+  for (const line of body.split('\n')) {
+    const t = line.trim();
+    if (!t || /^[#<>]/.test(t) || /^[-*+]/.test(t) || /^\|/.test(t) || /^```/.test(t)) continue;
+    return t.replace(/\*\*/g, '');
+  }
+  return '';
+}
+function clip(s, n) { s = String(s || ''); return s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s; }
+function titleFromSlug(slug) { return slug.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()); }
+
+function buildSite(input, opts = {}) {
+  const THEMES = mergedThemes(BUILTIN, opts.root || process.cwd());
+  const theme = THEMES[opts.theme] ? opts.theme : 'atris';
+  const siteTitle = opts.title || 'Atris';
+  const accent = opts.accent || '.';
+  const outDir = opts.out || 'dist';
+  const files = collectMd(input);
+  fs.mkdirSync(outDir, { recursive: true });
+  const nav = { home: 'index.html', label: siteTitle, accent };
+
+  const pages = [];
+  const seen = new Set();
+  for (const file of files) {
+    const md = fs.readFileSync(file, 'utf8');
+    const spec = parseMarkdownToSpec(md, { theme });
+    if (!THEMES[spec.theme]) spec.theme = theme;
+    let slug = slugFor(file, input);
+    while (seen.has(slug)) slug += '-1';
+    seen.add(slug);
+    const title = firstHeading(md) || titleFromSlug(slug);
+    const summary = firstParagraph(md);
+    const outFile = path.join(outDir, slug + '.html');
+    fs.writeFileSync(outFile, renderHtml(spec, { title, nav, themes: THEMES }));
+    pages.push({ src: file, out: outFile, href: slug + '.html', title, summary });
+  }
+
+  const indexSpec = {
+    theme, brand: { name: siteTitle, accent },
+    slides: [
+      { type: 'title', headline: opts.headline || `${siteTitle} **docs**`, sub: opts.sub || `${pages.length} page${pages.length === 1 ? '' : 's'}, one design system.` },
+      { type: 'toc', heading: 'Pages', items: pages.map((p) => ({ href: p.href, title: p.title, summary: clip(p.summary, 120) })) },
+      { type: 'close', tagline: opts.tagline || 'One workspace, one design system.', footer: siteTitle },
+    ],
+  };
+  const indexPath = path.join(outDir, 'index.html');
+  fs.writeFileSync(indexPath, renderHtml(indexSpec, { title: siteTitle, themes: THEMES }));
+  return { outDir, indexPath, pages };
+}
+
+const MIME = { '.html': 'text/html; charset=utf-8', '.css': 'text/css', '.js': 'text/javascript', '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg', '.svg': 'image/svg+xml' };
+
+// minimal static preview server for a built site dir (no deps)
+function serveSite(dir, port = 4321) {
+  const root = path.resolve(dir);
+  const server = http.createServer((req, res) => {
+    let rel = decodeURIComponent((req.url || '/').split('?')[0]);
+    if (rel.endsWith('/')) rel += 'index.html';
+    const file = path.normalize(path.join(root, rel));
+    if (!file.startsWith(root)) { res.writeHead(403); res.end('forbidden'); return; }
+    fs.readFile(file, (err, data) => {
+      if (err) { res.writeHead(404, { 'Content-Type': 'text/plain' }); res.end('not found'); return; }
+      res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+      res.end(data);
+    });
+  });
+  return new Promise((resolve) => server.listen(port, () => resolve({ server, url: `http://localhost:${port}` })));
+}
+
+module.exports = { buildSite, serveSite, collectMd, slugFor, firstHeading, firstParagraph };

--- a/lib/slides-deck.js
+++ b/lib/slides-deck.js
@@ -1,0 +1,237 @@
+// Atris deck engine — turn a plain content spec into a premium, anti-slop
+// Google Slides deck. Pure: spec -> batch-update requests (no network here).
+//
+// The product idea: PMs open Slides and get Arial-on-white slop by default.
+// This engine gives them a described deck rendered in a committed design system
+// (own backgrounds, distinctive fonts, one accent, real data panels). It is
+// built so it CANNOT emit the usual AI tells: em dashes are sanitized, labels
+// stay sentence case, no gradient text, no glassmorphism, one accent hue.
+//
+// Spec shape (see commands/deck.js for the CLI):
+//   { theme: 'terminal'|'paper',
+//     brand: { name: 'Sentinel', accent: '.' },
+//     slides: [ { type, ...fields } ] }
+// Emphasis: wrap a phrase in **double asterisks** to render it in the accent.
+
+// ---------- themes (OKLCH design system, flattened to sRGB hex) ----------
+const THEMES = {
+  terminal: { // warm dark "premium terminal"
+    fonts: { display: 'Fraunces', body: 'Outfit', mono: 'Roboto Mono' },
+    color: { bg: '#1E1A16', panel: '#2A231C', panelAlt: '#2F271F', line: '#3A332B',
+      ink: '#ECE6DD', soft: '#BCB2A4', faint: '#968C7E',
+      accent: '#D98E5C', accent2: '#E3A06B', onAccent: '#1E1A16',
+      sev: ['#D98E5C', '#DBBE84', '#7F97A4'] },
+  },
+  paper: { // light "editorial paper instrument"
+    fonts: { display: 'Fraunces', body: 'Outfit', mono: 'Roboto Mono' },
+    color: { bg: '#FBF8F2', panel: '#FFFFFF', panelAlt: '#F4EEE4', line: '#E5DDCF',
+      ink: '#2B241B', soft: '#6B5F4F', faint: '#877B69',
+      accent: '#B5572E', accent2: '#9A4723', onAccent: '#FFFFFF',
+      sev: ['#B5572E', '#C0883A', '#5F7787'] },
+  },
+};
+const COLOR_ROLES = ['bg', 'panel', 'line', 'ink', 'soft', 'faint', 'accent', 'accent2', 'onAccent'];
+
+const W = 720, H = 405, M = 48; // slide is 720 x 405 PT
+
+// ---------- low-level builder ----------
+function rgb(hex) { const n = parseInt(String(hex).slice(1), 16);
+  return { red: ((n >> 16) & 255) / 255, green: ((n >> 8) & 255) / 255, blue: (n & 255) / 255 }; }
+
+// strip the AI tells the engine refuses to ship. Returns sanitized text.
+function sanitize(t) {
+  return String(t == null ? '' : t)
+    .replace(/\s*[—]\s*/g, ', ')   // em dash -> comma (top AI-writing tell)
+    .replace(/\s-\s/g, ', ')         // spaced hyphen used as a dash
+    .replace(/\bAI-powered\b/gi, 'built for')
+    .replace(/\s{2,}/g, ' ');
+}
+
+// parse **emphasis** -> { plain, ranges:[{start,end}] } (indices into plain)
+function parseEmph(text) {
+  const ranges = []; let plain = ''; let i = 0;
+  while (i < text.length) {
+    if (text[i] === '*' && text[i + 1] === '*') {
+      const close = text.indexOf('**', i + 2);
+      if (close !== -1) { const inner = text.slice(i + 2, close);
+        ranges.push({ start: plain.length, end: plain.length + inner.length });
+        plain += inner; i = close + 2; continue; }
+    }
+    plain += text[i]; i++;
+  }
+  return { plain, ranges };
+}
+
+function makeCtx(theme) {
+  const C = theme.color, F = theme.fonts, requests = [];
+  let uid = 0; const nid = (p) => `${p}_${String(++uid).padStart(4, '0')}`;
+
+  const createSlide = (id) => requests.push({ createSlide: { objectId: id, slideLayoutReference: { predefinedLayout: 'BLANK' } } });
+  const bg = (slide, hex) => requests.push({ updatePageProperties: { objectId: slide,
+    pageProperties: { pageBackgroundFill: { solidFill: { color: { rgbColor: rgb(hex) } } } },
+    fields: 'pageBackgroundFill.solidFill.color' } });
+  const shape = (type, slide, x, y, w, h) => { const id = nid(type.slice(0, 2).toLowerCase());
+    requests.push({ createShape: { objectId: id, shapeType: type, elementProperties: {
+      pageObjectId: slide, size: { width: { magnitude: w, unit: 'PT' }, height: { magnitude: h, unit: 'PT' } },
+      transform: { scaleX: 1, scaleY: 1, translateX: x, translateY: y, unit: 'PT' } } } }); return id; };
+  const fill = (id, hex, outlineHex, weight) => {
+    const props = { shapeBackgroundFill: { solidFill: { color: { rgbColor: rgb(hex) } } } };
+    let fields = 'shapeBackgroundFill.solidFill.color';
+    if (outlineHex) { props.outline = { outlineFill: { solidFill: { color: { rgbColor: rgb(outlineHex) } } }, weight: { magnitude: weight || 1, unit: 'PT' } }; fields += ',outline.outlineFill.solidFill.color,outline.weight'; }
+    else { props.outline = { propertyState: 'NOT_RENDERED' }; fields += ',outline.propertyState'; }
+    requests.push({ updateShapeProperties: { objectId: id, shapeProperties: props, fields } }); return id; };
+  function styleRange(id, s, e, o) { if (e <= s || !o) return;
+    const style = {}, f = [];
+    if (o.family) { style.fontFamily = o.family; f.push('fontFamily'); }
+    if (o.size) { style.fontSize = { magnitude: o.size, unit: 'PT' }; f.push('fontSize'); }
+    if (o.color) { style.foregroundColor = { opaqueColor: { rgbColor: rgb(o.color) } }; f.push('foregroundColor'); }
+    if (o.bold) { style.bold = true; f.push('bold'); }
+    if (o.italic) { style.italic = true; f.push('italic'); }
+    if (!f.length) return;
+    requests.push({ updateTextStyle: { objectId: id, textRange: { type: 'FIXED_RANGE', startIndex: s, endIndex: e }, style, fields: f.join(',') } }); }
+  function box(slide, x, y, w, h, markup, opts = {}) {
+    const { plain, ranges } = parseEmph(sanitize(markup));
+    if (!plain.length) return null;
+    const id = shape('TEXT_BOX', slide, x, y, w, h);
+    requests.push({ insertText: { objectId: id, text: plain } });
+    styleRange(id, 0, plain.length, opts);
+    const accentColor = opts.accent || C.accent2;
+    ranges.forEach((r) => styleRange(id, r.start, r.end, { family: opts.family, size: opts.size, color: accentColor, italic: opts.emphItalic }));
+    if (opts.align || opts.line != null) requests.push({ updateParagraphStyle: { objectId: id, textRange: { type: 'ALL' },
+      style: { ...(opts.align ? { alignment: opts.align } : {}), ...(opts.line != null ? { lineSpacing: opts.line } : {}) },
+      fields: [opts.align && 'alignment', opts.line != null && 'lineSpacing'].filter(Boolean).join(',') } });
+    if (opts.vmid) requests.push({ updateShapeProperties: { objectId: id, shapeProperties: { contentAlignment: 'MIDDLE' }, fields: 'contentAlignment' } });
+    return id; }
+  const rule = (slide, x, y, w, hex) => fill(shape('RECTANGLE', slide, x, y, w, 2), hex || C.accent);
+
+  function wordmark(slide, x, y, size, brand, center) {
+    const name = (brand && brand.name) || 'Atris';
+    const ac = (brand && brand.accent) || '';
+    const id = box(slide, x, y, center ? W - x * 2 : size * 9, size * 1.6, name + ac,
+      { family: F.display, size, color: C.ink, align: center ? 'CENTER' : 'START' });
+    if (ac) styleRange(id, name.length, name.length + ac.length, { family: F.display, size, color: C.accent });
+    return id; }
+
+  // generalized data panel: header + rows + footer
+  function panel(slide, x, y, w, data) {
+    const rows = (data.rows || []).slice(0, 4);
+    const rowH = 38, headH = data.header ? 30 : 0, footH = data.footer ? 26 : 0;
+    const h = headH + rowH * rows.length + footH;
+    fill(shape('ROUND_RECTANGLE', slide, x, y, w, h), C.panel, C.line, 1);
+    if (data.header) {
+      box(slide, x + 14, y + 9, w * 0.6, 16, data.header.title || '', { family: F.body, size: 10.5, color: C.ink });
+      if (data.header.meta) box(slide, x + w - 120, y + 9, 106, 14, data.header.meta, { family: F.body, size: 8.5, color: C.faint, align: 'END' });
+      fill(shape('RECTANGLE', slide, x, y + headH, w, 0.75), C.line);
+    }
+    rows.forEach((r, i) => {
+      const ry = y + headH + i * rowH;
+      if (r.active) fill(shape('RECTANGLE', slide, x, ry, 2, rowH), C.accent);
+      const sev = C.sev[(r.sev != null ? r.sev : 0) % C.sev.length];
+      fill(shape('ELLIPSE', slide, x + 16, ry + rowH / 2 - 3.5, 7, 7), sev);
+      const nameTxt = sanitize(r.title || '') + (r.sub ? '\n' + sanitize(r.sub) : '');
+      const nb = box(slide, x + 30, ry + 6, w - 110, 28, nameTxt, { family: F.body, size: 11, color: C.ink, line: 108 });
+      if (r.sub && nb) styleRange(nb, sanitize(r.title || '').length + 1, nameTxt.length, { family: F.body, size: 9, color: C.faint });
+      if (r.value != null) {
+        const valTxt = String(r.value) + (r.valueSub ? '\n' + r.valueSub : '');
+        const bb = box(slide, x + w - 84, ry + 6, 70, 28, valTxt, { family: F.body, size: 11, color: C.ink, align: 'END' });
+        if (bb) { styleRange(bb, 0, String(r.value).length, { family: F.body, size: 13, color: C.ink, bold: true });
+          if (r.valueSub) styleRange(bb, String(r.value).length + 1, valTxt.length, { family: F.body, size: 8, color: C.faint }); }
+      }
+      if (i < rows.length - 1) fill(shape('RECTANGLE', slide, x, ry + rowH, w, 0.75), C.panelAlt);
+    });
+    if (data.footer) { const fy = y + headH + rowH * rows.length;
+      box(slide, x + 14, fy + 6, w * 0.62, 14, data.footer.left || '', { family: F.body, size: 9, color: C.faint });
+      if (data.footer.right) box(slide, x + w - 84, fy + 6, 70, 14, data.footer.right, { family: F.body, size: 9, color: C.accent2, align: 'END' }); }
+    return h; }
+
+  function chips(slide, x, y, list) { let cx = x;
+    (list || []).forEach((label) => { const t = sanitize(label); const w = 16 + t.length * 6.3;
+      fill(shape('ROUND_RECTANGLE', slide, cx, y, w, 24), C.panel, C.line, 1);
+      box(slide, cx, y, w, 24, t, { family: F.mono, size: 9.5, color: C.faint, align: 'CENTER', vmid: true });
+      cx += w + 10; }); }
+
+  function buttons(slide, y, list) {
+    const items = (list || []).slice(0, 3); const bw = 150, bh = 34, gap = 12;
+    const total = items.length * bw + (items.length - 1) * gap; let bx = (W - total) / 2;
+    items.forEach((b) => { const primary = b.primary;
+      fill(shape('ROUND_RECTANGLE', slide, bx, y, bw, bh), primary ? C.ink : C.bg, primary ? null : C.line, 1);
+      box(slide, bx, y, bw, bh, b.label || 'Button', { family: F.body, size: 12.5, color: primary ? C.bg : C.ink, align: 'CENTER', vmid: true });
+      bx += bw + gap; }); }
+
+  return { requests, C, F, nid, createSlide, bg, shape, fill, box, styleRange, rule, wordmark, panel, chips, buttons };
+}
+
+// ---------- slide archetypes ----------
+const ARCHE = {
+  title(ctx, slide, s, spec) {
+    ctx.wordmark(slide, M, 34, 15, spec.brand);
+    ctx.rule(slide, M, 96, 40);
+    const hasPanel = !!s.panel;
+    ctx.box(slide, M, 110, hasPanel ? 360 : 600, 180, s.headline || s.title || '',
+      { family: ctx.F.display, size: 40, color: ctx.C.ink, line: 100, emphItalic: true });
+    if (s.sub) ctx.box(slide, M, hasPanel ? 300 : 300, hasPanel ? 350 : 540, 70, s.sub, { family: ctx.F.body, size: 12.5, color: ctx.C.soft, line: 120 });
+    if (hasPanel) ctx.panel(slide, 432, 96, 240, s.panel);
+  },
+  statement(ctx, slide, s, spec) {
+    ctx.wordmark(slide, M, 34, 13, spec.brand);
+    ctx.rule(slide, M, 150, 40);
+    ctx.box(slide, M, 164, 600, 120, s.text || s.headline || '', { family: ctx.F.display, size: 46, color: ctx.C.ink, line: 100, emphItalic: true });
+    if (s.sub) ctx.box(slide, M, 286, 480, 70, s.sub, { family: ctx.F.body, size: 14, color: ctx.C.soft, line: 130 });
+  },
+  columns(ctx, slide, s, spec) {
+    ctx.wordmark(slide, M, 34, 13, spec.brand);
+    if (s.heading) ctx.box(slide, M, 110, 560, 34, s.heading, { family: ctx.F.display, size: 26, color: ctx.C.ink });
+    const cols = (s.columns || []).slice(0, 4); const n = cols.length || 1;
+    const span = W - M * 2, gap = 16, colW = (span - (n - 1) * gap) / n, cy = s.heading ? 188 : 150;
+    cols.forEach((c, i) => { const cx = M + i * (colW + gap);
+      if (i > 0) ctx.fill(ctx.shape('RECTANGLE', slide, cx - gap / 2, cy, 0.75, 120), ctx.C.line);
+      ctx.box(slide, cx, cy, colW - 8, 30, c.h || c.title || '', { family: ctx.F.display, size: 17, color: ctx.C.ink });
+      ctx.box(slide, cx, cy + 34, colW - 8, 120, c.b || c.body || '', { family: ctx.F.body, size: 11.5, color: ctx.C.soft, line: 134 }); });
+  },
+  panel(ctx, slide, s, spec) {
+    ctx.wordmark(slide, M, 34, 13, spec.brand);
+    if (s.heading) ctx.box(slide, M, 120, 260, 50, s.heading, { family: ctx.F.display, size: 30, color: ctx.C.ink });
+    if (s.sub) ctx.box(slide, M, 178, 260, 160, s.sub, { family: ctx.F.body, size: 12.5, color: ctx.C.soft, line: 132 });
+    ctx.panel(slide, 360, 110, 312, s.panel || { rows: [] });
+  },
+  chips(ctx, slide, s, spec) {
+    ctx.wordmark(slide, M, 34, 13, spec.brand);
+    if (s.heading) ctx.box(slide, M, 110, 580, 34, s.heading, { family: ctx.F.display, size: 28, color: ctx.C.ink });
+    if (s.sub) ctx.box(slide, M, 162, 480, 64, s.sub, { family: ctx.F.body, size: 12.5, color: ctx.C.soft, line: 132 });
+    ctx.chips(slide, M, 250, s.chips || []);
+    if (s.mono) ctx.box(slide, M, 300, 520, 24, s.mono, { family: ctx.F.mono, size: 12, color: ctx.C.accent2 });
+  },
+  bignumber(ctx, slide, s, spec) {
+    ctx.wordmark(slide, M, 34, 13, spec.brand);
+    ctx.box(slide, M, 138, W - M * 2, 120, s.number || s.value || '', { family: ctx.F.display, size: 92, color: ctx.C.accent2, line: 100 });
+    if (s.label) ctx.box(slide, M, 268, 520, 30, s.label, { family: ctx.F.body, size: 16, color: ctx.C.ink });
+    if (s.sub) ctx.box(slide, M, 300, 480, 50, s.sub, { family: ctx.F.body, size: 12.5, color: ctx.C.soft, line: 130 });
+  },
+  close(ctx, slide, s, spec) {
+    ctx.rule(slide, (W - 48) / 2, 150, 48);
+    const name = (spec.brand && spec.brand.name) || 'Atris';
+    const ac = (spec.brand && spec.brand.accent) || '';
+    const id = ctx.box(slide, 0, 168, W, 64, name + ac, { family: ctx.F.display, size: 52, color: ctx.C.ink, align: 'CENTER' });
+    if (ac && id) ctx.styleRange(id, name.length, name.length + ac.length, { family: ctx.F.display, size: 52, color: ctx.C.accent });
+    if (s.tagline) ctx.box(slide, 0, 244, W, 24, s.tagline, { family: ctx.F.body, size: 14, color: ctx.C.soft, align: 'CENTER' });
+    if (s.buttons) ctx.buttons(slide, 296, s.buttons);
+    if (s.footer) ctx.box(slide, 0, 360, W, 20, s.footer, { family: ctx.F.body, size: 10, color: ctx.C.faint, align: 'CENTER' });
+  },
+};
+
+// ---------- public: spec -> requests ----------
+function buildDeck(spec, opts = {}) {
+  const themes = opts.themes || THEMES;
+  const theme = themes[spec.theme] || THEMES.terminal;
+  const ctx = makeCtx(theme);
+  const slideIds = [];
+  (spec.slides || []).forEach((s, i) => {
+    const sid = `deck_slide_${i + 1}`; slideIds.push(sid);
+    ctx.createSlide(sid);
+    ctx.bg(sid, theme.color.bg);
+    (ARCHE[s.type] || ARCHE.statement)(ctx, sid, s, spec);
+  });
+  return { requests: ctx.requests, slideIds };
+}
+
+module.exports = { buildDeck, THEMES, ARCHE, sanitize, parseEmph, rgb, COLOR_ROLES };

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -1,0 +1,264 @@
+// Brand themes — a project defines its own theme in .atris/theme.json and every
+// renderer (deck, HTML, site, memory view) uses it. Compounds like slop rules:
+// describe your brand once, every deck and page is on-brand.
+//
+// theme.json shapes (both accepted):
+//   { "color": { "accent": "#00A88F", "bg": "#0B1410" }, "fonts": { "display": "Fraunces" } }
+//   { "themes": { "acme": { "color": {...} }, "acme-light": { "color": {...} } } }
+// Partial themes inherit every missing token from the base (a full warm-dark theme).
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_THEME_FILE = path.join('.atris', 'theme.json');
+
+// full base so a project can define just an accent + bg and inherit the rest
+const BASE = {
+  fonts: { display: 'Fraunces', body: 'Outfit', mono: 'ui-monospace, SFMono-Regular, monospace' },
+  color: {
+    bg: '#141110', panel: '#1E1915', panelAlt: '#2C2520', line: '#3D332D',
+    ink: '#EAE3D9', soft: '#A39B92', faint: '#7C736B',
+    accent: '#F59E0B', accent2: '#FBBF24', onAccent: '#141110',
+    sev: ['#F59E0B', '#FBBF24', '#7F97A4'],
+  },
+};
+
+const COLOR_ROLES = ['bg', 'panel', 'panelAlt', 'line', 'ink', 'soft', 'faint', 'accent', 'accent2', 'onAccent'];
+
+function normalizeTheme(t, base = BASE) {
+  const src = t && typeof t === 'object' ? t : {};
+  return {
+    fonts: { ...base.fonts, ...(src.fonts || {}) },
+    color: { ...base.color, ...(src.color || {}), sev: (src.color && src.color.sev) || base.color.sev },
+  };
+}
+
+function isValidThemeShape(t) {
+  if (!t || typeof t !== 'object') return false;
+  const hasColor = t.color && typeof t.color === 'object';
+  const hasFonts = t.fonts && typeof t.fonts === 'object';
+  return Boolean(hasColor || hasFonts);
+}
+
+// returns { name: normalizedTheme } from .atris/theme.json (or {} if none/bad)
+function loadProjectThemes(root = process.cwd()) {
+  let raw;
+  try { raw = JSON.parse(fs.readFileSync(path.join(root, PROJECT_THEME_FILE), 'utf8')); }
+  catch { return {}; }
+  const out = {};
+  if (raw && raw.themes && typeof raw.themes === 'object') {
+    for (const [name, t] of Object.entries(raw.themes)) if (isValidThemeShape(t)) out[name] = normalizeTheme(t);
+  } else if (isValidThemeShape(raw)) {
+    out[raw.name || 'brand'] = normalizeTheme(raw);
+  }
+  return out;
+}
+
+// merge built-in themes with project themes (project wins on name collision)
+function mergedThemes(builtin, root = process.cwd()) {
+  return { ...builtin, ...loadProjectThemes(root) };
+}
+
+function writeStarterTheme(root = process.cwd()) {
+  const file = path.join(root, PROJECT_THEME_FILE);
+  if (fs.existsSync(file)) return { file, already: true };
+  const starter = {
+    name: 'brand',
+    color: { accent: '#00A88F', accent2: '#3FD0B6', bg: '#0B1410', ink: '#E8F0EC' },
+    fonts: { display: 'Fraunces', body: 'Outfit' },
+  };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(starter, null, 2) + '\n');
+  return { file, already: false };
+}
+
+// ---------- color math (WCAG contrast — the tasteful guardrail) ----------
+function hexToRgb(hex) {
+  const h = String(hex == null ? '' : hex).trim().replace(/^#/, '');
+  const full = h.length === 3 ? h.split('').map((c) => c + c).join('') : h;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) return null;
+  return { r: parseInt(full.slice(0, 2), 16), g: parseInt(full.slice(2, 4), 16), b: parseInt(full.slice(4, 6), 16) };
+}
+
+function isHex(hex) { return hexToRgb(hex) != null; }
+
+function normHex(hex) {
+  const c = hexToRgb(hex);
+  if (!c) return null;
+  return '#' + [c.r, c.g, c.b].map((v) => v.toString(16).padStart(2, '0')).join('').toUpperCase();
+}
+
+function relLuminance(hex) {
+  const c = hexToRgb(hex);
+  if (!c) return 0;
+  const lin = [c.r, c.g, c.b].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+}
+
+function contrastRatio(a, b) {
+  const hi = Math.max(relLuminance(a), relLuminance(b));
+  const lo = Math.min(relLuminance(a), relLuminance(b));
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// the readable ink to drop on top of a solid color (near-black vs near-white)
+function bestOnColor(hex, dark = '#141110', light = '#FFFFFF') {
+  return contrastRatio(hex, dark) >= contrastRatio(hex, light) ? dark : light;
+}
+
+// blend two hex colors, t in [0,1] toward `b`
+function mix(a, b, t) {
+  const ca = hexToRgb(a), cb = hexToRgb(b);
+  if (!ca || !cb) return normHex(a) || '#000000';
+  const m = (x, y) => Math.round(x + (y - x) * t);
+  return '#' + [m(ca.r, cb.r), m(ca.g, cb.g), m(ca.b, cb.b)].map((v) => v.toString(16).padStart(2, '0')).join('').toUpperCase();
+}
+
+// ---------- the tasteful vocabulary (moods, fonts) used by `atris theme create` ----------
+const FONT_PERSONALITIES = {
+  'editorial-serif': { display: 'Fraunces', body: 'Outfit', mono: 'IBM Plex Mono' },
+  'clean-sans': { display: 'Space Grotesk', body: 'Outfit', mono: 'IBM Plex Mono' },
+  'mono-forward': { display: 'Space Grotesk', body: 'IBM Plex Mono', mono: 'IBM Plex Mono' },
+};
+
+// each mood is hand-tuned neutral scaffolding + a font pairing + curated accents.
+// the user picks a feeling; we keep the surface tasteful and let their accent lead.
+const MOODS = {
+  editorial: {
+    blurb: 'warm, literary, considered — Fraunces headlines on calm paper',
+    defaultMode: 'dark', fonts: 'editorial-serif',
+    swatches: ['#B5572E', '#D98E5C', '#9E3B2E', '#C08552'],
+    modes: {
+      dark:  { bg: '#1E1A16', panel: '#261F19', panelAlt: '#322820', line: '#443629', ink: '#EDE4D6', soft: '#B0A595', faint: '#837868' },
+      light: { bg: '#FBF8F2', panel: '#F2ECE0', panelAlt: '#E9E1D2', line: '#DCD2C0', ink: '#2A241D', soft: '#6B6256', faint: '#938A7C' },
+    },
+  },
+  technical: {
+    blurb: 'cool, precise, engineered — Space Grotesk on slate, mono accents',
+    defaultMode: 'dark', fonts: 'clean-sans',
+    swatches: ['#3B82F6', '#06B6D4', '#6366F1', '#14B8A6'],
+    modes: {
+      dark:  { bg: '#0E1116', panel: '#161B22', panelAlt: '#1C2330', line: '#2A3340', ink: '#E6EDF3', soft: '#9DA7B3', faint: '#6B7682' },
+      light: { bg: '#F7F9FB', panel: '#EEF2F6', panelAlt: '#E3E9F0', line: '#D2DAE3', ink: '#1A2230', soft: '#5A6675', faint: '#8A95A3' },
+    },
+  },
+  noir: {
+    blurb: 'high-contrast, near-black, one electric accent — confident and stark',
+    defaultMode: 'dark', forceMode: 'dark', fonts: 'clean-sans',
+    swatches: ['#C8FF00', '#FF2D78', '#FFB000', '#7DD3FC'],
+    modes: {
+      dark: { bg: '#0A0A0B', panel: '#131316', panelAlt: '#1B1B20', line: '#2A2A30', ink: '#F4F4F5', soft: '#A1A1AA', faint: '#6E6E76' },
+    },
+  },
+  paper: {
+    blurb: 'calm, light, low-key — ink on cream, nothing shouting',
+    defaultMode: 'light', forceMode: 'light', fonts: 'editorial-serif',
+    swatches: ['#2F4858', '#5B7553', '#B5572E', '#6B4E71'],
+    modes: {
+      light: { bg: '#FBF8F2', panel: '#F2ECE0', panelAlt: '#E9E1D2', line: '#DCD2C0', ink: '#2A241D', soft: '#6B6256', faint: '#938A7C' },
+    },
+  },
+  vivid: {
+    blurb: 'saturated, playful, energetic — a bold accent that carries the page',
+    defaultMode: 'dark', fonts: 'clean-sans',
+    swatches: ['#FF5C5C', '#8B5CF6', '#10B981', '#F59E0B'],
+    modes: {
+      dark:  { bg: '#121016', panel: '#1B1822', panelAlt: '#251F30', line: '#352C42', ink: '#F2EEF7', soft: '#ADA3BC', faint: '#7D7388' },
+      light: { bg: '#FCFAFF', panel: '#F3EFF9', panelAlt: '#E9E2F2', line: '#DAD0E6', ink: '#221B2C', soft: '#645A72', faint: '#938A9F' },
+    },
+  },
+};
+
+const MOOD_NAMES = Object.keys(MOODS);
+
+function resolveFonts(spec, mood) {
+  const m = MOODS[mood] || MOODS.editorial;
+  if (spec && typeof spec === 'object') return { ...FONT_PERSONALITIES[m.fonts], ...spec };
+  const key = spec && FONT_PERSONALITIES[spec] ? spec : m.fonts;
+  return { ...FONT_PERSONALITIES[key] };
+}
+
+function resolveMode(mood, mode) {
+  const m = MOODS[mood] || MOODS.editorial;
+  if (m.forceMode) return m.forceMode;
+  if ((mode === 'light' || mode === 'dark') && m.modes[mode]) return mode;
+  return m.defaultMode;
+}
+
+// pure: tasteful answers -> a full, normalized theme. The heart of `atris theme create`.
+//   answers = { mood, mode?, accent?, accent2?, fonts? }
+function buildTheme(answers = {}) {
+  const moodKey = MOODS[answers.mood] ? answers.mood : 'editorial';
+  const mood = MOODS[moodKey];
+  const mode = resolveMode(moodKey, answers.mode);
+  const surface = mood.modes[mode];
+
+  const accent = normHex(answers.accent) || mood.swatches[0];
+  const accent2 = normHex(answers.accent2) || mix(accent, surface.ink, 0.28);
+  const onAccent = bestOnColor(accent);
+  const fonts = resolveFonts(answers.fonts, moodKey);
+
+  return normalizeTheme({
+    color: { ...surface, accent, accent2, onAccent, sev: [accent, accent2, surface.faint] },
+    fonts,
+  });
+}
+
+// readability guardrail — human messages for low-contrast choices (empty array = clean)
+function themeWarnings(theme) {
+  const c = normalizeTheme(theme).color;
+  const warn = [];
+  const body = contrastRatio(c.ink, c.bg);
+  if (body < 4.5) warn.push(`body text (ink on bg) is ${body.toFixed(1)}:1 — below the 4.5:1 readable floor`);
+  const onAcc = contrastRatio(c.onAccent, c.accent);
+  if (onAcc < 4.5) warn.push(`text on the accent is ${onAcc.toFixed(1)}:1 — below 4.5:1`);
+  const accentBg = contrastRatio(c.accent, c.bg);
+  if (accentBg < 2.0) warn.push(`the accent barely separates from the background (${accentBg.toFixed(1)}:1) — pick a bolder color`);
+  return warn;
+}
+
+// write/replace a named theme in .atris/theme.json (always the themes-map form),
+// preserving every other theme. Throws (code EBADTHEME) if an existing file is present
+// but unparseable, so we never clobber a hand-edited brand file.
+function upsertProjectTheme(name, theme, root = process.cwd(), recipe = null) {
+  const themeName = (String(name == null ? '' : name).trim()) || 'brand';
+  const file = path.join(root, PROJECT_THEME_FILE);
+  let themes = {};
+  if (fs.existsSync(file)) {
+    let raw;
+    try { raw = JSON.parse(fs.readFileSync(file, 'utf8')); }
+    catch { const e = new Error(`${PROJECT_THEME_FILE} is not valid JSON — fix or remove it before saving`); e.code = 'EBADTHEME'; throw e; }
+    if (raw && raw.themes && typeof raw.themes === 'object') themes = { ...raw.themes };
+    else if (isValidThemeShape(raw)) themes[raw.name || 'brand'] = { name: raw.name, color: raw.color, fonts: raw.fonts };
+  }
+  const existed = Object.prototype.hasOwnProperty.call(themes, themeName);
+  const t = normalizeTheme(theme);
+  // recipe = the high-level answers (mood/mode/accent); inert to renderers, lets `theme edit` re-seed
+  const record = { name: themeName };
+  if (recipe && typeof recipe === 'object') record.recipe = recipe;
+  record.color = t.color; record.fonts = t.fonts;
+  themes[themeName] = record;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({ themes }, null, 2) + '\n');
+  return { file, name: themeName, action: existed ? 'updated' : 'created', count: Object.keys(themes).length };
+}
+
+// the saved high-level answers for a theme, if present (for `theme edit` pre-fill)
+function loadThemeRecipe(name, root = process.cwd()) {
+  let raw;
+  try { raw = JSON.parse(fs.readFileSync(path.join(root, PROJECT_THEME_FILE), 'utf8')); }
+  catch { return null; }
+  const rec = raw && raw.themes && raw.themes[name];
+  return rec && rec.recipe && typeof rec.recipe === 'object' ? rec.recipe : null;
+}
+
+module.exports = {
+  BASE, COLOR_ROLES, normalizeTheme, isValidThemeShape, loadProjectThemes, mergedThemes,
+  writeStarterTheme, PROJECT_THEME_FILE,
+  hexToRgb, isHex, normHex, relLuminance, contrastRatio, bestOnColor, mix,
+  FONT_PERSONALITIES, MOODS, MOOD_NAMES, resolveFonts, resolveMode,
+  buildTheme, themeWarnings, upsertProjectTheme, loadThemeRecipe,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.25.2",
+  "version": "3.26.0",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/card.test.js
+++ b/test/card.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildCard, SIZES, KINDS } = require('../lib/card');
+const { THEMES: HTML_THEMES } = require('../lib/html-render');
+const { normalizeTheme } = require('../lib/theme');
+
+test('statement card embeds the headline and the theme tokens', () => {
+  const card = buildCard({ kind: 'statement', headline: 'Ship faster' });
+  assert.equal(card.width, 1200);
+  assert.equal(card.height, 630);
+  assert.match(card.html, /Ship faster/);
+  assert.ok(card.html.includes(HTML_THEMES.atris.color.bg), 'uses the theme background');
+  assert.ok(card.html.includes(HTML_THEMES.atris.color.accent), 'uses the theme accent');
+});
+
+test('every size preset sets the right dimensions', () => {
+  for (const [name, dim] of Object.entries(SIZES)) {
+    const card = buildCard({ headline: 'x', size: name });
+    assert.equal(card.width, dim.w);
+    assert.equal(card.height, dim.h);
+    assert.match(card.html, new RegExp(`width:${dim.w}px;height:${dim.h}px`));
+  }
+});
+
+test('quote card renders the quote and attribution', () => {
+  const card = buildCard({ kind: 'quote', text: 'It just works', by: 'a founder', size: 'square' });
+  assert.match(card.html, /It just works/);
+  assert.match(card.html, /a founder/);
+  assert.match(card.html, /class="qtext"/);
+});
+
+test('stat card renders the number and label', () => {
+  const card = buildCard({ kind: 'stat', number: '10x', label: 'faster reviews' });
+  assert.match(card.html, /class="big"/);
+  assert.match(card.html, /10x/);
+  assert.match(card.html, /faster reviews/);
+});
+
+test('a project/brand theme flows into the card', () => {
+  const themes = { ...HTML_THEMES, brand: normalizeTheme({ color: { accent: '#00A88F', bg: '#0B1410' } }) };
+  const card = buildCard({ headline: 'On brand', theme: 'brand' }, { themes });
+  assert.ok(card.html.includes('#00A88F'), 'uses the brand accent');
+  assert.ok(card.html.includes('#0B1410'), 'uses the brand background');
+  assert.equal(card.theme, 'brand');
+});
+
+test('unknown theme falls back to atris (never throws)', () => {
+  const card = buildCard({ headline: 'hi', theme: 'does-not-exist' });
+  assert.ok(card.html.includes(HTML_THEMES.atris.color.accent));
+});
+
+test('**emphasis** becomes an accent span', () => {
+  const card = buildCard({ headline: 'made **on brand**' });
+  assert.match(card.html, /<span class="accent">on brand<\/span>/);
+});
+
+test('anti-slop: an em dash in input never reaches the output', () => {
+  const card = buildCard({ headline: 'fast — and clean', sub: 'one thing — done' });
+  assert.ok(!card.html.includes('—'), 'no em dash in rendered card');
+});
+
+test('html is escaped (no raw angle brackets from input)', () => {
+  const card = buildCard({ headline: '<script>x</script>' });
+  assert.ok(!card.html.includes('<script>x'), 'input tags are escaped');
+  assert.match(card.html, /&lt;script&gt;/);
+});
+
+test('KINDS and a long headline still produce valid output', () => {
+  assert.deepEqual(KINDS, ['statement', 'quote', 'stat']);
+  const long = 'a very long headline that should shrink to fit the card without overflowing the frame at all';
+  const card = buildCard({ headline: long });
+  assert.match(card.html, /font-size:\d+px/);
+});

--- a/test/deck-from-md.test.js
+++ b/test/deck-from-md.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseMarkdownToSpec, toColumn } = require('../lib/deck-from-md');
+const { buildDeck } = require('../lib/slides-deck');
+
+test('front matter sets theme, brand, accent', () => {
+  const md = `---\ntheme: paper\nbrand: Sentinel\naccent: .\n---\n# Hi\n`;
+  const spec = parseMarkdownToSpec(md);
+  assert.equal(spec.theme, 'paper');
+  assert.equal(spec.brand.name, 'Sentinel');
+  assert.equal(spec.brand.accent, '.');
+});
+
+test('first H1 becomes a title slide with the following paragraph as sub', () => {
+  const md = `# Read your incidents in the **dark.**\n\nOn-call shouldn't mean panic.\n`;
+  const spec = parseMarkdownToSpec(md);
+  assert.equal(spec.slides[0].type, 'title');
+  assert.equal(spec.slides[0].headline, 'Read your incidents in the **dark.**');
+  assert.equal(spec.slides[0].sub, "On-call shouldn't mean panic.");
+});
+
+test('H2 with 2-4 bullets becomes a columns slide', () => {
+  const md = `# T\n\n## What makes it calm\n\n- **Ranked by impact** severity from real blast radius\n- **Quiet by default** one signal per incident\n- **Built for 3am** high contrast, keyboard first\n`;
+  const spec = parseMarkdownToSpec(md);
+  const cols = spec.slides.find((s) => s.type === 'columns');
+  assert.ok(cols, 'expected a columns slide');
+  assert.equal(cols.heading, 'What makes it calm');
+  assert.equal(cols.columns.length, 3);
+  assert.equal(cols.columns[0].h, 'Ranked by impact');
+  assert.match(cols.columns[0].b, /blast radius/);
+});
+
+test('toColumn parses **Lead** rest, Lead: rest, and bare bullets', () => {
+  assert.deepEqual(toColumn('**Fast** ships in seconds'), { h: 'Fast', b: 'ships in seconds' });
+  assert.deepEqual(toColumn('Fast: ships in seconds'), { h: 'Fast', b: 'ships in seconds' });
+  assert.deepEqual(toColumn('just a bullet'), { h: 'just a bullet', b: '' });
+});
+
+test('a single "**value** label" section becomes a bignumber slide', () => {
+  const md = `# T\n\n## Impact\n\n**11 min** median time to first action\n`;
+  const spec = parseMarkdownToSpec(md);
+  const big = spec.slides.find((s) => s.type === 'bignumber');
+  assert.ok(big, 'expected a bignumber slide');
+  assert.equal(big.number, '11 min');
+  assert.equal(big.label, 'median time to first action');
+});
+
+test('Close/CTA section becomes a close slide', () => {
+  const md = `# T\n\n## Close\n\nRead your incidents in the dark.\n`;
+  const spec = parseMarkdownToSpec(md);
+  const close = spec.slides.find((s) => s.type === 'close');
+  assert.ok(close);
+  assert.equal(close.tagline, 'Read your incidents in the dark.');
+});
+
+test('plain H2 with a paragraph becomes a statement slide', () => {
+  const md = `# T\n\n## On-call should not mean panic\n\nSo the console is calm by default.\n`;
+  const spec = parseMarkdownToSpec(md);
+  const st = spec.slides.find((s) => s.type === 'statement');
+  assert.ok(st);
+  assert.equal(st.text, 'On-call should not mean panic');
+  assert.equal(st.sub, 'So the console is calm by default.');
+});
+
+test('the produced spec feeds buildDeck and emits one createSlide per slide', () => {
+  const md = `---\ntheme: terminal\nbrand: Sentinel\n---\n# Hello **world**\n\nIntro line.\n\n## Three things\n\n- **A** one\n- **B** two\n- **C** three\n\n## Close\n\nThanks.\n`;
+  const spec = parseMarkdownToSpec(md);
+  const { requests } = buildDeck(spec);
+  const creates = requests.filter((r) => r.createSlide).length;
+  assert.equal(creates, spec.slides.length);
+  assert.ok(spec.slides.length >= 3);
+});
+
+test('em dashes in the doc never reach a slide (engine sanitizes)', () => {
+  const md = `# Fast, reliable — and calm\n\nShip it — today.\n`;
+  const spec = parseMarkdownToSpec(md);
+  const { requests } = buildDeck(spec);
+  for (const r of requests) if (r.insertText) assert.ok(!r.insertText.text.includes('—'));
+});
+
+test('empty doc still yields a usable spec', () => {
+  const spec = parseMarkdownToSpec('');
+  assert.ok(spec.slides.length >= 1);
+  assert.ok(spec.theme);
+});

--- a/test/html-render.test.js
+++ b/test/html-render.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { renderHtml, renderBlock, THEMES } = require('../lib/html-render');
+const { parseMarkdownToSpec } = require('../lib/deck-from-md');
+const { scanFile } = require('../commands/slop');
+
+const SPEC = {
+  theme: 'atris', brand: { name: 'Aurora', accent: '.' },
+  slides: [
+    { type: 'title', headline: 'Beautiful **HTML**', sub: 'Same content model, new renderer.',
+      panel: { header: { title: 'Active', meta: 'live' }, rows: [{ title: 'A', sub: 'x', value: '42%', sev: 0, active: true }] } },
+    { type: 'columns', heading: 'Why', columns: [{ h: 'One', b: 'first' }, { h: 'Two', b: 'second' }] },
+    { type: 'bignumber', number: '90 sec', label: 'to a page' },
+    { type: 'quote', text: 'It just works.', by: 'a PM' },
+    { type: 'close', tagline: 'Ship it.', buttons: [{ label: 'Open', primary: true }], footer: 'atris.ai' },
+  ],
+};
+
+test('renderHtml emits a full document with a section per block', () => {
+  const html = renderHtml(SPEC);
+  assert.match(html, /^<!doctype html>/);
+  assert.match(html, /<\/html>\s*$/);
+  for (const t of ['hero', 'columns', 'bignumber', 'quote', 'close']) {
+    assert.ok(html.includes(`data-atris-block="${t}"`), `missing block ${t}`);
+  }
+});
+
+test('the atris theme matches atrisos-web tokens (amber + warm dark, --brand-*)', () => {
+  const html = renderHtml({ ...SPEC, theme: 'atris' });
+  assert.match(html, /--brand-primary:#F59E0B/i);
+  assert.match(html, /--brand-bg:#141110/i);
+  assert.match(html, /TWKLausanne/);
+  assert.ok(THEMES.atris && THEMES.atris.color.accent.toUpperCase() === '#F59E0B');
+});
+
+test('**emphasis** renders as an accent span', () => {
+  const html = renderHtml(SPEC);
+  assert.match(html, /<span class="accent">HTML<\/span>/);
+});
+
+test('content is HTML-escaped (no injection)', () => {
+  const html = renderHtml({ theme: 'atris', brand: { name: 'X' }, slides: [{ type: 'statement', text: '<script>alert(1)</script>' }] });
+  assert.ok(!html.includes('<script>alert(1)</script>'));
+  assert.match(html, /&lt;script&gt;/);
+});
+
+test('renderBlock emits the AppBlock html shape for embedding in an app', () => {
+  const block = renderBlock(SPEC, { title: 'Aurora deck' });
+  assert.equal(block.type, 'html');
+  assert.equal(block.config.block_type, 'html');
+  assert.match(block.config.html, /^<!doctype html>/);
+  assert.equal(block.title, 'Aurora deck');
+});
+
+test('generated HTML passes the slop gate (anti-slop by construction)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'html-'));
+  for (const theme of ['atris', 'terminal', 'paper']) {
+    const file = path.join(dir, `page-${theme}.html`);
+    fs.writeFileSync(file, renderHtml({ ...SPEC, theme }));
+    const findings = scanFile(file);
+    assert.equal(findings.length, 0, `${theme}: ${findings.map((f) => f.rule).join(', ')}`);
+  }
+});
+
+test('markdown -> spec -> HTML round trips', () => {
+  const md = `---\ntheme: atris\nbrand: Sentinel\n---\n# Hello **world**\n\nIntro.\n\n## Three\n\n- **A** one\n- **B** two\n- **C** three\n`;
+  const html = renderHtml(parseMarkdownToSpec(md));
+  assert.match(html, /Sentinel/);
+  assert.ok(html.includes('data-atris-block="columns"'));
+  assert.ok(!html.includes('—'));
+});

--- a/test/memory-view.test.js
+++ b/test/memory-view.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { buildMemorySpec, parseLessons, parseLearnings } = require('../lib/memory-view');
+const { renderHtml } = require('../lib/html-render');
+const { scanFile } = require('../commands/slop');
+
+function mkWorkspace(lessonsMd, learningsJsonl) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mem-'));
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+  if (lessonsMd != null) fs.writeFileSync(path.join(dir, 'atris', 'lessons.md'), lessonsMd);
+  if (learningsJsonl != null) fs.writeFileSync(path.join(dir, 'atris', 'learnings.jsonl'), learningsJsonl);
+  return dir;
+}
+
+test('parseLessons reads the lessons.md line format (date, id, status, text)', () => {
+  const ls = parseLessons('- **[2026-06-18] git-first-check** — pass — verify with git diff before git log.\nnoise\n');
+  assert.equal(ls.length, 1);
+  assert.equal(ls[0].date, '2026-06-18');
+  assert.equal(ls[0].id, 'git-first-check');
+  assert.equal(ls[0].status, 'pass');
+  assert.match(ls[0].text, /git diff/);
+});
+
+test('parseLearnings reads JSONL notes', () => {
+  const ns = parseLearnings('{"ts":"t","type":"pitfall","key":"narrow-grep","insight":"grep wide"}\n\n');
+  assert.equal(ns.length, 1);
+  assert.equal(ns[0].key, 'narrow-grep');
+});
+
+test('buildMemorySpec turns memory into a renderable, slop-clean page', () => {
+  const lessons = Array.from({ length: 5 }, (_, i) =>
+    `- **[2026-06-1${i}] lesson-${i}-thing** — ${i % 2 ? 'fail' : 'pass'} — something we learned number ${i} about the loop.`).join('\n');
+  const dir = mkWorkspace(lessons + '\n', '{"ts":"t","type":"note","key":"k","insight":"a field note"}\n');
+  const spec = buildMemorySpec(dir);
+  assert.equal(spec.theme, 'atris');
+  assert.ok(spec.slides.some((s) => s.type === 'bignumber'));
+  assert.ok(spec.slides.some((s) => s.type === 'panel'));
+  // renders and passes the slop gate
+  const out = path.join(dir, 'mem.html');
+  fs.writeFileSync(out, renderHtml(spec));
+  assert.equal(scanFile(out).length, 0);
+});
+
+test('em dashes in the raw lessons file never reach the rendered page', () => {
+  const dir = mkWorkspace('- **[2026-06-18] x-thing** — pass — a — b — c with dashes everywhere.\n');
+  const html = renderHtml(buildMemorySpec(dir));
+  assert.ok(!html.includes('—'), 'renderer sanitizes the source');
+});
+
+test('missing/empty memory still yields a usable spec', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mem-empty-'));
+  const spec = buildMemorySpec(dir);
+  assert.ok(spec.slides.length >= 2);
+  assert.ok(spec.slides[0].type === 'title');
+});

--- a/test/reel.test.js
+++ b/test/reel.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildReelFrame, revealCss, reelFrames, win } = require('../lib/reel');
+const { SIZES } = require('../lib/card');
+
+test('reelFrames returns seconds*fps frames from 0 to 1', () => {
+  const f = reelFrames(2, 20);
+  assert.equal(f.length, 40);
+  assert.equal(f[0], 0);
+  assert.equal(f[f.length - 1], 1);
+});
+
+test('reelFrames never returns fewer than 2 frames', () => {
+  assert.ok(reelFrames(0, 0).length >= 2);
+});
+
+test('at t=1 every element is fully revealed (final card state)', () => {
+  const css = revealCss(1);
+  assert.ok(!/opacity:0\.\d/.test(css), 'no partial opacities at t=1');
+  assert.match(css, /\.headline\{opacity:1\.000;transform:translateY\(0\.00px\)\}/);
+  assert.match(css, /\.foot\{opacity:1\.000/);
+});
+
+test('at t=0 nothing is revealed yet (clean fade-in start)', () => {
+  const css = revealCss(0);
+  assert.match(css, /\.headline\{opacity:0\.000/);
+  assert.match(css, /\.rule\{opacity:0\.000/);
+});
+
+test('reveal is monotonic in t (win increases)', () => {
+  let prev = -1;
+  for (let t = 0; t <= 1.0001; t += 0.1) {
+    const p = win(t, 0.18, 0.46);
+    assert.ok(p >= prev, `win should not decrease at t=${t}`);
+    prev = p;
+  }
+});
+
+test('a mid frame is partially revealed (between 0 and 1)', () => {
+  const css = revealCss(0.3);
+  const m = css.match(/\.headline\{opacity:([\d.]+)/);
+  const o = parseFloat(m[1]);
+  assert.ok(o > 0 && o < 1, `headline mid-opacity should be between 0 and 1, got ${o}`);
+});
+
+test('buildReelFrame reuses the card (right size, appends reveal style)', () => {
+  const frame = buildReelFrame({ headline: 'Ship it', size: 'square' }, 0.5);
+  assert.equal(frame.width, SIZES.square.w);
+  assert.equal(frame.height, SIZES.square.h);
+  assert.match(frame.html, /id="reel"/);
+  assert.match(frame.html, /Ship it/);
+});
+
+test('buildReelFrame is deterministic for a given t', () => {
+  const a = buildReelFrame({ headline: 'same' }, 0.42);
+  const b = buildReelFrame({ headline: 'same' }, 0.42);
+  assert.equal(a.html, b.html);
+});
+
+test('reel inherits the card theme + anti-slop (em dash stripped)', () => {
+  const frame = buildReelFrame({ headline: 'fast — clean', theme: 'paper' }, 1);
+  assert.ok(!frame.html.includes('—'), 'no em dash in a reel frame');
+});

--- a/test/site.test.js
+++ b/test/site.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { buildSite, collectMd, slugFor, firstHeading, firstParagraph } = require('../lib/site');
+const { scanFile } = require('../commands/slop');
+
+function mkDocs() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'site-'));
+  fs.writeFileSync(path.join(dir, 'intro.md'), '# Getting started\n\nHow to begin with the system.\n\n## Steps\n\n- **One** install it\n- **Two** run it\n');
+  fs.mkdirSync(path.join(dir, 'guides'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'guides', 'deep.md'), '# Deep dive\n\nThe details, explained calmly.\n');
+  fs.mkdirSync(path.join(dir, 'node_modules'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'node_modules', 'junk.md'), '# should be skipped\n');
+  return dir;
+}
+
+test('collectMd finds markdown recursively and skips noise dirs', () => {
+  const dir = mkDocs();
+  const files = collectMd(dir).map((f) => path.basename(f));
+  assert.ok(files.includes('intro.md'));
+  assert.ok(files.includes('deep.md'));
+  assert.ok(!files.includes('junk.md'), 'node_modules skipped');
+});
+
+test('slugFor makes flat, safe slugs from nested paths', () => {
+  const dir = '/tmp/docs';
+  assert.equal(slugFor('/tmp/docs/guides/deep.md', dir), 'guides-deep');
+  assert.equal(slugFor('/tmp/docs/Intro Page.md', dir), 'intro-page');
+});
+
+test('firstHeading and firstParagraph extract page meta', () => {
+  const md = '---\ntheme: atris\n---\n# **Hello** world\n\nThe first real line.\n';
+  assert.equal(firstHeading(md), 'Hello world');
+  assert.equal(firstParagraph(md), 'The first real line.');
+});
+
+test('buildSite writes an index + a page per doc, all slop-clean', () => {
+  const dir = mkDocs();
+  const out = path.join(dir, 'dist');
+  const res = buildSite(dir, { out, title: 'Docs' });
+  assert.equal(res.pages.length, 2);
+  assert.ok(fs.existsSync(res.indexPath));
+  // index links to each page
+  const index = fs.readFileSync(res.indexPath, 'utf8');
+  for (const p of res.pages) assert.ok(index.includes(`href="${p.href}"`), `index links ${p.href}`);
+  // nav present on a page, and the index has a toc block
+  assert.ok(fs.readFileSync(res.pages[0].out, 'utf8').includes('class="sitenav"'));
+  assert.ok(index.includes('data-atris-block="toc"'));
+  // every emitted file passes the slop gate
+  for (const f of [res.indexPath, ...res.pages.map((p) => p.out)]) {
+    assert.equal(scanFile(f).length, 0, `${path.basename(f)} should be slop-clean`);
+  }
+});
+
+test('a single markdown file builds a one-page site', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'site1-'));
+  const doc = path.join(dir, 'only.md');
+  fs.writeFileSync(doc, '# Only page\n\nJust one.\n');
+  const res = buildSite(doc, { out: path.join(dir, 'dist') });
+  assert.equal(res.pages.length, 1);
+  assert.ok(fs.existsSync(res.indexPath));
+});

--- a/test/slides-deck.test.js
+++ b/test/slides-deck.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildDeck, THEMES, sanitize, parseEmph, COLOR_ROLES } = require('../lib/slides-deck');
+const { SAMPLE } = require('../commands/deck');
+
+test('every theme defines all color roles + three fonts', () => {
+  for (const [name, t] of Object.entries(THEMES)) {
+    for (const role of COLOR_ROLES) assert.ok(t.color[role], `${name} missing color.${role}`);
+    assert.ok(t.fonts.display && t.fonts.body && t.fonts.mono, `${name} missing a font`);
+  }
+});
+
+test('buildDeck emits one createSlide + one background per slide', () => {
+  const { requests, slideIds } = buildDeck(SAMPLE);
+  const creates = requests.filter((r) => r.createSlide).length;
+  const bgs = requests.filter((r) => r.updatePageProperties).length;
+  assert.equal(creates, SAMPLE.slides.length);
+  assert.equal(bgs, SAMPLE.slides.length);
+  assert.equal(slideIds.length, SAMPLE.slides.length);
+});
+
+test('the engine never ships an em dash (sanitized out of all inserted text)', () => {
+  const spec = { theme: 'terminal', brand: { name: 'X' }, slides: [
+    { type: 'statement', text: 'Fast, reliable — and calm.', sub: 'Ship it — today.' }] };
+  const { requests } = buildDeck(spec);
+  for (const r of requests) if (r.insertText) assert.ok(!r.insertText.text.includes('—'), 'em dash leaked into a slide');
+});
+
+test('**emphasis** is stripped to plain text and styled with the accent', () => {
+  const { plain, ranges } = parseEmph('Read it in the **dark.**');
+  assert.ok(!plain.includes('*'));
+  assert.equal(plain, 'Read it in the dark.');
+  assert.equal(ranges.length, 1);
+  assert.equal(plain.slice(ranges[0].start, ranges[0].end), 'dark.');
+});
+
+test('columns archetype renders a heading + body per column', () => {
+  const spec = { theme: 'paper', brand: { name: 'X' }, slides: [
+    { type: 'columns', heading: 'H', columns: [{ h: 'A', b: 'a' }, { h: 'B', b: 'b' }, { h: 'C', b: 'c' }] }] };
+  const { requests } = buildDeck(spec);
+  const texts = requests.filter((r) => r.insertText).map((r) => r.insertText.text);
+  for (const t of ['A', 'B', 'C', 'a', 'b', 'c']) assert.ok(texts.includes(t), `missing column text ${t}`);
+});
+
+test('unknown slide type falls back to statement, unknown theme to terminal', () => {
+  const { requests } = buildDeck({ theme: 'nope', slides: [{ type: 'mystery', text: 'hi' }] });
+  assert.ok(requests.some((r) => r.insertText && r.insertText.text === 'hi'));
+});
+
+test('sanitize collapses spaced hyphen separators too', () => {
+  assert.equal(sanitize('on - call'), 'on, call');
+  assert.equal(sanitize('on-call'), 'on-call'); // real hyphenated word survives
+});

--- a/test/slop-loop.test.js
+++ b/test/slop-loop.test.js
@@ -1,0 +1,104 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { scanFile, applyFixes, loadProjectRules, addProjectRule, gitChangedLines, installHook, RULES } = require('../commands/slop');
+
+function tmpDir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'sloploop-')); }
+
+test('--fix repairs em dashes in place and leaves a comma', () => {
+  const dir = tmpDir();
+  const f = path.join(dir, 'copy.md');
+  fs.writeFileSync(f, 'Fast, reliable — and calm.\nShip it — today.\n');
+  const { fixedCount, fixedFiles } = applyFixes([f], RULES);
+  assert.ok(fixedCount >= 2);
+  assert.deepEqual(fixedFiles, [f]);
+  const after = fs.readFileSync(f, 'utf8');
+  assert.ok(!after.includes('—'), 'em dash should be gone');
+  assert.match(after, /Fast, reliable, and calm\./);
+  // re-scan is clean for em-dash
+  assert.equal(scanFile(f).filter((x) => x.rule === 'em-dash').length, 0);
+});
+
+test('--fix never touches tells that need judgment (gradient text stays)', () => {
+  const dir = tmpDir();
+  const f = path.join(dir, 'Hero.tsx');
+  fs.writeFileSync(f, '<h1 className="text-transparent bg-clip-text">hi</h1>\n');
+  const before = fs.readFileSync(f, 'utf8');
+  applyFixes([f], RULES);
+  assert.equal(fs.readFileSync(f, 'utf8'), before, 'unsafe tells are not auto-edited');
+});
+
+test('project rules from .atris/slop.rules.json load and fire', () => {
+  const dir = tmpDir();
+  fs.mkdirSync(path.join(dir, '.atris'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.atris', 'slop.rules.json'),
+    JSON.stringify([{ id: 'no-foobar', pattern: 'foobar', why: 'banned word', sev: 'error' }]));
+  const rules = RULES.concat(loadProjectRules(dir));
+  const f = path.join(dir, 'note.md');
+  fs.writeFileSync(f, 'this mentions foobar once\n');
+  const hits = scanFile(f, rules).map((x) => x.rule);
+  assert.ok(hits.includes('no-foobar'));
+});
+
+test('addProjectRule writes and dedups by id', () => {
+  const dir = tmpDir();
+  addProjectRule({ id: 'r1', pattern: 'aaa', why: 'first', sev: 'warn' }, dir);
+  addProjectRule({ id: 'r1', pattern: 'bbb', why: 'updated', sev: 'error' }, dir);
+  addProjectRule({ id: 'r2', pattern: 'ccc', why: 'second', sev: 'warn' }, dir);
+  const loaded = loadProjectRules(dir);
+  assert.equal(loaded.length, 2);
+  const r1 = loaded.find((r) => r.id === 'r1');
+  assert.equal(r1.sev, 'error');
+  assert.ok(r1.re.test('bbb'));
+});
+
+test('a malformed project rule is skipped, not fatal', () => {
+  const dir = tmpDir();
+  fs.mkdirSync(path.join(dir, '.atris'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.atris', 'slop.rules.json'),
+    JSON.stringify([{ id: 'bad', pattern: '(' }, { id: 'good', pattern: 'ok' }]));
+  const loaded = loadProjectRules(dir);
+  assert.equal(loaded.length, 1);
+  assert.equal(loaded[0].id, 'good');
+});
+
+test('installHook writes an executable pre-commit gate, idempotently', () => {
+  const dir = tmpDir();
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  const r1 = installHook(dir);
+  assert.equal(r1.already, false);
+  const hook = fs.readFileSync(r1.hookPath, 'utf8');
+  assert.match(hook, /atris slop detect --staged/);
+  assert.match(hook, /# atris slop gate/);
+  assert.ok((fs.statSync(r1.hookPath).mode & 0o111) !== 0, 'hook should be executable');
+  // second call is a no-op (idempotent), not a duplicate block
+  const r2 = installHook(dir);
+  assert.equal(r2.already, true);
+  const occurrences = fs.readFileSync(r1.hookPath, 'utf8').split('# atris slop gate').length - 1;
+  assert.equal(occurrences, 1);
+});
+
+test('installHook refuses a non-git directory', () => {
+  assert.throws(() => installHook(tmpDir()), /not a git repo/);
+});
+
+test('--diff scopes findings to changed lines only', () => {
+  const dir = tmpDir();
+  const git = (...a) => execFileSync('git', a, { cwd: dir, stdio: 'pipe' });
+  git('init', '-q');
+  git('config', 'user.email', 't@t.t'); git('config', 'user.name', 't');
+  const f = path.join(dir, 'doc.md');
+  // committed line already has an em dash; it must NOT be reported by --diff
+  fs.writeFileSync(f, 'old line with an em dash —\nsecond line clean\n');
+  git('add', '.'); git('commit', '-qm', 'base');
+  // add a NEW line with an em dash
+  fs.writeFileSync(f, 'old line with an em dash —\nsecond line clean\nnew line also — slop\n');
+  const changed = gitChangedLines(false, dir);
+  const abs = path.resolve(dir, 'doc.md');
+  assert.ok(changed.has(abs));
+  assert.ok(changed.get(abs).has(3), 'line 3 is the changed line');
+  assert.ok(!changed.get(abs).has(1), 'line 1 was not changed');
+});

--- a/test/slop.test.js
+++ b/test/slop.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { scanFile, RULES } = require('../commands/slop');
+
+function tmpFile(name, content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'slop-'));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+test('rules are well-formed (id, severity, regex, why)', () => {
+  for (const r of RULES) {
+    assert.ok(r.id && typeof r.id === 'string');
+    assert.ok(['error', 'warn'].includes(r.sev));
+    assert.ok(r.re instanceof RegExp);
+    assert.ok(r.why && typeof r.why === 'string');
+  }
+});
+
+test('flags the canonical slop tells', () => {
+  const slop = [
+    '<div className="bg-gradient-to-r from-purple-500 text-transparent bg-clip-text">',
+    '  Supercharge your workflow ✨',
+    '</div>',
+  ].join('\n');
+  const hits = scanFile(tmpFile('Slop.tsx', slop)).map((f) => f.rule);
+  assert.ok(hits.includes('ai-gradient-text'), 'gradient text');
+  assert.ok(hits.includes('ai-purple-gradient'), 'purple gradient');
+  assert.ok(hits.includes('hype-copy'), 'hype copy');
+  assert.ok(hits.includes('decorative-emoji'), 'emoji');
+});
+
+test('flags em dash as an AI-writing tell', () => {
+  const hits = scanFile(tmpFile('Copy.tsx', '<p>Fast, reliable — and calm.</p>')).map((f) => f.rule);
+  assert.ok(hits.includes('em-dash'), 'em dash');
+  // a plain hyphen must NOT trip it
+  assert.equal(scanFile(tmpFile('Ok.tsx', '<p>On-call, half-asleep.</p>')).length, 0);
+});
+
+test('clean markup produces zero findings', () => {
+  const clean = [
+    '<section className="rounded-lg border border-stone-200 bg-stone-50 p-12">',
+    '  <h1 className="text-stone-900 font-semibold">Read your incidents in the dark</h1>',
+    '</section>',
+  ].join('\n');
+  assert.equal(scanFile(tmpFile('Clean.tsx', clean)).length, 0);
+});
+
+test('findings carry file:line + rule id for the verification gate', () => {
+  const f = scanFile(tmpFile('X.css', '\n\n.x { backdrop-filter: blur(8px); }'))[0];
+  assert.equal(f.line, 3);
+  assert.equal(f.rule, 'glassmorphism');
+  assert.ok(f.file.endsWith('X.css'));
+});

--- a/test/theme.test.js
+++ b/test/theme.test.js
@@ -1,0 +1,209 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  loadProjectThemes, mergedThemes, normalizeTheme, isValidThemeShape, writeStarterTheme, BASE,
+  buildTheme, themeWarnings, contrastRatio, bestOnColor, upsertProjectTheme, loadThemeRecipe, MOODS,
+} = require('../lib/theme');
+const { renderHtml, THEMES: HTML_THEMES } = require('../lib/html-render');
+const { buildDeck, THEMES: DECK_THEMES, rgb } = require('../lib/slides-deck');
+const themeCmd = require('../commands/theme');
+
+// run a fn with cwd temporarily set to `dir` (the create/edit flow writes to process.cwd())
+async function inDir(dir, fn) {
+  const prev = process.cwd();
+  process.chdir(dir);
+  try { return await fn(); } finally { process.chdir(prev); }
+}
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'theme-')); }
+
+function mkProject(json) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'theme-'));
+  if (json != null) {
+    fs.mkdirSync(path.join(dir, '.atris'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.atris', 'theme.json'), typeof json === 'string' ? json : JSON.stringify(json));
+  }
+  return dir;
+}
+
+test('normalizeTheme inherits every missing token from the base', () => {
+  const t = normalizeTheme({ color: { accent: '#00A88F' } });
+  assert.equal(t.color.accent, '#00A88F');
+  assert.equal(t.color.bg, BASE.color.bg); // inherited
+  assert.equal(t.fonts.display, BASE.fonts.display); // inherited
+});
+
+test('isValidThemeShape requires color or fonts', () => {
+  assert.ok(isValidThemeShape({ color: { accent: '#fff' } }));
+  assert.ok(isValidThemeShape({ fonts: { display: 'Fraunces' } }));
+  assert.ok(!isValidThemeShape({}));
+  assert.ok(!isValidThemeShape(null));
+});
+
+test('loadProjectThemes reads the single-theme and themes-map forms', () => {
+  const single = loadProjectThemes(mkProject({ name: 'acme', color: { accent: '#112233' } }));
+  assert.ok(single.acme);
+  assert.equal(single.acme.color.accent, '#112233');
+
+  const many = loadProjectThemes(mkProject({ themes: { a: { color: { accent: '#aa0000' } }, b: { color: { accent: '#00bb00' } } } }));
+  assert.equal(Object.keys(many).length, 2);
+  assert.equal(many.a.color.accent, '#aa0000');
+});
+
+test('a broken theme.json degrades to no project themes (not fatal)', () => {
+  assert.deepEqual(loadProjectThemes(mkProject('{ not json')), {});
+  assert.deepEqual(loadProjectThemes(mkProject({ themes: { bad: {} } })), {}); // empty theme skipped
+});
+
+test('mergedThemes lets a project theme override a built-in by name', () => {
+  const dir = mkProject({ themes: { atris: { color: { accent: '#FF0000' } } } });
+  const merged = mergedThemes(HTML_THEMES, dir);
+  assert.equal(merged.atris.color.accent, '#FF0000'); // project wins
+  assert.equal(merged.terminal.color.accent, HTML_THEMES.terminal.color.accent); // others intact
+});
+
+test('a project theme flows into the HTML renderer', () => {
+  const dir = mkProject({ name: 'brand', color: { accent: '#00A88F', bg: '#0B1410' } });
+  const themes = mergedThemes(HTML_THEMES, dir);
+  const html = renderHtml({ theme: 'brand', brand: { name: 'X' }, slides: [{ type: 'title', headline: 'Hi' }] }, { themes });
+  assert.match(html, /--brand-primary:#00A88F/i);
+  assert.match(html, /--brand-bg:#0B1410/i);
+});
+
+test('a project theme flows into the deck renderer', () => {
+  const dir = mkProject({ name: 'brand', color: { accent: '#00A88F' } });
+  const themes = { ...DECK_THEMES, ...loadProjectThemes(dir) };
+  const { requests } = buildDeck({ theme: 'brand', brand: { name: 'X' }, slides: [{ type: 'bignumber', number: '9' }] }, { themes });
+  const accent = rgb('#00A88F');
+  const usesAccent = JSON.stringify(requests).includes(JSON.stringify(accent.red).slice(0, 6));
+  assert.ok(usesAccent, 'the deck should use the project accent color');
+});
+
+test('writeStarterTheme scaffolds .atris/theme.json idempotently', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'theme-init-'));
+  const r1 = writeStarterTheme(dir);
+  assert.equal(r1.already, false);
+  assert.ok(fs.existsSync(r1.file));
+  assert.equal(writeStarterTheme(dir).already, true);
+  assert.ok(loadProjectThemes(dir).brand);
+});
+
+// ---------- theme create: the guided generator ----------
+
+test('buildTheme resolves a full theme from a mood + mode + accent', () => {
+  const t = buildTheme({ mood: 'technical', mode: 'light', accent: '#3B82F6' });
+  assert.equal(t.color.accent, '#3B82F6');
+  assert.equal(t.color.bg, MOODS.technical.modes.light.bg); // surface from the mood
+  assert.equal(t.fonts.display, 'Space Grotesk'); // technical => clean-sans
+  assert.ok(t.color.accent2 && t.color.onAccent); // derived
+  assert.equal(t.color.sev.length, 3);
+});
+
+test('buildTheme honors forceMode (noir is dark-only)', () => {
+  const t = buildTheme({ mood: 'noir', mode: 'light' });
+  assert.equal(t.color.bg, MOODS.noir.modes.dark.bg);
+});
+
+test('buildTheme with no answers gives a sensible editorial default', () => {
+  const t = buildTheme();
+  assert.equal(t.color.accent, MOODS.editorial.swatches[0]);
+  assert.equal(t.color.bg, MOODS.editorial.modes.dark.bg);
+});
+
+test('buildTheme picks readable onAccent (contrast >= 4.5 with the accent)', () => {
+  for (const mood of Object.keys(MOODS)) {
+    const t = buildTheme({ mood });
+    assert.ok(contrastRatio(t.color.onAccent, t.color.accent) >= 4.5, `${mood} onAccent unreadable`);
+  }
+});
+
+test('contrastRatio: black/white ~21, identical color = 1', () => {
+  assert.ok(Math.abs(contrastRatio('#000000', '#FFFFFF') - 21) < 0.1);
+  assert.equal(Math.round(contrastRatio('#abcdef', '#abcdef')), 1);
+  assert.equal(bestOnColor('#FFFFFF'), '#141110'); // dark ink on a light color
+});
+
+test('every built-in mood passes its own readability guard', () => {
+  for (const mood of Object.keys(MOODS)) assert.deepEqual(themeWarnings(buildTheme({ mood })), []);
+});
+
+test('themeWarnings flags an unreadable theme', () => {
+  const warns = themeWarnings({ color: { bg: '#FFFFFF', ink: '#F0F0F0', accent: '#FEFEFE', onAccent: '#FFFFFF' } });
+  assert.ok(warns.length >= 2);
+});
+
+// ---------- upsertProjectTheme: save / preserve / migrate ----------
+
+test('upsertProjectTheme creates then updates, preserving other themes', () => {
+  const dir = tmp();
+  const r1 = upsertProjectTheme('acme', buildTheme({ mood: 'technical', accent: '#3B82F6' }), dir);
+  assert.equal(r1.action, 'created');
+  upsertProjectTheme('acme-light', buildTheme({ mood: 'paper' }), dir);
+  const r3 = upsertProjectTheme('acme', buildTheme({ mood: 'vivid', accent: '#8B5CF6' }), dir);
+  assert.equal(r3.action, 'updated');
+  assert.equal(r3.count, 2);
+  const loaded = loadProjectThemes(dir);
+  assert.equal(loaded.acme.color.accent, '#8B5CF6'); // updated
+  assert.ok(loaded['acme-light']); // preserved
+});
+
+test('upsertProjectTheme migrates a single-theme file into the map form', () => {
+  const dir = mkProject({ name: 'old', color: { accent: '#112233' } });
+  upsertProjectTheme('fresh', buildTheme({ mood: 'noir' }), dir);
+  const loaded = loadProjectThemes(dir);
+  assert.ok(loaded.old, 'pre-existing single theme should be preserved');
+  assert.ok(loaded.fresh);
+});
+
+test('upsertProjectTheme refuses to clobber an unparseable file (EBADTHEME)', () => {
+  const dir = mkProject('{ not json at all');
+  assert.throws(() => upsertProjectTheme('x', buildTheme(), dir), (e) => e.code === 'EBADTHEME');
+});
+
+test('a saved recipe round-trips for theme edit', () => {
+  const dir = tmp();
+  upsertProjectTheme('acme', buildTheme({ mood: 'vivid', accent: '#10B981' }), dir, { mood: 'vivid', mode: 'dark', accent: '#10B981' });
+  const recipe = loadThemeRecipe('acme', dir);
+  assert.equal(recipe.mood, 'vivid');
+  assert.equal(recipe.accent, '#10B981');
+});
+
+// ---------- the command, non-interactive (flag-driven) ----------
+
+test('theme create --flags writes .atris/theme.json with the new theme', async () => {
+  const dir = tmp();
+  const code = await inDir(dir, () => themeCmd.run(['create', 'acme', '--mood', 'technical', '--accent', '#3B82F6']));
+  assert.equal(code, 0);
+  const loaded = loadProjectThemes(dir);
+  assert.ok(loaded.acme);
+  assert.equal(loaded.acme.color.accent, '#3B82F6');
+});
+
+test('theme create rejects a bad hex / unknown mood', async () => {
+  const dir = tmp();
+  assert.equal(await inDir(dir, () => themeCmd.run(['create', 'x', '--accent', 'not-a-color'])), 2);
+  assert.equal(await inDir(dir, () => themeCmd.run(['create', 'x', '--mood', 'banana'])), 2);
+});
+
+test('theme edit updates an existing theme via flags', async () => {
+  const dir = tmp();
+  await inDir(dir, () => themeCmd.run(['create', 'acme', '--mood', 'technical', '--accent', '#3B82F6']));
+  const code = await inDir(dir, () => themeCmd.run(['edit', 'acme', '--accent', '#06B6D4']));
+  assert.equal(code, 0);
+  assert.equal(loadProjectThemes(dir).acme.color.accent, '#06B6D4');
+});
+
+test('theme edit on a missing theme errors', async () => {
+  const dir = tmp();
+  assert.equal(await inDir(dir, () => themeCmd.run(['edit', 'ghost'])), 2);
+});
+
+test('a created theme flows end-to-end into the HTML renderer', async () => {
+  const dir = tmp();
+  await inDir(dir, () => themeCmd.run(['create', 'brand', '--mood', 'technical', '--accent', '#3B82F6']));
+  const themes = mergedThemes(HTML_THEMES, dir);
+  const html = renderHtml({ theme: 'brand', brand: { name: 'X' }, slides: [{ type: 'title', headline: 'Hi' }] }, { themes });
+  assert.match(html, /--brand-primary:#3B82F6/i);
+});


### PR DESCRIPTION
## The regression

`deck`, `card`, `reel`, `slop`, `site`, and `theme` shipped in **v3.23.0 / v3.24.0** but are **absent from published `atris@3.25.2`**. Verified against the npm tarball.

Cause: 3.23/3.24 were released from the `feat/atris-reel` branch, which was **never merged to master** (`git merge-base --is-ancestor v3.24.0 origin/master` = false; it forked at `e6d934c`). When 3.25.x shipped from master, the features weren't there. Anyone who upgraded past 3.24.0 lost them — the published "latest" went backwards. (This is the "release from master, not a hot feature branch" rule, learned the hard way.)

## The fix

Restore the exact v3.24.0 suite onto master:
- 6 commands: `deck card reel slop site theme`
- 8 libs + 10 test files (all additive, self-contained)
- router + knownCommands wiring in `bin/atris.js`

## Proof

- Full suite green against master's current base: **1361 / 1361** (the 10 restored test files included).
- `deck sample` produces output; import-integrity gate clean on the new files.
- Bumps **3.26.0** so the next release carries the features forward.

After merge: tag `v3.26.0` to republish with the suite restored.