### PR TITLE
ci: block releases that drop a command vs published latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
             exit 1
           fi
 
+      - name: Block command regressions vs published latest
+        run: node scripts/check-command-regression.js
+
       - name: Publish with npm trusted publishing
         run: |
           npm config delete //registry.npmjs.org/:_authToken || true

--- a/scripts/check-command-regression.js
+++ b/scripts/check-command-regression.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+'use strict';
+
+// No-command-regression release gate.
+//
+// A published release must never drop a command the previous published version
+// had. atris@3.25.0 shipped from a lineage that lacked deck/card/reel/slop/site/
+// theme, so `atris@latest` silently lost six commands that 3.24.0 had. This gate
+// compares the about-to-publish command surface against the currently-published
+// atris@latest and refuses to publish if any command disappeared. Intentional
+// removals are acknowledged with ATRIS_ALLOW_COMMAND_REMOVALS="a,b".
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// Parse the knownCommands array literal out of bin/atris.js source (the
+// invocable command surface — what `atris <x>` accepts).
+function extractKnownCommands(source) {
+  const start = String(source || '').indexOf('const knownCommands');
+  if (start === -1) return [];
+  const open = source.indexOf('[', start);
+  const close = source.indexOf('];', open);
+  if (open === -1 || close === -1) return [];
+  const body = source.slice(open + 1, close);
+  const matches = body.match(/'([^']+)'/g) || [];
+  return matches.map((s) => s.slice(1, -1));
+}
+
+// Commands present in the published surface but missing locally (minus allowed).
+function diffCommandRegression(publishedCommands, localCommands, { allow = [] } = {}) {
+  const local = new Set(localCommands);
+  const allowed = new Set(allow);
+  const removed = publishedCommands.filter((c) => !local.has(c) && !allowed.has(c));
+  return { ok: removed.length === 0, removed };
+}
+
+// Fetch bin/atris.js from the published tarball. Best-effort: returns null if
+// npm is unreachable or the package can't be fetched (do not block on infra).
+function fetchPublishedBin(version = 'latest', runner = spawnSync) {
+  let dir;
+  try {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-regression-'));
+    const pack = runner('npm', ['pack', `atris@${version}`], { cwd: dir, encoding: 'utf8' });
+    if (pack.status !== 0) return null;
+    const tgz = String(pack.stdout || '').trim().split('\n').pop();
+    if (!tgz) return null;
+    const extract = runner('tar', ['xzf', tgz, '-C', dir, 'package/bin/atris.js'], { cwd: dir, encoding: 'utf8' });
+    if (extract.status !== 0) return null;
+    return fs.readFileSync(path.join(dir, 'package', 'bin', 'atris.js'), 'utf8');
+  } catch (_) {
+    return null;
+  } finally {
+    if (dir) try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
+function main() {
+  const localCommands = extractKnownCommands(fs.readFileSync(path.join(repoRoot, 'bin', 'atris.js'), 'utf8'));
+  if (!localCommands.length) {
+    console.error('check-command-regression: could not read local knownCommands; aborting.');
+    return 1;
+  }
+  const publishedSource = fetchPublishedBin('latest');
+  if (!publishedSource) {
+    console.warn('check-command-regression: could not fetch atris@latest; skipping (infra, not a regression).');
+    return 0;
+  }
+  const publishedCommands = extractKnownCommands(publishedSource);
+  const allow = (process.env.ATRIS_ALLOW_COMMAND_REMOVALS || '').split(',').map((s) => s.trim()).filter(Boolean);
+  const { ok, removed } = diffCommandRegression(publishedCommands, localCommands, { allow });
+  if (!ok) {
+    console.error(`Refusing to publish: these commands exist in atris@latest but not in this release:\n  ${removed.join(', ')}`);
+    console.error(`If the removal is intentional, set ATRIS_ALLOW_COMMAND_REMOVALS="${removed.join(',')}" and re-run.`);
+    return 1;
+  }
+  console.log(`No command regressions vs atris@latest (${publishedCommands.length} published, ${localCommands.length} local).`);
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = { extractKnownCommands, diffCommandRegression, fetchPublishedBin, main };

--- a/test/check-command-regression.test.js
+++ b/test/check-command-regression.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { extractKnownCommands, diffCommandRegression } = require('../scripts/check-command-regression');
+
+test('extractKnownCommands parses the multi-line knownCommands array', () => {
+  const src = `
+const foo = 1;
+const knownCommands = ['init', 'log',
+                       'deck', 'slop', 'card'];
+if (!knownCommands.includes(command)) {}
+`;
+  assert.deepEqual(extractKnownCommands(src), ['init', 'log', 'deck', 'slop', 'card']);
+});
+
+test('extractKnownCommands reads the real bin/atris.js surface', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'atris.js'), 'utf8');
+  const cmds = extractKnownCommands(src);
+  assert.ok(cmds.length > 50, `expected a real command surface, got ${cmds.length}`);
+  // The recovered creative suite must be present so the gate guards it.
+  for (const c of ['deck', 'card', 'reel', 'slop', 'site', 'theme']) {
+    assert.ok(cmds.includes(c), `knownCommands should include ${c}`);
+  }
+});
+
+test('diffCommandRegression flags a command dropped since the published version', () => {
+  const published = ['init', 'deck', 'card', 'reel', 'slop'];
+  const local = ['init', 'deck']; // dropped card/reel/slop — the 3.25.0 failure
+  const { ok, removed } = diffCommandRegression(published, local);
+  assert.equal(ok, false);
+  assert.deepEqual(removed.sort(), ['card', 'reel', 'slop']);
+});
+
+test('diffCommandRegression passes when local is a superset (added commands ok)', () => {
+  const { ok, removed } = diffCommandRegression(['init', 'deck'], ['init', 'deck', 'reel']);
+  assert.equal(ok, true);
+  assert.deepEqual(removed, []);
+});
+
+test('diffCommandRegression honors an explicit allow-list for intentional removals', () => {
+  const { ok, removed } = diffCommandRegression(['init', 'deck', 'oldcmd'], ['init', 'deck'], { allow: ['oldcmd'] });
+  assert.equal(ok, true);
+  assert.deepEqual(removed, []);
+});
+
+test('the publish workflow runs the regression gate before publishing', () => {
+  const wf = fs.readFileSync(path.join(__dirname, '..', '.github', 'workflows', 'publish.yml'), 'utf8');
+  assert.match(wf, /check-command-regression\.js/);
+  const gateIdx = wf.indexOf('check-command-regression.js');
+  const publishIdx = wf.indexOf('npm run publish:release');
+  assert.ok(gateIdx !== -1 && publishIdx !== -1 && gateIdx < publishIdx, 'gate must run before publish');
+});


### PR DESCRIPTION
## Why

3.25.0 silently lost `deck/card/reel/slop/site/theme` because it shipped from a lineage that lacked them and **nothing compared the new release surface to what was already published**. (Recovered in 3.26.0 via #112.) This is the guardrail so it can't recur.

## What

A release gate (`scripts/check-command-regression.js`, wired into `publish.yml` before the publish step):
- parses the about-to-ship `knownCommands` from `bin/atris.js`
- fetches `atris@latest`'s `knownCommands` from its npm tarball
- **refuses to publish** if any command present in latest is missing in the new release
- intentional removals are acknowledged via `ATRIS_ALLOW_COMMAND_REMOVALS="a,b"`
- best-effort fetch: never blocks on npm being unreachable, only on a real regression

## Proof

- Pure parser + diff unit-tested (6 tests); a test asserts the workflow runs the gate before publishing.
- Live: `No command regressions vs atris@latest (110 published, 110 local)` → exit 0; drop `deck` locally → exit 1 naming `deck`.
- Full suite green: **1370 / 1370**. No version bump — takes effect on the next release.