### PR TITLE
reconcile: one exactly-safe master (3.28.0) + broadened security review

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
             exit 1
           fi
 
+      - name: Block command regressions vs published latest
+        run: node scripts/check-command-regression.js
+
       - name: Publish with npm trusted publishing
         run: |
           npm config delete //registry.npmjs.org/:_authToken || true

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -823,7 +823,7 @@ if (command === '2' && ['fast', 'pro'].includes(String(firstCommandArg || '').to
 const knownCommands = ['init', 'log', 'now', 'radar', 'ctop', 'status', 'analytics', 'visualize', 'brain', 'brainstorm', 'autopilot', 'run', 'plan', 'do', 'review', 'release',
                        'activate', '_activate', 'agent', 'chat', 'fast', 'ax', 'console', 'serve', 'login', 'logout', 'whoami', 'switch', 'use', 'accounts', '_resolve', '_profile-email', '_switch-session', 'shell-init', 'update', 'upgrade', 'version', 'help', 'next', 'atris',
                        'clean', 'verify', 'search', 'skill', 'member', 'codex-goal', 'app', 'apps', 'learn', 'lesson', 'plugin', 'experiments', 'receipt', 'proof', 'openclaw', 'pull', 'push', 'live', 'align', 'terminal', 'computer', 'diff', 'business', 'sync', 'youtube',
-                       'ingest', 'query', 'lint', 'loop', 'pulse', 'task', 'mission', 'probe', 'worktree', 'aeo', 'slop', 'deck', 'site', 'theme', 'card', 'reel', 'improve', 'xp', 'play', 'gm', 'x', 'recap',
+                       'ingest', 'query', 'lint', 'loop', 'pulse', 'task', 'mission', 'probe', 'worktree', 'aeo', 'slop', 'security-review', 'secure', 'deck', 'site', 'theme', 'card', 'reel', 'improve', 'xp', 'play', 'gm', 'x', 'recap', 'signup', 'clarity', 'moves',
                        'gmail', 'calendar', 'twitter', 'slack', 'imessage', 'integrations', 'setup', 'clean-workspace', 'cw',
                        'fork', 'browse', 'publish', 'sleep', 'wake', 'feedback', 'errors', 'wiki', 'code-review', 'cr', 'soul', 'fleet', 'compile', 'spaceship'];
 
@@ -2059,6 +2059,27 @@ if (command === 'init') {
 } else if (command === 'slop') {
   // Slop: deterministic frontend-slop detector (no LLM). Exit 1 = slop found, for CI + the autopilot gate.
   Promise.resolve(require('../commands/slop').slopCommand(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'security-review' || command === 'secure') {
+  // Security review: deterministic secrets/PII/code-risk scan (no LLM). Exit 1 = HIGH finding,
+  // for the autopilot/mission/CI gate + a SOC 2 evidence artifact via --json.
+  Promise.resolve(require('../commands/security-review').securityReviewCommand(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'signup') {
+  // Signup: one-call seedless agent signup → writes the active profile (install→signup→play seam).
+  Promise.resolve(require('../commands/signup').signupCommand(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'moves') {
+  // Moves: your 3 next moves — approve one into the loop, kill, or skip.
+  Promise.resolve(require('../commands/moves').movesCommand(process.argv.slice(3)))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
+    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+} else if (command === 'clarity') {
+  // Clarity: interview yourself once; agents read how you work so you stop repeating it.
+  Promise.resolve(require('../commands/clarity').clarityCommand(process.argv.slice(3)))
     .then((code) => process.exit(typeof code === 'number' ? code : 0))
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'deck') {

--- a/commands/activate.js
+++ b/commands/activate.js
@@ -158,6 +158,30 @@ function activateAtris() {
     wikiStatus.bullets.forEach((line) => console.log(`- ${line.replace(/^- /, '')}`));
   }
   console.log('');
+  try {
+    const { nextMoves } = require('../lib/next-moves');
+    const { readProfile, isEmptyProfile } = require('../lib/clarity');
+    const root = process.cwd();
+    const moves = nextMoves(root, 3);
+    console.log('Your next moves:');
+    if (moves.length) {
+      moves.forEach((m, i) => console.log(`  ${i + 1}. ${m.title}`));
+      console.log('  steer them: atris moves');
+    } else {
+      console.log('  none queued. add to ROADMAP.md under "## Open loop items", or jot one with atris log');
+    }
+    const profile = readProfile(root);
+    console.log('');
+    if (isEmptyProfile(profile)) {
+      console.log('Tip: run atris clarity once so agents learn how you work.');
+    } else {
+      console.log('How you work (atris clarity):');
+      ['focus', 'voice', 'cadence', 'done', 'leash']
+        .filter((k) => profile[k])
+        .forEach((k) => console.log(`  ${k}: ${profile[k]}`));
+    }
+    console.log('');
+  } catch { /* alive onboarding is best-effort; never block activate */ }
   console.log('Next: atris plan → do → review (or atris log)');
   console.log('');
 }

--- a/commands/clarity.js
+++ b/commands/clarity.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// `atris clarity`: interview the operator for how they work, write it down once.
+// The interview moves one question at a time so you stay in flow. The result is
+// a durable profile (.atris/clarity.json + atris/CLARITY.md) that agents read.
+
+const readline = require('readline');
+const {
+  QUESTIONS,
+  KEYS,
+  mergeProfile,
+  isEmptyProfile,
+  renderClarityMd,
+  readProfile,
+  writeProfile,
+  profilePaths,
+} = require('../lib/clarity');
+
+function parseSets(args) {
+  const answers = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--set' && args[i + 1]) {
+      const eq = args[i + 1].indexOf('=');
+      if (eq > 0) {
+        const key = args[i + 1].slice(0, eq).trim();
+        const val = args[i + 1].slice(eq + 1).trim();
+        if (KEYS.includes(key)) answers[key] = val;
+      }
+      i++;
+    }
+  }
+  return answers;
+}
+
+function ask(rl, question) {
+  return new Promise((resolve) => rl.question(question, (a) => resolve(a)));
+}
+
+async function clarityCommand(args = [], root = process.cwd()) {
+  const sub = args[0];
+  const stamp = new Date().toISOString();
+
+  if (args.includes('--help') || args.includes('-h') || sub === 'help') {
+    console.log('');
+    console.log('Usage: atris clarity [show|--json|--set key=value|--reset]');
+    console.log('');
+    console.log('Interview the operator for how they work, once. Agents read the result.');
+    console.log('');
+    console.log('  atris clarity                 Run the interview (one question at a time)');
+    console.log('  atris clarity show            Show the current profile');
+    console.log('  atris clarity --json          Print the profile as JSON');
+    console.log('  atris clarity --set voice=plain   Set one field without prompting');
+    console.log('  atris clarity --reset         Clear the profile');
+    console.log('');
+    console.log(`Fields: ${KEYS.join(', ')}`);
+    console.log('');
+    return 0;
+  }
+
+  if (args.includes('--reset')) {
+    writeProfile(root, { updated_at: stamp });
+    console.log('clarity profile reset.');
+    return 0;
+  }
+
+  const existing = readProfile(root);
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(existing, null, 2));
+    return 0;
+  }
+
+  if (sub === 'show') {
+    console.log(renderClarityMd(existing));
+    return 0;
+  }
+
+  // Non-interactive set: write fields and exit.
+  const sets = parseSets(args);
+  if (Object.keys(sets).length) {
+    const merged = mergeProfile(existing, sets, stamp);
+    // Only the keys whose values actually landed (mergeProfile drops empties).
+    const changed = Object.keys(sets).filter((k) => sets[k].trim() && merged[k] === sets[k].trim());
+    if (!changed.length) {
+      console.log('nothing to set (empty value ignored). use --reset to clear all.');
+      return 0;
+    }
+    const { md } = writeProfile(root, merged);
+    console.log(`saved ${changed.join(', ')} to ${md.replace(`${root}/`, '')}`);
+    return 0;
+  }
+
+  // Interactive interview. Only on a terminal, so spawns never hang.
+  if (!process.stdin.isTTY) {
+    console.log(renderClarityMd(existing));
+    if (isEmptyProfile(existing)) {
+      console.log('Run `atris clarity` in a terminal to fill this in, or use --set key=value.');
+    }
+    return 0;
+  }
+
+  console.log('');
+  console.log('clarity interview. plain answers, one at a time. enter to keep the current value.');
+  console.log('');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answers = {};
+  for (const { key, q } of QUESTIONS) {
+    const current = existing[key] ? ` [${existing[key]}]` : '';
+    // eslint-disable-next-line no-await-in-loop
+    const a = (await ask(rl, `${q}${current}\n> `)).trim();
+    if (a) answers[key] = a;
+    console.log('');
+  }
+  rl.close();
+
+  const merged = mergeProfile(existing, answers, stamp);
+  const { md } = writeProfile(root, merged);
+  console.log('clarity saved. agents will read it from:');
+  console.log(`  ${md.replace(`${root}/`, '')}`);
+  console.log('');
+  console.log(renderClarityMd(merged));
+  return 0;
+}
+
+module.exports = { clarityCommand, parseSets };

--- a/commands/moves.js
+++ b/commands/moves.js
@@ -1,0 +1,156 @@
+'use strict';
+
+// `atris moves`: alive onboarding. Shows the 3 highest-leverage next moves and
+// lets you approve (seed it into the loop), kill (stop suggesting it), or skip.
+// This is the seed of proactiveness: the workspace proposes, you steer.
+
+const readline = require('readline');
+const {
+  nextMoves,
+  recordDecision,
+  seedInboxFromMove,
+} = require('../lib/next-moves');
+
+function currentMoves(root, limit) {
+  return nextMoves(root, limit);
+}
+
+function renderMoves(moves) {
+  if (!moves.length) {
+    return [
+      '',
+      'your next moves',
+      '',
+      '  nothing queued. add an item to ROADMAP.md under "## Open loop items",',
+      '  or jot an idea with `atris log`.',
+      '',
+    ].join('\n');
+  }
+  const lines = ['', 'your next moves', ''];
+  moves.forEach((m, i) => {
+    lines.push(`  ${i + 1}. ${m.title}`);
+    lines.push(`     why: ${m.why}   id: ${m.id}`);
+    lines.push('');
+  });
+  lines.push('  approve:  atris moves --approve <id|N>   seed it into the loop');
+  lines.push('  kill:     atris moves --kill <id|N>      stop suggesting it');
+  lines.push('  (use the id when you act later; the numbered order can shift)');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function parseIndexes(value) {
+  return String(value || '')
+    .split(/[\s,]+/)
+    .map((s) => parseInt(s, 10))
+    .filter((n) => Number.isInteger(n) && n >= 1);
+}
+
+// Resolve --approve/--kill tokens to move objects. A token is either a stable
+// move id (m_...) or a 1-based position. The id is preferred because the list
+// can re-rank between viewing and acting, so a bare index can hit a different
+// move than the one you saw.
+function resolveSelection(moves, value) {
+  const tokens = String(value || '').split(/[\s,]+/).filter(Boolean);
+  const byId = new Map(moves.map((m) => [m.id, m]));
+  const seen = new Set();
+  const out = [];
+  for (const tok of tokens) {
+    let move = null;
+    if (byId.has(tok)) move = byId.get(tok);
+    else if (/^\d+$/.test(tok)) move = moves[parseInt(tok, 10) - 1];
+    if (move && !seen.has(move.id)) { seen.add(move.id); out.push(move); }
+  }
+  return out;
+}
+
+function applyDecision(root, selectedMoves, decision, stamp) {
+  const { claimRoadmapItem } = require('../lib/next-moves');
+  const acted = [];
+  for (const move of selectedMoves) {
+    recordDecision(root, move, decision, stamp);
+    if (decision === 'approve') {
+      // Seed then claim, mirroring the loop. For a roadmap-sourced move, mark it
+      // claimed in ROADMAP so the loop and the moves list agree it is handled.
+      const seeded = seedInboxFromMove(root, move);
+      if (move.source === 'roadmap') claimRoadmapItem(root, move.title);
+      acted.push({ move, seeded });
+    } else {
+      acted.push({ move });
+    }
+  }
+  return acted;
+}
+
+function readArgValue(args, name) {
+  const i = args.indexOf(name);
+  if (i === -1) return null;
+  return args[i + 1] || '';
+}
+
+async function movesCommand(args = [], root = process.cwd()) {
+  if (args.includes('--help') || args.includes('-h') || args[0] === 'help') {
+    console.log('');
+    console.log('Usage: atris moves [--approve <id|N>] [--kill <id|N>] [--json] [--limit N]');
+    console.log('');
+    console.log('Show the next moves and steer them. Each move has a stable id; prefer it');
+    console.log('over the position number, which can shift between viewing and acting.');
+    console.log('');
+    console.log('  atris moves                  Show the 3 next moves (prompts on a terminal)');
+    console.log('  atris moves --approve <id|N> Seed that move into the loop (writes the inbox)');
+    console.log('  atris moves --kill <id|N>    Stop suggesting that move');
+    console.log('  atris moves --json           Print the moves (with ids) as JSON, no prompt');
+    console.log('  atris moves --limit N        Show N moves (default 3)');
+    console.log('');
+    return 0;
+  }
+
+  const limitArg = readArgValue(args, '--limit');
+  const limit = limitArg && !Number.isNaN(parseInt(limitArg, 10)) ? Math.max(1, parseInt(limitArg, 10)) : 3;
+  const stamp = new Date().toISOString();
+
+  const approveVal = readArgValue(args, '--approve');
+  const killVal = readArgValue(args, '--kill');
+
+  if (approveVal !== null || killVal !== null) {
+    const moves = currentMoves(root, limit);
+    const killed = applyDecision(root, resolveSelection(moves, killVal), 'kill', stamp);
+    const approved = applyDecision(root, resolveSelection(moves, approveVal), 'approve', stamp);
+    for (const a of approved) {
+      const note = a.seeded && a.seeded.alreadyPresent ? 'already in the inbox' : 'seeded into the loop';
+      console.log(`approved: ${a.move.title}  ->  ${note}`);
+    }
+    for (const k of killed) console.log(`killed: ${k.move.title}  ->  will not suggest again`);
+    if (!approved.length && !killed.length) console.log('no matching move for that id or number.');
+    return 0;
+  }
+
+  const moves = currentMoves(root, limit);
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify({ moves }, null, 2));
+    return 0;
+  }
+
+  console.log(renderMoves(moves));
+
+  // Only prompt on a real terminal, so spawned/non-interactive runs never hang.
+  if (!process.stdin.isTTY || !moves.length) return 0;
+
+  const answer = await new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question('approve N, kill kN, or enter to skip: ', (a) => { rl.close(); resolve(a.trim()); });
+  });
+  if (!answer) return 0;
+
+  const killTokens = (answer.match(/k\s*\d+/gi) || []).map((t) => t.replace(/k/i, '').trim());
+  const approveTokens = answer.replace(/k\s*\d+/gi, '').trim();
+
+  const killed = applyDecision(root, resolveSelection(moves, killTokens.join(' ')), 'kill', stamp);
+  const approved = applyDecision(root, resolveSelection(moves, approveTokens), 'approve', stamp);
+  for (const a of approved) console.log(`approved: ${a.move.title}  ->  seeded into the loop`);
+  for (const k of killed) console.log(`killed: ${k.move.title}`);
+  return 0;
+}
+
+module.exports = { movesCommand, renderMoves, currentMoves, parseIndexes, resolveSelection };

--- a/commands/security-review.js
+++ b/commands/security-review.js
@@ -1,0 +1,132 @@
+// atris security-review — deterministic secrets / PII / privacy scan (no LLM).
+//
+// "Is this workspace safe to commit, publish, or hand to an autonomous loop?"
+// Answers it with facts: file:line + rule + severity. Exit 1 on a HIGH finding,
+// so it drops into the autopilot/mission/CI verification gate. `--json` emits a
+// SOC 2 evidence artifact. Scans git-tracked files by default (what is exposed
+// is what is committed), or a path you pass.
+//
+// Usage:
+//   atris security-review                 scan tracked files (default)
+//   atris security-review src/            scan a path
+//   atris security-review --staged        scan staged changes (pre-commit gate)
+//   atris security-review --json          machine output for CI / the loop
+//   atris security-review --strict        also fail on MEDIUM (PII/paths)
+//   atris security-review hook            install a pre-commit gate
+//
+// Exit code: 0 = clean, 1 = findings at/over the fail threshold, 2 = bad usage.
+
+const fs = require('fs');
+const path = require('path');
+const { runScan, RULES } = require('../lib/security-scan');
+
+const ICON = { high: '✗', medium: '!', low: '·', privacy: '✗', secret: '✗', pii: '!' };
+const SEV_ORDER = { high: 0, medium: 1, low: 2 };
+
+function securityReviewCommand(argv = []) {
+  const sub = argv[0];
+  if (sub === 'help' || argv.includes('-h') || argv.includes('--help')) return printHelp();
+  if (sub === 'rules') return printRules();
+  if (sub === 'hook' || sub === 'install-hook') return installHook();
+
+  const json = argv.includes('--json');
+  const quiet = argv.includes('--quiet');
+  const strict = argv.includes('--strict');
+  const staged = argv.includes('--staged');
+  const paths = argv.filter((a) => !a.startsWith('-') && a !== 'scan');
+  const root = process.cwd();
+
+  let result;
+  try {
+    result = runScan({ root, paths, staged });
+  } catch (e) {
+    console.error(`security-review: ${e.message}`);
+    return 2;
+  }
+
+  const { findings, counts, scanned } = result;
+  findings.sort((a, b) => (SEV_ORDER[a.sev] - SEV_ORDER[b.sev]) || a.file.localeCompare(b.file) || (a.line - b.line));
+  const failThreshold = strict ? ['high', 'medium'] : ['high'];
+  const failing = findings.filter((f) => failThreshold.includes(f.sev)).length;
+
+  if (json) {
+    console.log(JSON.stringify({
+      ok: failing === 0,
+      scanned,
+      counts,
+      fail_threshold: strict ? 'medium' : 'high',
+      findings,
+      generated_for: 'soc2-evidence',
+    }, null, 2));
+    return failing ? 1 : 0;
+  }
+
+  if (!quiet) {
+    console.log('\n  ◉ atris security review');
+    if (!findings.length) {
+      console.log(`\n  ✓ clean — no secrets, PII, or sensitive files in ${scanned} tracked file${scanned === 1 ? '' : 's'}\n`);
+      return 0;
+    }
+    console.log('');
+    const w = Math.max(...findings.map((f) => `${f.file}${f.line ? ':' + f.line : ''}`.length));
+    for (const f of findings) {
+      const loc = `${f.file}${f.line ? ':' + f.line : ''}`.padEnd(w);
+      console.log(`  ${ICON[f.sev] || '·'} ${f.sev.toUpperCase().padEnd(6)} ${loc}  ${f.rule.padEnd(22)} ${f.why}`);
+    }
+  }
+  console.log(`\n  ${counts.high || 0} high · ${counts.medium || 0} medium · ${counts.low || 0} low across ${scanned} file${scanned === 1 ? '' : 's'}`);
+  if (failing) {
+    console.log(`  ${failing} finding${failing === 1 ? '' : 's'} at/over the ${strict ? 'MEDIUM' : 'HIGH'} threshold · exit 1`);
+    console.log('  fix or suppress (trailing `atris-allow-secret`), then re-run.\n');
+  } else {
+    console.log(`  no findings at the ${strict ? 'MEDIUM' : 'HIGH'} threshold · exit 0\n`);
+  }
+  return failing ? 1 : 0;
+}
+
+function printRules() {
+  console.log('\n  atris security-review — deterministic rules:\n');
+  for (const r of RULES) console.log(`  ${r.sev.toUpperCase().padEnd(6)} ${r.cat.padEnd(8)} ${r.id.padEnd(22)} ${r.why}`);
+  console.log(`\n  ${RULES.length} rules + tracked-sensitive-file check. Suppress a line with a trailing \`atris-allow-secret\`.\n`);
+  return 0;
+}
+
+function installHook() {
+  const root = process.cwd();
+  const hookDir = path.join(root, '.git', 'hooks');
+  try {
+    fs.mkdirSync(hookDir, { recursive: true });
+    const hookPath = path.join(hookDir, 'pre-commit');
+    const marker = '# atris security gate';
+    let content = '';
+    try { content = fs.readFileSync(hookPath, 'utf8'); } catch {}
+    if (content.includes(marker)) { console.log(`\n  already installed: ${path.relative(root, hookPath)}\n`); return 0; }
+    if (!content) content = '#!/bin/sh\n';
+    if (!content.endsWith('\n')) content += '\n';
+    content += `\n${marker}\nif command -v atris >/dev/null 2>&1; then atris security-review --staged --quiet || exit 1; fi\n`;
+    fs.writeFileSync(hookPath, content);
+    fs.chmodSync(hookPath, 0o755);
+    console.log(`\n  ✓ security pre-commit gate installed: ${path.relative(root, hookPath)}\n    every commit now runs: atris security-review --staged\n`);
+    return 0;
+  } catch (e) { console.error(`  ${e.message}`); return 2; }
+}
+
+function printHelp() {
+  console.log(`
+  atris security-review — deterministic secrets / PII / privacy scan (no LLM)
+
+    atris security-review            scan git-tracked files (default)
+    atris security-review <path>     scan a file or dir
+    atris security-review --staged   scan staged changes (pre-commit gate)
+    atris security-review --strict   also fail on MEDIUM (PII / personal paths)
+    atris security-review --json     machine output / SOC 2 evidence artifact
+    atris security-review rules       list the active detectors
+    atris security-review hook        install a pre-commit gate
+
+  Scans for hardcoded secrets, API keys, personal data, and tracked sensitive
+  files. exit 0 = clean, 1 = found. Wire into the autopilot/mission gate and CI.
+`);
+  return 0;
+}
+
+module.exports = { securityReviewCommand };

--- a/commands/signup.js
+++ b/commands/signup.js
@@ -1,0 +1,101 @@
+// atris signup <handle>
+//
+// One-call seedless agent signup. A brand-new agent with no account hits
+// POST /api/auth/agent/signup (unauthenticated) and gets back a real, INERT
+// Atris identity + token, then we write the active profile so `atris play`
+// works on the very next command. This closes the install -> signup -> play
+// seam: `npm i -g atris && atris signup x && atris play`.
+//
+// The account is born inert by design (0 credits, no executing agent, external
+// mail paid-gated) — identity is free, capability is earned via AgentXP.
+// Backend: backend/routers/agent_auth_router.py (POST /auth/agent/signup).
+
+const crypto = require('crypto');
+const { apiRequestJson, getApiBaseUrl } = require('../utils/api');
+const { saveCredentials } = require('../utils/auth');
+
+// Mirror the server rule exactly (^[a-z0-9]{3,30}$) so we fail fast and friendly
+// before spending a network round trip / a rate-limit slot.
+const HANDLE_RE = /^[a-z0-9]{3,30}$/;
+
+// Proof-of-work — mirror the server (agent_auth_router.py). The signup endpoint
+// requires a nonce whose sha256(prefix:handle:bucket:nonce) has DIFFICULTY_BITS
+// leading zero bits. Bucket = current 5-min window. Solved locally (~1s) so
+// signup stays a single call; this is the cost that makes mass-minting expensive.
+const POW_PREFIX = 'atris-signup-v1';
+const POW_WINDOW_S = 300;
+const POW_DIFFICULTY_BITS = 20;
+
+function solvePow(handle) {
+  const bucket = Math.floor(Date.now() / 1000 / POW_WINDOW_S);
+  const fullBytes = Math.floor(POW_DIFFICULTY_BITS / 8);
+  const remBits = POW_DIFFICULTY_BITS % 8;
+  for (let n = 0; ; n++) {
+    const d = crypto.createHash('sha256').update(`${POW_PREFIX}:${handle}:${bucket}:${n}`).digest();
+    let ok = true;
+    for (let i = 0; i < fullBytes; i++) { if (d[i] !== 0) { ok = false; break; } }
+    if (ok && remBits && (d[fullBytes] >> (8 - remBits)) !== 0) ok = false;
+    if (ok) return String(n);
+  }
+}
+
+function parseHandle(args = []) {
+  const positional = args.find((a) => a && !a.startsWith('-'));
+  return (positional || '').trim().toLowerCase();
+}
+
+async function signupCommand(args = []) {
+  const handle = parseHandle(args);
+
+  if (!handle) {
+    console.error('Usage: atris signup <handle>');
+    console.error('  handle: 3–30 characters, lowercase letters and digits only.');
+    return 1;
+  }
+  if (!HANDLE_RE.test(handle)) {
+    console.error(`✗ Invalid handle "${handle}".`);
+    console.error('  Must be 3–30 characters, lowercase letters and digits (a–z, 0–9). No spaces or symbols.');
+    return 1;
+  }
+
+  console.log(`Claiming @${handle} … (solving proof-of-work)`);
+  const pow = solvePow(handle);
+
+  const res = await apiRequestJson('/auth/agent/signup', {
+    method: 'POST',
+    body: { handle, pow },
+  });
+
+  if (res.ok && res.data && res.data.token) {
+    const { token, email, user_id: userId } = res.data;
+    const identity = email || `${handle}@atrismail.com`;
+    saveCredentials(token, null, identity, userId || null, 'atrisos');
+    console.log(`\n✓ You're in — ${identity}`);
+    console.log('  Inert starter account (0 credits): identity is free, capability is earned.');
+    console.log('  Saved to your active profile.');
+    console.log('\nNext:');
+    console.log('  atris play     # claim a starter mission and earn your first proof-backed rep');
+    console.log('  atris xp       # see where you stand on the board');
+    return 0;
+  }
+
+  // Friendly, actionable errors — no stack traces for expected cases.
+  if (res.status === 409) {
+    console.error(`✗ "${handle}" is already taken or reserved. Try a different handle.`);
+    return 1;
+  }
+  if (res.status === 429) {
+    console.error('✗ Too many signups right now. Wait a minute and try again.');
+    return 1;
+  }
+  if (res.status === 404) {
+    console.error('✗ Seedless signup isn’t available on this backend yet.');
+    console.error('  Use `atris login` for now, or try again after the next deploy.');
+    return 1;
+  }
+  console.error(`✗ Signup failed: ${res.error || 'unknown error'} (status ${res.status}).`);
+  console.error(`  API: ${getApiBaseUrl()}`);
+  return 1;
+}
+
+module.exports = { signupCommand, parseHandle, HANDLE_RE };

--- a/lib/clarity.js
+++ b/lib/clarity.js
@@ -1,0 +1,97 @@
+'use strict';
+
+// The clarity interview. The front door of the product: draw out how the human
+// works, write it down once, and let every agent read it so they prompt
+// themselves well. A small, high-signal profile, not a survey.
+
+const fs = require('fs');
+const path = require('path');
+
+// One or two ideas at a time, plain English. Each answer is free text; the
+// parenthetical is a nudge, not a fixed menu.
+const QUESTIONS = [
+  { key: 'focus', q: 'what are you building, and who is it for?' },
+  { key: 'voice', q: 'how should output sound? (plain, terse, warm, formal)' },
+  { key: 'cadence', q: 'how do you like to work? (one idea at a time, batch, overnight autonomous)' },
+  { key: 'done', q: 'what does "done" mean to you? (tests green, shipped, you reviewed it)' },
+  { key: 'leash', q: 'how much should agents do without asking? (ask first, proceed and report, full auto)' },
+];
+
+const KEYS = QUESTIONS.map((x) => x.key);
+
+function isEmptyProfile(profile) {
+  return !profile || !KEYS.some((k) => profile[k]);
+}
+
+function renderClarityMd(profile = {}) {
+  const labels = {
+    focus: 'Focus',
+    voice: 'Voice',
+    cadence: 'Cadence',
+    done: 'Done means',
+    leash: 'Leash',
+  };
+  const lines = [
+    '# Clarity profile',
+    '',
+    'How the operator works. Agents read this to prompt themselves well,',
+    'so the human does not have to repeat themselves.',
+    '',
+  ];
+  for (const key of KEYS) {
+    if (profile[key]) lines.push(`- ${labels[key]}: ${profile[key]}`);
+  }
+  if (isEmptyProfile(profile)) {
+    lines.push('- (not set yet, run `atris clarity` to fill this in)');
+  }
+  lines.push('');
+  if (profile.updated_at) lines.push(`Updated: ${profile.updated_at}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+function profilePaths(root = process.cwd()) {
+  return {
+    json: path.join(root, '.atris', 'clarity.json'),
+    md: path.join(root, 'atris', 'CLARITY.md'),
+  };
+}
+
+function readProfile(root = process.cwd()) {
+  const { json } = profilePaths(root);
+  try {
+    return JSON.parse(fs.readFileSync(json, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeProfile(root, profile) {
+  const { json, md } = profilePaths(root);
+  fs.mkdirSync(path.dirname(json), { recursive: true });
+  fs.mkdirSync(path.dirname(md), { recursive: true });
+  fs.writeFileSync(json, `${JSON.stringify(profile, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(md, renderClarityMd(profile), 'utf8');
+  return { json, md };
+}
+
+// Merge new answers over an existing profile (so --set is incremental).
+function mergeProfile(existing, answers, stamp) {
+  const merged = { ...existing };
+  for (const key of KEYS) {
+    if (typeof answers[key] === 'string' && answers[key].trim()) merged[key] = answers[key].trim();
+  }
+  merged.updated_at = stamp || merged.updated_at || null;
+  return merged;
+}
+
+module.exports = {
+  QUESTIONS,
+  KEYS,
+  mergeProfile,
+  isEmptyProfile,
+  renderClarityMd,
+  profilePaths,
+  readProfile,
+  writeProfile,
+};

--- a/lib/next-moves.js
+++ b/lib/next-moves.js
@@ -1,0 +1,362 @@
+'use strict';
+
+// Alive onboarding: the engine behind `atris moves`.
+//
+// It reads the workspace for the highest-leverage next moves (the goal in
+// ROADMAP.md, work already in flight, fresh inbox ideas), ranks them, and lets
+// the human approve, kill, or skip. Approved moves are seeded into today's
+// inbox, which the loop's hasWork() already reads, so onboarding feeds the
+// loop without touching the autonomous core.
+
+const fs = require('fs');
+const path = require('path');
+
+function safeRead(p) {
+  try { return fs.readFileSync(p, 'utf8'); } catch { return ''; }
+}
+
+// Normalize a title for dedup and suppression, the same way moveId does, so a
+// move matches itself across case and whitespace.
+function norm(title) {
+  return String(title == null ? '' : title).trim().toLowerCase();
+}
+
+// Short, stable id so a kill on Tuesday still suppresses the same move on
+// Wednesday. Pure function of (source, title).
+function moveId(source, title) {
+  const s = `${source}:${String(title).trim().toLowerCase()}`;
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return `m_${(h >>> 0).toString(36)}`;
+}
+
+const WEIGHT = { roadmap: 100, task: 60, inbox: 40 };
+
+// One section-boundary shape for every reader and writer: tolerate a header
+// suffix (e.g. "(priority)"), stop at a sibling/parent heading (## or #) or a
+// malformed "##Next", but NOT at a child ### inside the section. Keeping a single
+// definition is the whole point: divergent boundaries are how the gate and the
+// picker drift apart.
+const SECTION_TAIL = '\\b[^\\n]*\\r?\\n([\\s\\S]*?)(?=\\r?\\n##[^#]|\\r?\\n# |$)';
+const OPEN_ITEMS_RE = new RegExp(`##\\s+Open loop items${SECTION_TAIL}`, 'i');
+const INBOX_RE = new RegExp(`##\\s+Inbox${SECTION_TAIL}`, 'i');
+
+// Locate a section's body and its character span, so a writer can splice an edit
+// back into exactly the region a reader parsed.
+function findSection(text, re) {
+  const m = text.match(re);
+  if (!m) return null;
+  const bodyStart = m.index + m[0].length - m[1].length;
+  return { body: m[1], start: bodyStart, end: bodyStart + m[1].length };
+}
+
+// Clean inbox titles out of a journal's ## Inbox section. The one inbox parser,
+// shared by latestInboxItems, todayInboxItems, and the run.js work gate.
+function parseInboxTitles(text) {
+  const m = (text || '').match(INBOX_RE);
+  if (!m) return [];
+  return m[1]
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('- ') && l.length > 2)
+    .map((l) => l.replace(/^-\s*\*\*[IC]?\d*:?\*\*\s*/, '').replace(/^-\s*\*\*/, '').replace(/\*\*$/, '').replace(/^-\s*/, '').trim())
+    .filter(Boolean);
+}
+
+function readRoadmapOpenItems(root) {
+  const text = safeRead(path.join(root, 'ROADMAP.md'));
+  if (!text) return [];
+  const section = findSection(text, OPEN_ITEMS_RE);
+  if (!section) return [];
+  return section.body
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => /^- \[ \]/.test(l))
+    .map((l) => l.replace(/^- \[ \]\s*/, '').trim())
+    .filter(Boolean)
+    .map((title) => ({
+      title,
+      why: 'open item in ROADMAP.md, the goal the loop pursues',
+      source: 'roadmap',
+      weight: WEIGHT.roadmap,
+    }));
+}
+
+function readActiveTasks(root) {
+  const text = safeRead(path.join(root, '.atris', 'state', 'tasks.projection.json'));
+  if (!text) return [];
+  let proj;
+  try { proj = JSON.parse(text); } catch { return []; }
+  const tasks = Array.isArray(proj && proj.tasks) ? proj.tasks : [];
+  return tasks
+    .filter((t) => t && t.title && ['open', 'claimed'].includes(String(t.status || '').toLowerCase()))
+    .map((t) => ({
+      title: String(t.title).trim(),
+      why: `task in flight (${t.status}${t.claimed_by ? `, ${t.claimed_by}` : ''})`,
+      source: 'task',
+      ref: t.display_id || t.id || null,
+      weight: WEIGHT.task,
+    }));
+}
+
+function inboxItemsFrom(text) {
+  return parseInboxTitles(text).map((title) => ({ title, why: 'fresh idea in today\'s inbox', source: 'inbox', weight: WEIGHT.inbox }));
+}
+
+// Most recent journal under atris/logs/YYYY/, parsed for ## Inbox items. Used to
+// SURFACE ideas in `atris moves`.
+function latestInboxItems(root) {
+  const logsDir = path.join(root, 'atris', 'logs');
+  let years;
+  try { years = fs.readdirSync(logsDir).filter((d) => /^\d{4}$/.test(d)).sort(); } catch { return []; }
+  if (!years.length) return [];
+  const yearDir = path.join(logsDir, years[years.length - 1]);
+  let files;
+  try { files = fs.readdirSync(yearDir).filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f)).sort(); } catch { return []; }
+  if (!files.length) return [];
+  return inboxItemsFrom(safeRead(path.join(yearDir, files[files.length - 1])));
+}
+
+// TODAY's journal inbox only. The loop's work gate and the seed-suppression must
+// read the SAME file the seeder writes (today's), or a prior-day duplicate makes
+// them disagree. Returns [] if today's file is absent.
+function todayInboxItems(root) {
+  const { file } = todayLogFile(root);
+  if (!fs.existsSync(file)) return [];
+  return inboxItemsFrom(safeRead(file));
+}
+
+function gatherCandidates(root = process.cwd()) {
+  return [
+    ...readRoadmapOpenItems(root),
+    ...readActiveTasks(root),
+    ...latestInboxItems(root),
+  ];
+}
+
+// Pure ranking: drop killed/approved, sort by weight, then dedupe by title
+// (keeping the highest-weight copy), take `limit`.
+//
+// Suppression: the exact move the operator acted on is dropped by id. Titles are
+// only suppressed for IDEAS (roadmap/inbox), never for a real `task`, so killing
+// or approving an idea can't hide a genuine in-flight task that happens to share
+// the title.
+function pickNextMoves(candidates, { limit = 3, killedIds = [], killedTitles = [], approvedIds = [], approvedTitles = [] } = {}) {
+  const blockedIds = new Set([...killedIds, ...approvedIds]);
+  const blockedTitles = new Set([...killedTitles, ...approvedTitles].map(norm));
+  const seen = new Set();
+  return candidates
+    .map((c) => ({ ...c, id: moveId(c.source, c.title), _key: norm(c.title) }))
+    .filter((c) => {
+      if (!c._key) return false;
+      if (blockedIds.has(c.id)) return false;
+      if (c.source !== 'task' && blockedTitles.has(c._key)) return false;
+      return true;
+    })
+    .sort((a, b) => (b.weight || 0) - (a.weight || 0))
+    .filter((c) => {
+      if (seen.has(c._key)) return false;
+      seen.add(c._key);
+      return true;
+    })
+    .map(({ _key, ...c }) => c)
+    .slice(0, limit);
+}
+
+const DECISIONS_FILE = ['.atris', 'state', 'moves.decisions.jsonl'];
+
+function decisionsPath(root) {
+  return path.join(root, ...DECISIONS_FILE);
+}
+
+function readDecisions(root = process.cwd()) {
+  const text = safeRead(decisionsPath(root));
+  const rows = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+    .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+    .filter(Boolean);
+  const idsFor = (decision) => rows.filter((r) => r.decision === decision).map((r) => r.id);
+  const titlesFor = (decision) => rows.filter((r) => r.decision === decision).map((r) => norm(r.title));
+  return {
+    killedIds: idsFor('kill'),
+    killedTitles: titlesFor('kill'),
+    approvedIds: idsFor('approve'),
+    approvedTitles: titlesFor('approve'),
+  };
+}
+
+function recordDecision(root, move, decision, stamp) {
+  const p = decisionsPath(root);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const row = { id: move.id, title: move.title, source: move.source, decision, at: stamp || null };
+  fs.appendFileSync(p, `${JSON.stringify(row)}\n`, 'utf8');
+  return row;
+}
+
+function todayLogFile(root, date = new Date()) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  const dateFormatted = `${y}-${m}-${d}`;
+  return { file: path.join(root, 'atris', 'logs', String(y), `${dateFormatted}.md`), dateFormatted };
+}
+
+// The canonical day-journal sections every reader expects (status, analytics,
+// section parsers). Mirrors lib/journal.js createLogFile, minus the em dash in
+// its title, so a journal first created by the idle-seed path is not malformed.
+function canonicalJournal(dateFormatted) {
+  return `# Log ${dateFormatted}\n\n## Handoff\n\n---\n\n## Completed ✅\n\n---\n\n## In Progress 🔄\n\n---\n\n## Backlog\n\n---\n\n## Notes\n\n---\n\n## Inbox\n\n`;
+}
+
+// Seed an approved move into today's inbox so the loop's hasWork() finds it.
+// Idempotent by title: if the same title is already in today's inbox, it is not
+// appended again (so a retry or a concurrent cycle cannot duplicate it).
+function seedInboxFromMove(root, move, date) {
+  const { file, dateFormatted } = todayLogFile(root, date);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  let content = safeRead(file);
+  if (!content) {
+    content = canonicalJournal(dateFormatted);
+  }
+  if (!/##\s+Inbox/i.test(content)) {
+    content = content.replace(/^(#.*\n)/, `$1\n## Inbox\n`);
+    if (!/##\s+Inbox/i.test(content)) content += `\n## Inbox\n`;
+  }
+  const target = norm(move.title);
+  if (parseInboxTitles(content).some((t) => norm(t) === target)) {
+    return { file, line: null, nextId: null, alreadyPresent: true };
+  }
+  const existingIds = (content.match(/-\s*\*\*I(\d+):/g) || []).map((m2) => parseInt(m2.match(/I(\d+)/)[1], 10));
+  const nextId = existingIds.length ? Math.max(...existingIds) + 1 : 1;
+  const line = `- **I${nextId}:** ${move.title}`;
+  // Insert right after the Inbox header line only (do not consume blank lines or
+  // following sections). Use a function replacer so a title containing $ tokens
+  // ($1, $&, $$) is inserted literally, not interpreted as a replacement pattern.
+  content = content.replace(/(##\s+Inbox[^\n]*\r?\n)/i, (m) => `${m}${line}\n`);
+  fs.writeFileSync(file, content, 'utf8');
+  return { file, line, nextId };
+}
+
+// Claim an open ROADMAP item for the loop by flipping its `- [ ]` to `- [~]`
+// (claimed, in flight) WITHIN the "## Open loop items" section only. This is the
+// single source of truth for "the loop took this on": readRoadmapOpenItems only
+// returns `- [ ]`, so a claimed item is excluded, and the work gate and the seed
+// picker stay in agreement. Scoped to the section so a same-titled `- [ ]` in
+// another section (Big jobs, an example block) is never flipped by mistake.
+// `- [~]` is distinct from human `- [x]` (done) so a reader is not misled.
+function claimRoadmapItem(root, title) {
+  const p = path.join(root, 'ROADMAP.md');
+  const text = safeRead(p);
+  if (!text) return false;
+  const section = findSection(text, OPEN_ITEMS_RE);
+  if (!section) return false;
+  const target = norm(title);
+  let changed = false;
+  const newBody = section.body.split(/\r?\n/).map((line) => {
+    if (changed) return line;
+    const m = line.match(/^(\s*)- \[ \]\s*(.+?)\s*$/);
+    if (m && norm(m[2]) === target) {
+      changed = true;
+      return `${m[1]}- [~] ${m[2].trim()}`;
+    }
+    return line;
+  }).join('\n');
+  if (!changed) return false;
+  const out = text.slice(0, section.start) + newBody + text.slice(section.end);
+  fs.writeFileSync(p, out, 'utf8');
+  return true;
+}
+
+// Add one bounded item to the "## Open loop items" section so the loop (and
+// `atris moves`) will pursue it: messy input straight into the working queue,
+// no markdown editing. Creates ROADMAP.md and the section if missing. Dedups
+// against existing OPEN items only (a done/claimed one can be re-added).
+function addRoadmapItem(root, text) {
+  // Collapse any whitespace/newlines to single spaces (a multi-line title would
+  // break the markdown line) and strip a leading bullet/checkbox the user may
+  // have pasted, so the item is exactly one well-formed `- [ ]` line.
+  const title = String(text || '').replace(/\s+/g, ' ').trim().replace(/^- \[[ x~]\]\s*/, '').replace(/^- /, '').trim();
+  if (!title) return { added: false, reason: 'empty', title: null };
+  const p = path.join(root, 'ROADMAP.md');
+  let content = safeRead(p);
+  if (!content) content = '# Roadmap\n\n## Open loop items\n\n';
+  let section = findSection(content, OPEN_ITEMS_RE);
+  if (!section) {
+    if (!content.endsWith('\n')) content += '\n';
+    content += '\n## Open loop items\n\n';
+    section = findSection(content, OPEN_ITEMS_RE);
+  }
+  const openTitles = section.body.split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => /^- \[ \]/.test(l))
+    .map((l) => norm(l.replace(/^- \[ \]\s*/, '')));
+  if (openTitles.includes(norm(title))) return { added: false, reason: 'already an open item', title };
+  // Insert at the top of the section body so the loop pulls it next.
+  const out = `${content.slice(0, section.start)}\n- [ ] ${title}\n${content.slice(section.start)}`;
+  fs.writeFileSync(p, out, 'utf8');
+  return { added: true, title };
+}
+
+// Group the Open loop items by state: queued `- [ ]`, in-flight `- [~]` (claimed
+// by the loop), done `- [x]`. The evidence for a loop report.
+function roadmapItemsByState(root) {
+  const out = { open: [], claimed: [], done: [] };
+  const text = safeRead(path.join(root, 'ROADMAP.md'));
+  if (!text) return out;
+  const section = findSection(text, OPEN_ITEMS_RE);
+  if (!section) return out;
+  for (const raw of section.body.split(/\r?\n/)) {
+    const l = raw.trim();
+    let m;
+    if ((m = l.match(/^- \[ \]\s*(.+)$/))) out.open.push(m[1].trim());
+    else if ((m = l.match(/^- \[~\]\s*(.+)$/))) out.claimed.push(m[1].trim());
+    else if ((m = l.match(/^- \[x\]\s*(.+)$/))) out.done.push(m[1].trim());
+  }
+  return out;
+}
+
+// The top open ROADMAP item the loop has not already handled. Claimed items are
+// marked `- [~]` (so readRoadmapOpenItems drops them); this also skips anything
+// already in TODAY's inbox or killed/approved, so an idle loop advances to the
+// next item each cycle. todayInboxItems (not latestInboxItems) so the picker, the
+// work gate, and the seeder all read the same file. Root-explicit and pure of
+// cwd, so it is testable without a live runner.
+function pickRoadmapSeed(root = process.cwd()) {
+  const items = readRoadmapOpenItems(root);
+  if (!items.length) return null;
+  const inbox = todayInboxItems(root).map((i) => norm(i.title));
+  const { killedTitles, approvedTitles } = readDecisions(root);
+  const blocked = new Set([...inbox, ...killedTitles, ...approvedTitles]);
+  return items.find((it) => !blocked.has(norm(it.title))) || null;
+}
+
+// Shared "3 next moves" recipe used by both `atris moves` and `atris activate`,
+// so the ranking inputs live in one place.
+function nextMoves(root = process.cwd(), limit = 3) {
+  const { killedIds, killedTitles, approvedIds, approvedTitles } = readDecisions(root);
+  return pickNextMoves(gatherCandidates(root), { limit, killedIds, killedTitles, approvedIds, approvedTitles });
+}
+
+module.exports = {
+  moveId,
+  norm,
+  WEIGHT,
+  parseInboxTitles,
+  readRoadmapOpenItems,
+  readActiveTasks,
+  latestInboxItems,
+  todayInboxItems,
+  gatherCandidates,
+  pickNextMoves,
+  nextMoves,
+  readDecisions,
+  recordDecision,
+  seedInboxFromMove,
+  pickRoadmapSeed,
+  claimRoadmapItem,
+  addRoadmapItem,
+  roadmapItemsByState,
+  todayLogFile,
+};

--- a/lib/security-scan.js
+++ b/lib/security-scan.js
@@ -1,0 +1,188 @@
+'use strict';
+
+// atris security scan — deterministic secrets / PII / privacy detectors (no LLM).
+//
+// A finding is a fact (file:line + rule + severity), so it drops straight into a
+// loop / mission / CI gate and doubles as a SOC 2 evidence artifact (machine
+// JSON). Precision over recall: a noisy gate gets muted, and a muted gate is dead.
+// Suppress a single line with a trailing `atris-allow-secret` comment.
+//
+// Zero external deps (Node built-ins only) — repo contract.
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCAN_EXTS = new Set([
+  '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.json', '.md', '.mdx', '.txt',
+  '.yml', '.yaml', '.env', '.sh', '.bash', '.zsh', '.py', '.rb', '.go', '.java',
+  '.php', '.toml', '.ini', '.cfg', '.conf', '.html', '.vue', '.svelte', '.patch',
+]);
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage', 'out', 'vendor', '.cache', '__pycache__']);
+
+// Lines that opt out, and placeholder noise we never flag.
+const ALLOW_MARKER = /atris-allow-secret|atris-security-ignore/i;
+const PLACEHOLDER = /\b(?:example|placeholder|your[_-]?|my[_-]?key|xxx+|redacted|dummy|sample|changeme|test[_-]?key|fake|dummy|<[a-z_-]+>|process\.env|getenv|os\.environ|import\.meta\.env)\b/i;
+
+// High-precision secret patterns. severity high => fails the gate.
+const SECRET_RULES = [
+  { id: 'private-key', sev: 'high', cat: 'secret', re: /-----BEGIN (?:RSA |EC |OPENSSH |PGP |DSA |ENCRYPTED )?PRIVATE KEY-----/, why: 'private key committed in source' },
+  { id: 'aws-access-key-id', sev: 'high', cat: 'secret', re: /\bAKIA[0-9A-Z]{16}\b/, why: 'AWS access key id' },
+  { id: 'github-token', sev: 'high', cat: 'secret', re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/, why: 'GitHub personal/OAuth token' },
+  { id: 'slack-token', sev: 'high', cat: 'secret', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/, why: 'Slack token' },
+  { id: 'slack-webhook', sev: 'high', cat: 'secret', re: /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/_-]{20,}/, why: 'Slack incoming webhook url' },
+  { id: 'openai-key', sev: 'high', cat: 'secret', re: /\bsk-(?:proj-)?[A-Za-z0-9]{20,}\b/, why: 'OpenAI-style API key' },
+  { id: 'anthropic-key', sev: 'high', cat: 'secret', re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/, why: 'Anthropic API key' },
+  { id: 'google-api-key', sev: 'high', cat: 'secret', re: /\bAIza[0-9A-Za-z_-]{35}\b/, why: 'Google API key' },
+  { id: 'stripe-key', sev: 'high', cat: 'secret', re: /\b[rs]k_live_[A-Za-z0-9]{20,}\b/, why: 'Stripe live key' },
+  { id: 'npm-token', sev: 'high', cat: 'secret', re: /\bnpm_[A-Za-z0-9]{36}\b/, why: 'npm access token' },
+  { id: 'jwt', sev: 'medium', cat: 'secret', re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}\b/, why: 'JWT (often carries claims/PII)' },
+  { id: 'bearer-token', sev: 'medium', cat: 'secret', re: /\bBearer\s+[A-Za-z0-9._-]{24,}/, why: 'hardcoded Bearer token' },
+  { id: 'assigned-secret', sev: 'high', cat: 'secret', re: /(?:password|passwd|pwd|secret|api[_-]?key|apikey|access[_-]?token|auth[_-]?token|client[_-]?secret|private[_-]?key)\s*[:=]\s*['"][^'"\s]{8,}['"]/i, why: 'hardcoded credential assignment' },
+];
+
+// Personal data. Home-path is the recurring leak (a username + local layout).
+const PII_RULES = [
+  { id: 'home-path', sev: 'medium', cat: 'pii', re: /(?:\/Users\/|\/home\/)(?!runner\/|runner\b|root\/|root\b|ubuntu\/|ubuntu\b|user\/|user\b|node\/)[a-z][a-z0-9_.-]+/i, why: 'personal home path leaks a username + local layout (use os.homedir()/relative)' },
+  { id: 'windows-home-path', sev: 'medium', cat: 'pii', re: /[A-Za-z]:\\Users\\(?!Public\b)[^\\\s'"]+/, why: 'personal Windows path leaks a username' },
+  { id: 'email', sev: 'low', cat: 'pii', re: /\b[A-Za-z0-9._%+-]+@(?!example\.|sentry\.io|test\b|localhost|[\w.-]*\.local\b|sub\.)[A-Za-z0-9.-]+\.(?:com|net|org|ai|io|dev|co)\b/, why: 'email address (possible PII)' },
+  { id: 'phone', sev: 'low', cat: 'pii', re: /(?<![\d.\w])(?:\+?1[-.\s])?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}(?![\d.\w])/, why: 'phone-number-shaped string' },
+];
+
+// Code-execution risks. For an AI CLI that runs autonomous loops and shells out,
+// these are the "are we actually safe" checks beyond data exposure. eval/Function
+// are almost never legitimate (HIGH); shelling out with interpolated input is the
+// command-injection class (MEDIUM — common and sometimes safe, so it asks for a
+// human look rather than hard-failing the gate).
+const CODE_RULES = [
+  { id: 'eval-call', sev: 'high', cat: 'code', re: /(?<![.\w])eval\((?!\s*\))/, why: 'eval() executes arbitrary code' },
+  { id: 'new-function', sev: 'high', cat: 'code', re: /\bnew\s+Function\(/, why: 'new Function() executes arbitrary code' },
+  { id: 'shell-exec-interpolation', sev: 'medium', cat: 'code', re: /\b(?:exec|execSync)\s*\(\s*[`'"][^`'"]*(?:\$\{|"\s*\+|'\s*\+)/, why: 'shell exec with interpolated input (command-injection risk; prefer execFile/spawn with an args array)' },
+  { id: 'child-process-shell-true', sev: 'medium', cat: 'code', re: /\bshell\s*:\s*true\b/, why: 'child_process shell:true enables shell interpretation of args' },
+];
+
+// extra per-line excludes that keep email/path rules from firing on safe noise
+const EMAIL_SAFE = /\b(?:noreply|no-reply|support|hello|info|contact|team|hi|admin|press)@/i;
+
+const RULES = [...SECRET_RULES, ...PII_RULES, ...CODE_RULES];
+
+// Filenames that should never be committed (checked against the tracked file list).
+const SENSITIVE_FILE_RE = /(?:^|\/)(?:\.env(?:\.[\w.-]+)?|id_rsa|id_dsa|id_ed25519|.*\.pem|.*\.pfx|.*\.p12|.*\.keystore|credentials\.json|\.npmrc|\.pypirc|\.netrc|secrets?\.(?:json|ya?ml|env))$/i;
+const SENSITIVE_FILE_ALLOW = /\.env\.example$|\.env\.sample$|\.env\.template$/i;
+
+function scanLine(line, rules = RULES) {
+  if (ALLOW_MARKER.test(line)) return [];
+  const findings = [];
+  const placeholder = PLACEHOLDER.test(line);
+  for (const rule of rules) {
+    const m = rule.re.exec(line);
+    if (!m) continue;
+    // Secrets in obvious placeholder/env-read lines are not real leaks.
+    if (rule.cat === 'secret' && placeholder) continue;
+    if (rule.id === 'email' && EMAIL_SAFE.test(line)) continue;
+    findings.push({ rule: rule.id, sev: rule.sev, cat: rule.cat, why: rule.why, snippet: m[0].trim().slice(0, 60) });
+  }
+  return findings;
+}
+
+function scanText(text, rules = RULES) {
+  const out = [];
+  const lines = String(text || '').split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    for (const f of scanLine(lines[i], rules)) out.push({ ...f, line: i + 1 });
+  }
+  return out;
+}
+
+// Code-execution rules only make sense in actual code files — `eval(` written in
+// a markdown doc is prose, not a vuln.
+const CODE_EXTS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.py', '.rb', '.go', '.java', '.php', '.sh', '.bash', '.zsh']);
+
+function rulesForFile(file) {
+  return CODE_EXTS.has(path.extname(file)) ? RULES : RULES.filter((r) => r.cat !== 'code');
+}
+
+function scanFile(file, rules) {
+  let text;
+  try { text = fs.readFileSync(file, 'utf8'); } catch { return []; }
+  return scanText(text, rules || rulesForFile(file)).map((f) => ({ ...f, file }));
+}
+
+// Repo-level hygiene: a sensitive file being tracked at all is a finding,
+// independent of its contents.
+function sensitiveFileFindings(relPaths) {
+  const out = [];
+  for (const p of relPaths) {
+    if (SENSITIVE_FILE_RE.test(p) && !SENSITIVE_FILE_ALLOW.test(p)) {
+      out.push({ file: p, line: 0, rule: 'tracked-sensitive-file', sev: 'high', cat: 'privacy', why: 'sensitive file is tracked in git (gitignore + remove it)', snippet: path.basename(p) });
+    }
+  }
+  return out;
+}
+
+function gitTrackedFiles(root, { staged = false } = {}) {
+  try {
+    const args = staged ? ['diff', '--cached', '--name-only', '--diff-filter=ACM'] : ['ls-files'];
+    const out = execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return out.split('\n').map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return null; // not a git repo / git unavailable
+  }
+}
+
+function walk(target, out) {
+  let stat;
+  try { stat = fs.statSync(target); } catch { return out; }
+  if (stat.isFile()) { out.push(target); return out; }
+  if (stat.isDirectory()) {
+    if (SKIP_DIRS.has(path.basename(target))) return out;
+    for (const name of fs.readdirSync(target)) {
+      if (name === '.git' || SKIP_DIRS.has(name)) continue;
+      walk(path.join(target, name), out);
+    }
+  }
+  return out;
+}
+
+function scannable(file) {
+  const ext = path.extname(file);
+  return SCAN_EXTS.has(ext) || path.basename(file).startsWith('.env');
+}
+
+// Resolve the set of files to scan + the relative-path list for hygiene checks.
+function resolveTargets({ root = process.cwd(), paths = [], staged = false } = {}) {
+  if (paths.length) {
+    const files = paths.flatMap((p) => walk(path.resolve(root, p), [])).filter(scannable);
+    return { files, relPaths: files.map((f) => path.relative(root, f)) };
+  }
+  const tracked = gitTrackedFiles(root, { staged });
+  if (tracked) {
+    const files = tracked.filter(scannable).map((p) => path.join(root, p)).filter((f) => fs.existsSync(f));
+    return { files, relPaths: tracked };
+  }
+  const files = walk(root, []).filter(scannable);
+  return { files, relPaths: files.map((f) => path.relative(root, f)) };
+}
+
+// Full scan: line-level findings across files + repo hygiene findings.
+// The scanner's own pattern database and its fixtures necessarily contain the
+// very strings it detects — never scan them (a tool that flags itself is noise).
+const SELF_FILES = new Set(['lib/security-scan.js', 'commands/security-review.js', 'test/security-scan.test.js']);
+
+function runScan({ root = process.cwd(), paths = [], staged = false } = {}) {
+  const { files, relPaths } = resolveTargets({ root, paths, staged });
+  const findings = [];
+  for (const f of files) {
+    if (SELF_FILES.has(path.relative(root, f))) continue;
+    for (const finding of scanFile(f)) findings.push({ ...finding, file: path.relative(root, finding.file) });
+  }
+  findings.push(...sensitiveFileFindings(relPaths.filter((p) => !SELF_FILES.has(p))));
+  const counts = { high: 0, medium: 0, low: 0 };
+  for (const f of findings) counts[f.sev] = (counts[f.sev] || 0) + 1;
+  return { findings, counts, scanned: files.length };
+}
+
+module.exports = {
+  scanLine, scanText, scanFile, sensitiveFileFindings, gitTrackedFiles,
+  resolveTargets, runScan, SECRET_RULES, PII_RULES, RULES,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.26.1",
+  "version": "3.28.0",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",
@@ -48,11 +48,6 @@
     "atris/features/_templates/",
     "atris/features/company-brain-sync/",
     "templates/",
-    "atris/wiki/index.md",
-    "atris/wiki/concepts/agent-activation-contract.md",
-    "atris/wiki/concepts/workspace-initialization-contract.md",
-    "atris/wiki/sources/atrisos-generative-ui-product-surface-2026-05-10.txt",
-    "atris/wiki/sources/jack-dorsey-2026-05-10.txt",
     "atris/policies/",
     "atris/skills/"
   ],

--- a/scripts/check-command-regression.js
+++ b/scripts/check-command-regression.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+'use strict';
+
+// No-command-regression release gate.
+//
+// 3.25.0 shipped from a lineage that lacked deck/card/reel/slop/site/theme, so
+// `atris@latest` silently lost six commands. This gate compares the about-to-
+// publish command surface against the currently-published atris@latest and
+// refuses to publish if any command disappeared. Intentional removals are
+// acknowledged with ATRIS_ALLOW_COMMAND_REMOVALS="a,b".
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// Parse the knownCommands array literal out of bin/atris.js (the invocable surface).
+function extractKnownCommands(source) {
+  const start = String(source || '').indexOf('const knownCommands');
+  if (start === -1) return [];
+  const open = source.indexOf('[', start);
+  const close = source.indexOf('];', open);
+  if (open === -1 || close === -1) return [];
+  const body = source.slice(open + 1, close);
+  const matches = body.match(/'([^']+)'/g) || [];
+  return matches.map((s) => s.slice(1, -1));
+}
+
+function diffCommandRegression(publishedCommands, localCommands, { allow = [] } = {}) {
+  const local = new Set(localCommands);
+  const allowed = new Set(allow);
+  const removed = publishedCommands.filter((c) => !local.has(c) && !allowed.has(c));
+  return { ok: removed.length === 0, removed };
+}
+
+// Fetch bin/atris.js from the published tarball. Best-effort: null on infra failure.
+function fetchPublishedBin(version = 'latest', runner = spawnSync) {
+  let dir;
+  try {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-regression-'));
+    const pack = runner('npm', ['pack', `atris@${version}`], { cwd: dir, encoding: 'utf8' });
+    if (pack.status !== 0) return null;
+    const tgz = String(pack.stdout || '').trim().split('\n').pop();
+    if (!tgz) return null;
+    const extract = runner('tar', ['xzf', tgz, '-C', dir, 'package/bin/atris.js'], { cwd: dir, encoding: 'utf8' });
+    if (extract.status !== 0) return null;
+    return fs.readFileSync(path.join(dir, 'package', 'bin', 'atris.js'), 'utf8');
+  } catch (_) {
+    return null;
+  } finally {
+    if (dir) try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
+function main() {
+  const localCommands = extractKnownCommands(fs.readFileSync(path.join(repoRoot, 'bin', 'atris.js'), 'utf8'));
+  if (!localCommands.length) {
+    console.error('check-command-regression: could not read local knownCommands; aborting.');
+    return 1;
+  }
+  const publishedSource = fetchPublishedBin('latest');
+  if (!publishedSource) {
+    console.warn('check-command-regression: could not fetch atris@latest; skipping (infra, not a regression).');
+    return 0;
+  }
+  const publishedCommands = extractKnownCommands(publishedSource);
+  const allow = (process.env.ATRIS_ALLOW_COMMAND_REMOVALS || '').split(',').map((s) => s.trim()).filter(Boolean);
+  const { ok, removed } = diffCommandRegression(publishedCommands, localCommands, { allow });
+  if (!ok) {
+    console.error(`Refusing to publish: these commands exist in atris@latest but not in this release:\n  ${removed.join(', ')}`);
+    console.error(`If the removal is intentional, set ATRIS_ALLOW_COMMAND_REMOVALS="${removed.join(',')}" and re-run.`);
+    return 1;
+  }
+  console.log(`No command regressions vs atris@latest (${publishedCommands.length} published, ${localCommands.length} local).`);
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = { extractKnownCommands, diffCommandRegression, fetchPublishedBin, main };

--- a/test/check-command-regression.test.js
+++ b/test/check-command-regression.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { extractKnownCommands, diffCommandRegression } = require('../scripts/check-command-regression');
+
+test('extractKnownCommands parses the multi-line knownCommands array', () => {
+  const src = `
+const knownCommands = ['init', 'log',
+                       'deck', 'slop', 'security-review'];
+if (!knownCommands.includes(command)) {}
+`;
+  assert.deepEqual(extractKnownCommands(src), ['init', 'log', 'deck', 'slop', 'security-review']);
+});
+
+test('extractKnownCommands reads the real bin/atris.js and includes the safety surface', () => {
+  const cmds = extractKnownCommands(fs.readFileSync(path.join(__dirname, '..', 'bin', 'atris.js'), 'utf8'));
+  assert.ok(cmds.length > 50);
+  for (const c of ['deck', 'card', 'reel', 'slop', 'site', 'theme', 'signup', 'clarity', 'moves', 'security-review']) {
+    assert.ok(cmds.includes(c), `knownCommands should include ${c}`);
+  }
+});
+
+test('diffCommandRegression flags a command dropped since the published version', () => {
+  const { ok, removed } = diffCommandRegression(['init', 'deck', 'card', 'slop'], ['init', 'deck']);
+  assert.equal(ok, false);
+  assert.deepEqual(removed.sort(), ['card', 'slop']);
+});
+
+test('diffCommandRegression passes when local is a superset', () => {
+  const { ok } = diffCommandRegression(['init', 'deck'], ['init', 'deck', 'reel']);
+  assert.equal(ok, true);
+});
+
+test('diffCommandRegression honors an explicit allow-list', () => {
+  const { ok } = diffCommandRegression(['init', 'oldcmd'], ['init'], { allow: ['oldcmd'] });
+  assert.equal(ok, true);
+});
+
+test('the publish workflow runs the regression gate before publishing', () => {
+  const wf = fs.readFileSync(path.join(__dirname, '..', '.github', 'workflows', 'publish.yml'), 'utf8');
+  assert.match(wf, /check-command-regression\.js/);
+  assert.ok(wf.indexOf('check-command-regression.js') < wf.indexOf('npm run publish:release'), 'gate must run before publish');
+});

--- a/test/clarity.test.js
+++ b/test/clarity.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const clarity = require('../lib/clarity');
+const { parseSets } = require('../commands/clarity');
+const { scrubAgentEnv } = require('./helpers/agent-env');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-clarity-'));
+}
+function runCli(args, cwd) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: { ...scrubAgentEnv(), ATRIS_SKIP_UPDATE_CHECK: '1' },
+  });
+}
+
+test('mergeProfile keeps only known keys and trims (fresh profile)', () => {
+  const p = clarity.mergeProfile({}, { voice: '  plain  ', bogus: 'x', focus: 'atris' }, '2026-06-25');
+  assert.equal(p.voice, 'plain');
+  assert.equal(p.focus, 'atris');
+  assert.equal('bogus' in p, false);
+  assert.equal(p.updated_at, '2026-06-25');
+});
+
+test('parseSets pins the key=value boundary contract', () => {
+  assert.deepEqual(parseSets(['--set', 'focus']), {}, 'no = is dropped');
+  assert.deepEqual(parseSets(['--set', '=plain']), {}, 'empty key is dropped');
+  assert.deepEqual(parseSets(['--set', 'voice=a = b']), { voice: 'a = b' }, 'value keeps embedded =');
+  assert.deepEqual(parseSets(['--set', 'bogus=z']), {}, 'unknown key filtered by KEYS');
+});
+
+test('`atris clarity --set voice=` (empty value) reports nothing saved and writes no field', () => {
+  const root = tmp();
+  try {
+    const res = runCli(['clarity', '--set', 'voice='], root);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /nothing to set/);
+    const p = path.join(root, '.atris', 'clarity.json');
+    if (fs.existsSync(p)) assert.equal('voice' in JSON.parse(fs.readFileSync(p, 'utf8')), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('mergeProfile is incremental and does not wipe prior fields', () => {
+  const first = clarity.mergeProfile({}, { voice: 'plain' }, 's1');
+  const second = clarity.mergeProfile(first, { cadence: 'overnight autonomous' }, 's2');
+  assert.equal(second.voice, 'plain');
+  assert.equal(second.cadence, 'overnight autonomous');
+  assert.equal(second.updated_at, 's2');
+});
+
+test('renderClarityMd shows set fields, flags empty, and uses no em dash', () => {
+  const md = clarity.renderClarityMd({ voice: 'terse', updated_at: 's' });
+  assert.match(md, /- Voice: terse/);
+  assert.equal(md.includes('—'), false);
+  const empty = clarity.renderClarityMd({});
+  assert.match(empty, /not set yet/);
+});
+
+test('`atris clarity --set` writes both the json and the readable CLARITY.md', () => {
+  const root = tmp();
+  try {
+    const res = runCli(['clarity', '--set', 'voice=plain', '--set', 'cadence=overnight autonomous'], root);
+    assert.equal(res.status, 0, res.stderr);
+    const json = JSON.parse(fs.readFileSync(path.join(root, '.atris', 'clarity.json'), 'utf8'));
+    assert.equal(json.voice, 'plain');
+    assert.equal(json.cadence, 'overnight autonomous');
+    const md = fs.readFileSync(path.join(root, 'atris', 'CLARITY.md'), 'utf8');
+    assert.match(md, /Clarity profile/);
+    assert.match(md, /- Voice: plain/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('`atris clarity --json` and `show` read back the saved profile', () => {
+  const root = tmp();
+  try {
+    runCli(['clarity', '--set', 'focus=ship atris'], root);
+    const j = runCli(['clarity', '--json'], root);
+    assert.equal(JSON.parse(j.stdout).focus, 'ship atris');
+    const s = runCli(['clarity', 'show'], root);
+    assert.match(s.stdout, /- Focus: ship atris/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('`atris clarity` is non-interactive-safe (no hang, prints profile + guidance)', () => {
+  const root = tmp();
+  try {
+    const res = runCli(['clarity'], root);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Clarity profile/);
+    assert.match(res.stdout, /terminal to fill this in/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('atris activate surfaces the clarity profile so agents read it', () => {
+  const root = tmp();
+  try {
+    runCli(['init'], root);
+    runCli(['clarity', '--set', 'voice=plain, terse'], root);
+    const res = runCli(['activate'], root);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /How you work \(atris clarity\)/);
+    assert.match(res.stdout, /voice: plain, terse/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('`atris clarity --reset` clears the profile fields', () => {
+  const root = tmp();
+  try {
+    runCli(['clarity', '--set', 'voice=plain'], root);
+    runCli(['clarity', '--reset'], root);
+    const json = JSON.parse(fs.readFileSync(path.join(root, '.atris', 'clarity.json'), 'utf8'));
+    assert.equal('voice' in json, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/moves.test.js
+++ b/test/moves.test.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const nextMoves = require('../lib/next-moves');
+const { parseIndexes } = require('../commands/moves');
+const { scrubAgentEnv } = require('./helpers/agent-env');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-moves-'));
+}
+function runCli(args, cwd) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: { ...scrubAgentEnv(), ATRIS_SKIP_UPDATE_CHECK: '1' },
+  });
+}
+function writeRoadmap(root, items) {
+  const body = items.map((i) => `- [ ] ${i}`).join('\n');
+  fs.writeFileSync(path.join(root, 'ROADMAP.md'), `# Roadmap\n\n## Open loop items\n\n${body}\n\n## Other\n\ntext\n`, 'utf8');
+}
+
+test('pickNextMoves ranks roadmap over task over inbox, and dedupes', () => {
+  const cands = [
+    { title: 'inbox idea', why: 'x', source: 'inbox', weight: 40 },
+    { title: 'goal item', why: 'x', source: 'roadmap', weight: 100 },
+    { title: 'task in flight', why: 'x', source: 'task', weight: 60 },
+    { title: 'goal item', why: 'dup', source: 'roadmap', weight: 100 },
+  ];
+  const picks = nextMoves.pickNextMoves(cands, { limit: 3 });
+  assert.deepEqual(picks.map((p) => p.source), ['roadmap', 'task', 'inbox']);
+  assert.equal(picks.length, 3, 'dedup dropped the duplicate goal item');
+});
+
+test('pickNextMoves drops killed ids', () => {
+  const cands = [{ title: 'a', why: 'x', source: 'roadmap', weight: 100 }];
+  const id = nextMoves.moveId('roadmap', 'a');
+  assert.equal(nextMoves.pickNextMoves(cands, { killedIds: [id] }).length, 0);
+});
+
+test('moveId is stable and case-insensitive on title', () => {
+  assert.equal(nextMoves.moveId('roadmap', 'Do The Thing'), nextMoves.moveId('roadmap', 'do the thing'));
+});
+
+test('seedInboxFromMove writes an I# item under today\'s Inbox', () => {
+  const root = tmp();
+  try {
+    const res = nextMoves.seedInboxFromMove(root, { title: 'ship the loop', source: 'roadmap' });
+    const content = fs.readFileSync(res.file, 'utf8');
+    assert.match(content, /## Inbox/);
+    assert.match(content, /- \*\*I1:\*\* ship the loop/);
+    // second seed increments the id
+    const res2 = nextMoves.seedInboxFromMove(root, { title: 'second', source: 'roadmap' });
+    assert.equal(res2.nextId, 2);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readRoadmapOpenItems reads only the unchecked items in the section', () => {
+  const root = tmp();
+  try {
+    fs.writeFileSync(path.join(root, 'ROADMAP.md'),
+      '# R\n\n## Open loop items\n\n- [ ] alpha\n- [x] done already\n- [ ] beta\n\n## Next\n\n- [ ] not in scope\n', 'utf8');
+    const items = nextMoves.readRoadmapOpenItems(root).map((i) => i.title);
+    assert.deepEqual(items, ['alpha', 'beta']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('`atris moves --json` surfaces roadmap open items', () => {
+  const root = tmp();
+  try {
+    writeRoadmap(root, ['first move', 'second move']);
+    const res = runCli(['moves', '--json'], root);
+    assert.equal(res.status, 0, res.stderr);
+    const moves = JSON.parse(res.stdout).moves;
+    assert.equal(moves[0].title, 'first move');
+    assert.equal(moves[0].source, 'roadmap');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('`atris moves --approve` seeds the move into the inbox the loop reads', () => {
+  const root = tmp();
+  try {
+    writeRoadmap(root, ['approved move']);
+    const res = runCli(['moves', '--approve', '1'], root);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /approved: approved move/);
+    // the move now lives in today's inbox
+    const logsDir = path.join(root, 'atris', 'logs');
+    const year = fs.readdirSync(logsDir)[0];
+    const file = fs.readdirSync(path.join(logsDir, year))[0];
+    const journal = fs.readFileSync(path.join(logsDir, year, file), 'utf8');
+    assert.match(journal, /## Inbox/);
+    assert.match(journal, /approved move/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('`atris moves --kill` stops suggesting that move', () => {
+  const root = tmp();
+  try {
+    writeRoadmap(root, ['keep me', 'kill me']);
+    let res = runCli(['moves', '--kill', '2'], root);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /killed: kill me/);
+    res = runCli(['moves', '--json'], root);
+    const titles = JSON.parse(res.stdout).moves.map((m) => m.title);
+    assert.ok(titles.includes('keep me'));
+    assert.ok(!titles.includes('kill me'), 'killed move should not reappear');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('pickNextMoves suppresses a killed title across sources', () => {
+  const cands = [
+    { title: 'ship it', source: 'roadmap', weight: 100 },
+    { title: 'ship it', source: 'inbox', weight: 40 },
+  ];
+  const killedId = nextMoves.moveId('roadmap', 'ship it');
+  const picks = nextMoves.pickNextMoves(cands, { killedIds: [killedId], killedTitles: ['ship it'] });
+  assert.equal(picks.length, 0, 'same title from a different source stays suppressed');
+});
+
+test('pickNextMoves suppresses approved moves so they stop nagging', () => {
+  const cands = [{ title: 'approved one', source: 'roadmap', weight: 100 }];
+  assert.equal(nextMoves.pickNextMoves(cands, { approvedTitles: ['approved one'] }).length, 0);
+});
+
+test('killing or approving an idea never hides a real task with the same title', () => {
+  const cands = [
+    { title: 'fix login', source: 'roadmap', weight: 100 },
+    { title: 'fix login', source: 'task', weight: 60, ref: 'CLI-42' },
+  ];
+  // kill the roadmap idea by its id + title
+  const killed = nextMoves.pickNextMoves(cands, { killedIds: [nextMoves.moveId('roadmap', 'fix login')], killedTitles: ['fix login'] });
+  assert.equal(killed.length, 1);
+  assert.equal(killed[0].source, 'task', 'the genuine in-flight task survives');
+  // same for approve
+  const approved = nextMoves.pickNextMoves(cands, { approvedIds: [nextMoves.moveId('roadmap', 'fix login')], approvedTitles: ['fix login'] });
+  assert.equal(approved.length, 1);
+  assert.equal(approved[0].source, 'task');
+});
+
+test('pickNextMoves keeps the highest-weight copy of a duplicated title', () => {
+  const cands = [
+    { title: 'dup', source: 'inbox', weight: 40 },
+    { title: 'dup', source: 'roadmap', weight: 100 },
+  ];
+  const picks = nextMoves.pickNextMoves(cands, {});
+  assert.equal(picks.length, 1);
+  assert.equal(picks[0].source, 'roadmap', 'sort-before-dedup keeps the roadmap copy');
+});
+
+test('`atris moves --approve` then --json no longer shows the approved move', () => {
+  const root = tmp();
+  try {
+    writeRoadmap(root, ['keep me too', 'approve me']);
+    runCli(['moves', '--approve', '2'], root);
+    const res = runCli(['moves', '--json'], root);
+    const titles = JSON.parse(res.stdout).moves.map((m) => m.title);
+    assert.ok(!titles.includes('approve me'), 'approved move should be suppressed, not nag');
+    assert.ok(titles.includes('keep me too'));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('`atris moves --approve` claims the roadmap item ([~]) so the loop agrees it is handled', () => {
+  const root = tmp();
+  try {
+    writeRoadmap(root, ['approve me', 'keep me']);
+    const res = runCli(['moves', '--approve', '1'], root);
+    assert.equal(res.status, 0, res.stderr);
+    const roadmap = fs.readFileSync(path.join(root, 'ROADMAP.md'), 'utf8');
+    assert.match(roadmap, /- \[~\] approve me/, 'approved roadmap move is claimed in ROADMAP');
+    assert.match(roadmap, /- \[ \] keep me/, 'the other item stays open');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveSelection prefers a stable id, falls back to position, ignores garbage', () => {
+  const { resolveSelection } = require('../commands/moves');
+  const moves = nextMoves.pickNextMoves([
+    { title: 'a', source: 'roadmap', weight: 100 },
+    { title: 'b', source: 'roadmap', weight: 90 },
+  ], {});
+  assert.deepEqual(resolveSelection(moves, moves[1].id).map((m) => m.title), ['b'], 'resolves by stable id');
+  assert.deepEqual(resolveSelection(moves, '1').map((m) => m.title), ['a'], 'positional fallback');
+  assert.deepEqual(resolveSelection(moves, '99'), [], 'out of range');
+  assert.deepEqual(resolveSelection(moves, 'nope'), [], 'garbage');
+});
+
+test('`atris moves --kill <id>` kills exactly that move regardless of position', () => {
+  const root = tmp();
+  try {
+    writeRoadmap(root, ['first', 'second']);
+    const secondId = JSON.parse(runCli(['moves', '--json'], root).stdout).moves.find((m) => m.title === 'second').id;
+    const res = runCli(['moves', '--kill', secondId], root);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /killed: second/);
+    const after = JSON.parse(runCli(['moves', '--json'], root).stdout).moves.map((m) => m.title);
+    assert.ok(!after.includes('second'), 'the id-targeted move is gone');
+    assert.ok(after.includes('first'), 'the other move stays');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('parseIndexes parses lists and drops non-positive / garbage', () => {
+  assert.deepEqual(parseIndexes('abc'), []);
+  assert.deepEqual(parseIndexes('0'), []);
+  assert.deepEqual(parseIndexes('1, 3'), [1, 3]);
+  assert.deepEqual(parseIndexes(''), []);
+});
+
+test('`atris moves --approve 99` (out of range) seeds nothing and says so', () => {
+  const root = tmp();
+  try {
+    writeRoadmap(root, ['only one']);
+    const res = runCli(['moves', '--approve', '99'], root);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /no matching move/);
+    assert.equal(fs.existsSync(path.join(root, 'atris', 'logs')), false, 'nothing should be seeded');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/security-scan.test.js
+++ b/test/security-scan.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { scanLine, scanText, sensitiveFileFindings, runScan } = require('../lib/security-scan');
+const cli = path.join(__dirname, '..', 'bin', 'atris.js');
+
+function sevs(findings) { return findings.map((f) => f.rule).sort(); }
+
+test('scanLine flags real high-severity secrets', () => {
+  assert.deepEqual(sevs(scanLine('const k = "AKIA1234567890ABCDEF";')), ['aws-access-key-id']);
+  assert.equal(scanLine('token = "ghp_' + 'a'.repeat(36) + '"')[0].rule, 'github-token');
+  assert.equal(scanLine('OPENAI="sk-' + 'a'.repeat(24) + '"')[0].rule, 'openai-key');
+  assert.equal(scanLine('-----BEGIN RSA PRIVATE KEY-----')[0].sev, 'high');
+  assert.equal(scanLine('const password = "hunter2hunter2";')[0].rule, 'assigned-secret');
+});
+
+test('scanLine ignores placeholders and env reads (no false-positive secrets)', () => {
+  assert.deepEqual(scanLine('const apiKey = process.env.API_KEY;'), []);
+  assert.deepEqual(scanLine('password: "your-password-here"'), []);
+  assert.deepEqual(scanLine('// example: api_key = "xxxxxxxxxxxx"'), []);
+  assert.deepEqual(scanLine('token = "<your-token>"'), []);
+});
+
+test('scanLine respects an inline suppression marker', () => {
+  assert.deepEqual(scanLine('const k = "AKIA1234567890ABCDEF"; // atris-allow-secret'), []);
+});
+
+test('scanLine flags personal home paths but not CI/system paths', () => {
+  assert.equal(scanLine('cwd: /Users/keshavrao/arena/atris-cli')[0].rule, 'home-path');
+  assert.equal(scanLine('path = /home/jdoe/secret/app')[0].rule, 'home-path');
+  assert.deepEqual(scanLine('runner at /home/runner/work/repo'), []);
+  assert.deepEqual(scanLine('install to /Users/runner/app'), []);
+});
+
+test('email rule is low-severity and skips role addresses', () => {
+  assert.equal(scanLine('contact: alice.personal@gmail.com')[0].sev, 'low');
+  assert.deepEqual(scanLine('support@acme.com for help'), []);
+  assert.deepEqual(scanLine('reach noreply@service.io'), []);
+  assert.deepEqual(scanLine('user@example.com is a placeholder'), []);
+});
+
+test('sensitiveFileFindings flags tracked secret files but allows .env.example', () => {
+  const f = sensitiveFileFindings(['.env', 'src/app.js', 'keys/id_rsa', 'config/.env.example', 'certs/server.pem']);
+  assert.deepEqual(f.map((x) => x.file).sort(), ['.env', 'certs/server.pem', 'keys/id_rsa']);
+  assert.ok(f.every((x) => x.sev === 'high'));
+});
+
+test('runScan over a temp tree finds planted secrets + sensitive files', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-sec-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'app.js'), 'const k = "AKIA1234567890ABCDEF";\nconst safe = process.env.TOKEN;\n');
+    fs.writeFileSync(path.join(dir, '.env'), 'SECRET=abc123\n');
+    fs.writeFileSync(path.join(dir, 'clean.js'), 'module.exports = 1;\n');
+    const { findings, counts } = runScan({ root: dir });
+    const rules = new Set(findings.map((f) => f.rule));
+    assert.ok(rules.has('aws-access-key-id'), 'should find the AWS key');
+    assert.ok(rules.has('tracked-sensitive-file'), 'should flag the tracked .env');
+    assert.ok(counts.high >= 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the CLI exits 1 on a high finding and 0 when clean (--json)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-sec-cli-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'leak.js'), 'const k = "AKIA1234567890ABCDEF";\n');
+    const bad = spawnSync(process.execPath, [cli, 'security-review', '.', '--json'], { cwd: dir, encoding: 'utf8', env: { ...process.env, ATRIS_SKIP_UPDATE_CHECK: '1' } });
+    assert.equal(bad.status, 1, bad.stdout + bad.stderr);
+    const report = JSON.parse(bad.stdout);
+    assert.equal(report.ok, false);
+    assert.ok(report.findings.some((f) => f.rule === 'aws-access-key-id'));
+
+    fs.writeFileSync(path.join(dir, 'leak.js'), 'module.exports = 42;\n');
+    const good = spawnSync(process.execPath, [cli, 'security-review', '.', '--json'], { cwd: dir, encoding: 'utf8', env: { ...process.env, ATRIS_SKIP_UPDATE_CHECK: '1' } });
+    assert.equal(good.status, 0, good.stdout + good.stderr);
+    assert.equal(JSON.parse(good.stdout).ok, true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('scanLine flags code-execution risks but not prose mentions', () => {
+  assert.equal(scanLine('const out = eval(userInput);')[0].rule, 'eval-call');
+  assert.equal(scanLine('const f = new Function("return 1");')[0].rule, 'new-function');
+  assert.equal(scanLine('execSync(`git log ${ref}`)')[0].rule, 'shell-exec-interpolation');
+  assert.equal(scanLine('spawn(cmd, args, { shell: true })')[0].rule, 'child-process-shell-true');
+  // prose / safe usage must NOT trip the gate
+  assert.deepEqual(scanLine('the held-out eval (generalization, not memorization)'), []);
+  assert.deepEqual(scanLine('execFileSync("git", ["log", ref])'), []);
+});
+
+test('code-execution rules only apply to code files, not docs', () => {
+  const { scanFile } = require('../lib/security-scan');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-sec-code-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'note.md'), 'You can use eval(x) to run code.\n');
+    assert.deepEqual(scanFile(path.join(dir, 'note.md')), []);
+    fs.writeFileSync(path.join(dir, 'run.js'), 'eval(x)\n');
+    assert.equal(scanFile(path.join(dir, 'run.js'))[0].rule, 'eval-call');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/signup.test.js
+++ b/test/signup.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseHandle, HANDLE_RE, signupCommand } = require('../commands/signup');
+
+test('HANDLE_RE accepts lowercase alnum 3-30', () => {
+  assert.ok(HANDLE_RE.test('ada'));
+  assert.ok(HANDLE_RE.test('agent007'));
+  assert.ok(HANDLE_RE.test('a'.repeat(30)));
+});
+
+test('HANDLE_RE rejects too short, too long, symbols, case', () => {
+  assert.ok(!HANDLE_RE.test('ab'));
+  assert.ok(!HANDLE_RE.test('a'.repeat(31)));
+  for (const bad of ['a.b', 'a-b', 'a b', 'Ada', 'a_b', 'a/b']) {
+    assert.ok(!HANDLE_RE.test(bad), bad);
+  }
+});
+
+test('parseHandle picks the first positional, lowercased', () => {
+  assert.equal(parseHandle(['NewBie']), 'newbie');
+  assert.equal(parseHandle(['--json', 'ghost']), 'ghost');
+  assert.equal(parseHandle(['  Spaced  ']), 'spaced');
+  assert.equal(parseHandle([]), '');
+});
+
+test('signupCommand returns 1 on missing handle without a network call', async () => {
+  const code = await signupCommand([]);
+  assert.equal(code, 1);
+});
+
+test('signupCommand returns 1 on invalid handle without a network call', async () => {
+  // Symbols / wrong length fail the client-side guard before any request.
+  assert.equal(await signupCommand(['a.b!']), 1);
+  assert.equal(await signupCommand(['ab']), 1);
+});


### PR DESCRIPTION
## Why

A concurrent force-push during the privacy cleanup split history: `master` (3.26.1) has the scrub but lost the safety features, while `npm latest` (3.27.0) has the features but predates the scrub. This converges them into a single clean, complete master and supersedes 3.27.0.

## What
- **Re-land** (clobbered by the force-push): `signup`, `clarity`, `moves` (+ activate clarity hook), and the **no-command-regression release gate** (publish refuses to drop a command vs `atris@latest`).
- **Broaden `security-review`** beyond secrets/PII: `eval`, `new Function`, shell exec with interpolation, `child_process shell:true` — scoped to code files; the scanner no longer flags its own pattern DB/fixtures.
- **Privacy hardening**: dropped all `atris/wiki/*` (now gitignored) and the internal `atris-labs-*` source docs from the npm `files` allowlist, so they never ship.
- Bumps **3.28.0**.

## Proof
- Full suite **1413/1413**.
- Regression gate live: `0 drops vs atris@latest (113 published, 115 local)`.
- `security-review`: **0 high** (93 medium = personal paths in still-tracked files the cleanup is removing).
- Both gates run before publish in `publish.yml`.

Supervision note: residual personal-path MEDIUMs remain in still-tracked dev files; the concurrent cleanup is removing them. This PR does not fight that — it's additive + the version bump.