### PR TITLE
feat: security-review --land — the landing for the overnight loop (3.30.0)

### DIFF
--- a/commands/security-review.js
+++ b/commands/security-review.js
@@ -31,6 +31,8 @@ const {
   applyBaseline,
   shouldFail,
   scoreFindings,
+  recordRun,
+  buildLanding,
 } = require('../lib/security-scan');
 
 const ICON = { critical: '✗', high: '✗', medium: '!', low: '·', privacy: '✗', secret: '✗', pii: '!' };
@@ -46,6 +48,8 @@ function parseArgs(argv) {
     noBaseline: false,
     deep: false,
     md: false,
+    land: false,
+    noRecord: false,
     baseline: DEFAULT_BASELINE,
     paths: [],
   };
@@ -60,6 +64,8 @@ function parseArgs(argv) {
     else if (arg === '--no-baseline') opts.noBaseline = true;
     else if (arg === '--deep') opts.deep = true;
     else if (arg === '--md' || arg === '--markdown') opts.md = true;
+    else if (arg === '--land' || arg === '--landing') opts.land = true;
+    else if (arg === '--no-record') opts.noRecord = true;
     else if (arg === '--baseline') {
       if (!argv[i + 1] || argv[i + 1].startsWith('-')) throw new Error('--baseline requires a path');
       opts.baseline = argv[++i];
@@ -144,6 +150,13 @@ function securityReviewCommand(argv = []) {
   const failing = failingCount(findings, threshold);
   const ok = !shouldFail(findings, threshold);
 
+  // Flight recorder + landing: the loop appends one row per run; the landing
+  // compares this run to the last one. buildLanding must read the ledger BEFORE
+  // recordRun appends this run.
+  const scanResult = { findings, counts, scanned: raw.scanned, suppressed: result.suppressed };
+  const landing = buildLanding(root, scanResult, { failOn: threshold });
+  if (!opts.noRecord) recordRun(root, scanResult, { failOn: threshold });
+
   if (opts.json) {
     console.log(JSON.stringify({
       ok,
@@ -155,6 +168,7 @@ function securityReviewCommand(argv = []) {
       score: scoreFindings(findings),
       score_all: scoreFindings(allFindings),
       fail_threshold: threshold,
+      landing,
       findings,
       deep_review: opts.deep ? deepReviewPayload({ findings, counts, scanned: raw.scanned, suppressed: result.suppressed }) : undefined,
       generated_for: 'soc2-evidence',
@@ -175,6 +189,11 @@ function securityReviewCommand(argv = []) {
     console.log(renderDeepReview({
       findings, counts, scanned: raw.scanned, threshold, suppressed: result.suppressed, baseline: result.baseline,
     }));
+    return ok ? 0 : 1;
+  }
+
+  if (opts.land) {
+    console.log(renderLanding(landing, threshold));
     return ok ? 0 : 1;
   }
 
@@ -203,6 +222,49 @@ function securityReviewCommand(argv = []) {
     console.log(`  no findings at the ${threshold.toUpperCase()} threshold · exit 0\n`);
   }
   return ok ? 0 : 1;
+}
+
+// The landing: short, true, decision-ready. What you read after the overnight
+// loop — the opposite of a finding dump.
+function renderLanding(landing, threshold) {
+  const date = new Date().toISOString().slice(0, 10);
+  const L = ['', `  ✈ security landing — ${date}`, ''];
+  if (landing.cleared) {
+    L.push(`  CLEARED TO SHIP    no unresolved findings at the ${threshold.toUpperCase()} line`);
+  } else {
+    const n = landing.open.length;
+    L.push(`  HOLD               ${n} finding${n === 1 ? '' : 's'} need a decision before ship`);
+  }
+  L.push('');
+  if (landing.hadPrevRun) {
+    L.push('  since last run:');
+    L.push(`    fixed     ${landing.fixed}`);
+    L.push(`    new       ${landing.appeared}`);
+    L.push(`    accepted  ${landing.accepted}  (known-safe, in baseline)`);
+  } else {
+    L.push(`  first run:  ${landing.open.length} open · ${landing.accepted} accepted (baseline)`);
+  }
+  L.push('');
+  if (landing.open.length) {
+    L.push('  needs you:');
+    for (const f of landing.open.slice(0, 10)) {
+      L.push(`    ${f.sev.toUpperCase().padEnd(8)} ${f.file}${f.line ? ':' + f.line : ''} — ${f.why}`);
+    }
+    if (landing.open.length > 10) L.push(`    … and ${landing.open.length - 10} more`);
+  } else {
+    L.push('  needs you:  nothing');
+  }
+  L.push('');
+  if (landing.trend.length > 1) {
+    const a = landing.trend[0], b = landing.trend[landing.trend.length - 1];
+    const da = a.critical + a.high, db = b.critical + b.high;
+    const dir = db < da ? 'improving' : db > da ? 'worsening' : 'steady';
+    L.push(`  posture: critical ${a.critical}→${b.critical}, high ${a.high}→${b.high} over ${landing.trend.length} runs (${dir})`);
+  } else {
+    L.push(`  posture: ${landing.runs} run${landing.runs === 1 ? '' : 's'} recorded · scanned ${landing.scanned} files`);
+  }
+  L.push('');
+  return L.join('\n');
 }
 
 function printRules() {
@@ -343,6 +405,8 @@ function printHelp() {
     atris security-review --json     machine output / SOC 2 evidence artifact
     atris security-review --md       markdown evidence report
     atris security-review --deep     prompt a stronger model with framework + evidence
+    atris security-review --land     the landing: cleared-to-ship or hold, what changed,
+                                      what needs you, the trend (read this after the loop)
     atris security-review --update-baseline
                                       accept current findings in .security-review.baseline.json
     atris security-review --no-baseline

--- a/lib/security-scan.js
+++ b/lib/security-scan.js
@@ -431,10 +431,82 @@ function scoreFindings(findings) {
   return findings.reduce((sum, f) => sum + (score[f.sev] || 0), 0);
 }
 
+// --- the loop's flight recorder + landing ---
+// Takeoff = the overnight loop grinding the repo. Landing = the one clean
+// artifact a human reads after: what changed, what still needs you, the trend.
+// One compact row per run keeps it honest without noise.
+const DEFAULT_LEDGER = path.join('.atris', 'state', 'security_review.jsonl');
+
+function gitCommit(root) {
+  try { return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); }
+  catch { return null; }
+}
+
+function openFingerprints(findings, failOn = 'high') {
+  const threshold = SEVERITY_RANK[failOn] == null ? SEVERITY_RANK.high : SEVERITY_RANK[failOn];
+  return findings.filter((f) => SEVERITY_RANK[f.sev] >= threshold)
+    .map((f) => f.fingerprint || findingFingerprint(f));
+}
+
+function recordRun(root, scan, { failOn = 'high' } = {}) {
+  try {
+    const findings = scan.findings || [];
+    const row = {
+      ts: new Date().toISOString(),
+      commit: gitCommit(root),
+      scanned: scan.scanned || 0,
+      counts: scan.counts || summarizeFindings(findings),
+      accepted: scan.suppressed || 0,
+      open: [...new Set(openFingerprints(findings, failOn))].sort(),
+    };
+    const file = path.join(root, DEFAULT_LEDGER);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.appendFileSync(file, JSON.stringify(row) + '\n');
+    return row;
+  } catch { return null; }
+}
+
+function loadLedger(root) {
+  try {
+    return fs.readFileSync(path.join(root, DEFAULT_LEDGER), 'utf8')
+      .split('\n').filter(Boolean)
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(Boolean);
+  } catch { return []; }
+}
+
+// Compare the current scan to the last recorded run. Returns the decision-ready
+// landing: cleared-to-ship or hold, what was fixed/appeared, what still needs a
+// human, and the trend over recent runs.
+function buildLanding(root, scan, { failOn = 'high' } = {}) {
+  const ledger = loadLedger(root);
+  const prev = ledger.length ? ledger[ledger.length - 1] : null;
+  const findings = scan.findings || [];
+  const open = findings.filter((f) => SEVERITY_RANK[f.sev] >= (SEVERITY_RANK[failOn] ?? SEVERITY_RANK.high));
+  const openNow = new Set(open.map((f) => f.fingerprint || findingFingerprint(f)));
+  const prevOpen = new Set(prev ? prev.open || [] : []);
+  return {
+    cleared: openNow.size === 0,
+    open,
+    fixed: [...prevOpen].filter((fp) => !openNow.has(fp)).length,
+    appeared: prev ? [...openNow].filter((fp) => !prevOpen.has(fp)).length : openNow.size,
+    accepted: scan.suppressed || 0,
+    scanned: scan.scanned || 0,
+    runs: ledger.length + 1,
+    hadPrevRun: Boolean(prev),
+    // include THIS run as the latest trend point so the posture line is current
+    trend: [
+      ...ledger.slice(-4).map((r) => ({ ts: r.ts, critical: (r.counts && r.counts.critical) || 0, high: (r.counts && r.counts.high) || 0 })),
+      { ts: new Date().toISOString(), critical: (scan.counts && scan.counts.critical) || 0, high: (scan.counts && scan.counts.high) || 0 },
+    ],
+  };
+}
+
 module.exports = {
   scanLine, scanText, scanFile, sensitiveFileFindings, gitTrackedFiles,
   resolveTargets, runScan, SECRET_RULES, PII_RULES, RULES, CODE_RULES,
-  DEFAULT_BASELINE, SEVERITIES, SEVERITY_RANK, normalizeSnippet,
+  DEFAULT_BASELINE, DEFAULT_LEDGER, SEVERITIES, SEVERITY_RANK, normalizeSnippet,
   shannonEntropy, secretQuality, findingFingerprint, summarizeFindings,
   loadBaseline, writeBaseline, applyBaseline, shouldFail, scoreFindings,
+  recordRun, loadLedger, buildLanding,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/security-scan.test.js
+++ b/test/security-scan.test.js
@@ -177,3 +177,48 @@ test('code-execution rules only apply to code files, not docs', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('security landing: records runs and reports a clean, decision-ready summary', () => {
+  const lib = require('../lib/security-scan');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-sec-land-'));
+  try {
+    // run 1: a real finding is open -> HOLD, nothing fixed yet
+    const open = { findings: [{ rule: 'aws-access-key-id', sev: 'critical', cat: 'secret', file: 'a.js', line: 1, why: 'x', fingerprint: 'fp1' }], counts: { critical: 1, high: 0, medium: 0, low: 0 }, scanned: 1, suppressed: 0 };
+    let landing = lib.buildLanding(dir, open, { failOn: 'high' });
+    assert.equal(landing.cleared, false);
+    assert.equal(landing.open.length, 1);
+    lib.recordRun(dir, open, { failOn: 'high' });
+
+    // run 2: the finding is gone -> CLEARED, fixed 1
+    const clean = { findings: [], counts: { critical: 0, high: 0, medium: 0, low: 0 }, scanned: 1, suppressed: 0 };
+    landing = lib.buildLanding(dir, clean, { failOn: 'high' });
+    assert.equal(landing.cleared, true);
+    assert.equal(landing.fixed, 1);
+    assert.equal(landing.appeared, 0);
+    lib.recordRun(dir, clean, { failOn: 'high' });
+
+    // ledger has both runs
+    assert.equal(lib.loadLedger(dir).length, 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI --land prints the landing report and gates', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-sec-land-cli-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'leak.js'), 'const k = "' + 'AKIA' + 'ZX7QWP2KMR4VT9BH' + '";\n');
+    const hold = spawnSync(process.execPath, [cli, 'security-review', '--land'], { cwd: dir, encoding: 'utf8', env: { ...process.env, ATRIS_SKIP_UPDATE_CHECK: '1' } });
+    assert.equal(hold.status, 1, hold.stdout + hold.stderr);
+    assert.match(hold.stdout, /security landing/);
+    assert.match(hold.stdout, /HOLD/);
+    assert.match(hold.stdout, /needs you:/);
+
+    fs.writeFileSync(path.join(dir, 'leak.js'), 'module.exports = 1;\n');
+    const cleared = spawnSync(process.execPath, [cli, 'security-review', '--land'], { cwd: dir, encoding: 'utf8', env: { ...process.env, ATRIS_SKIP_UPDATE_CHECK: '1' } });
+    assert.equal(cleared.status, 0, cleared.stdout + cleared.stderr);
+    assert.match(cleared.stdout, /CLEARED TO SHIP/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why
An airplane has takeoff (the long-horizon agent loop) and a landing. The landing was missing: after running the security loop overnight, you need ONE clean artifact that tells you the truth and what needs you — not a finding dump. No noise.

## What
- **Flight recorder**: every `security-review` run appends one compact row to `.atris/state/security_review.jsonl` (commit, counts, accepted, open fingerprints).
- **`--land`**: compares this run to the last and prints the landing —
  - `CLEARED TO SHIP` or `HOLD` (one line, the bottom line)
  - since last run: **fixed / new / accepted**
  - **needs you**: the short list still open (file:line + plain English)
  - **posture**: critical/high trend over recent runs (improving/steady/worsening)

## How it's used
Run `security-review` on a cadence (pulse/mission/cron) overnight; read `atris security-review --land` in the morning. The loop grinds; the landing is what you understand.

## Proof
Full suite **1418/1418**. Smoke: leak present → HOLD + needs-you; fixed → CLEARED + 'fixed 1, needs you: nothing'. Bumps 3.30.0.