### PR TITLE
cli: centralize log path helpers (PR1 of journal→logs)

### DIFF
--- a/lib/file-ops.js
+++ b/lib/file-ops.js
@@ -57,7 +57,7 @@ function createLogFile(logFile, dateFormatted) {
       const prevMonth = String(prev.getMonth() + 1).padStart(2, '0');
       const prevDay = String(prev.getDate()).padStart(2, '0');
       const prevDateFormatted = `${prevYear}-${prevMonth}-${prevDay}`;
-      const prevLogFile = path.join(process.cwd(), 'atris', 'logs', prevYear.toString(), `${prevDateFormatted}.md`);
+      const { logFile: prevLogFile } = getLogPath(prevDateFormatted);
 
       if (fs.existsSync(prevLogFile)) {
         const prevContent = fs.readFileSync(prevLogFile, 'utf8');

--- a/lib/journal.js
+++ b/lib/journal.js
@@ -3,7 +3,13 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { spawnSync } = require('child_process');
-const escapeRegExp = require('./escape-regexp');
+
+// Path/directory helpers for atris/logs/<YYYY>/<YYYY-MM-DD>.md live in lib/file-ops.
+// Re-export them here so existing `require('../lib/journal')` consumers
+// (activate, autopilot, brainstorm, run, status, visualize, workflow) keep working
+// without code changes while we collapse the duplicate-truth bug. PR2/3 will
+// re-point consumers directly at lib/file-ops.
+const { getLogPath, ensureLogDirectory, createLogFile } = require('./file-ops');
 
 /**
  * Check if two timestamps are effectively the same (within 5ms).
@@ -187,78 +193,6 @@ function showLogDiff(localPath, remoteContent) {
       }
     }
   }
-}
-
-function getLogPath(dateStr) {
-  const targetDir = path.join(process.cwd(), 'atris');
-  const date = dateStr ? new Date(dateStr) : new Date();
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const dateFormatted = `${year}-${month}-${day}`; // YYYY-MM-DD in local time
-
-  const logsDir = path.join(targetDir, 'logs');
-  const yearDir = path.join(logsDir, year.toString());
-  const logFile = path.join(yearDir, `${dateFormatted}.md`);
-
-  return { logsDir, yearDir, logFile, dateFormatted };
-}
-
-function ensureLogDirectory() {
-  const { logsDir, yearDir } = getLogPath();
-
-  if (!fs.existsSync(logsDir)) {
-    fs.mkdirSync(logsDir, { recursive: true });
-  }
-
-  if (!fs.existsSync(yearDir)) {
-    fs.mkdirSync(yearDir, { recursive: true });
-  }
-}
-
-function createLogFile(logFile, dateFormatted) {
-  let carryInProgress = '';
-  let carryBacklog = '';
-  let carryInbox = '';
-
-  try {
-    const [y, m, d] = String(dateFormatted).split('-').map(Number);
-    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
-      const prev = new Date(y, m - 1, d);
-      prev.setDate(prev.getDate() - 1);
-
-      const prevYear = prev.getFullYear();
-      const prevMonth = String(prev.getMonth() + 1).padStart(2, '0');
-      const prevDay = String(prev.getDate()).padStart(2, '0');
-      const prevDateFormatted = `${prevYear}-${prevMonth}-${prevDay}`;
-      const prevLogFile = path.join(process.cwd(), 'atris', 'logs', prevYear.toString(), `${prevDateFormatted}.md`);
-
-      if (fs.existsSync(prevLogFile)) {
-        const prevContent = fs.readFileSync(prevLogFile, 'utf8');
-
-        const sectionBody = (headingLine) => {
-          const regex = new RegExp(
-            `## ${escapeRegExp(headingLine)}\\n([\\s\\S]*?)(?=\\n---|\\n## |$)`
-          );
-          const match = prevContent.match(regex);
-          return match ? match[1].trim() : '';
-        };
-
-        carryInProgress = sectionBody('In Progress 🔄');
-        carryBacklog = sectionBody('Backlog');
-        carryInbox = sectionBody('Inbox');
-      }
-    }
-  } catch {
-    // Best-effort carry-forward; never block journal creation.
-  }
-
-  const inProgressBody = carryInProgress ? `${carryInProgress}\n\n` : '';
-  const backlogBody = carryBacklog ? `${carryBacklog}\n\n` : '';
-  const inboxBody = carryInbox ? `${carryInbox}\n\n` : '';
-
-  const initialContent = `# Log — ${dateFormatted}\n\n## Handoff\n\n---\n\n## Completed ✅\n\n---\n\n## In Progress 🔄\n\n${inProgressBody}---\n\n## Backlog\n\n${backlogBody}---\n\n## Notes\n\n---\n\n## Inbox\n\n${inboxBody}\n`;
-  fs.writeFileSync(logFile, initialContent);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Make `lib/file-ops.js` the canonical home for `getLogPath`, `ensureLogDirectory`, `createLogFile`. `lib/journal.js` now re-exports them so every existing consumer keeps working unchanged.
- Replace the last `'atris/logs/<year>/<date>.md'` literal path inside `createLogFile` with a `getLogPath()` call.
- Net: -74 / +8 lines. No API, route, convention, or docs changes.

Behavior-preserving prep for PR2 (rename surfaces) → PR3 (CLI callers) → PR4 (docs lockstep). See the rename plan in the workflow output for full scope.

## Verification

- `journal.getLogPath === fileOps.getLogPath` confirmed (same function reference, not a copy).
- Live smoke: `getLogPath('2026-06-27')` → `ensureLogDirectory()` → `createLogFile(...)` creates `atris/logs/2026/2026-06-26.md` with `# Log — 2026-06-26` header. Logs come back end-to-end.
- `npm test`: 1357 pass / 2 fail. Both fails are pre-existing env-dependent "play mode" username assertions unrelated to path helpers.

## Test plan

- [ ] `npm test`
- [ ] `node bin/atris.js log` writes to `atris/logs/<YYYY>/<YYYY-MM-DD>.md`
- [ ] `node bin/atris.js activate` / `status` / `run` / `autopilot` / `brainstorm` / `visualize` / `workflow` still import the trio from `lib/journal` without breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)