### PR TITLE
docs: surface `atris signup` + add npm package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Requires Node.js 18+.
 
 If you want Atris cloud workspaces, businesses, or integrations, run `atris setup` after install.
 
+## Sign Up
+
+Claim a handle to create your Atris identity:
+
+```bash
+atris signup <handle>
+```
+
+A handle is 3–30 lowercase letters and digits. This mints a starter account at `<handle>@atrismail.com`: identity is free, capability is earned through proof-backed work. Your active profile is saved, so `atris play` works next.
+
 ## How To Run Atris
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "atris",
   "version": "3.30.1",
+  "description": "Turn any repo into a workspace an agent can operate: shared context, a plan/do/review loop, durable tasks and daily logs, and verification that ends work on a real check.",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",


### PR DESCRIPTION
## Why
The npm `atris` package (~1.3K installs/mo) is distribution we already have but don't convert: the `description` field was blank (empty npm search snippet) and the README jumped **Install → Run/Play** without ever showing account creation. People install the CLI and never reach `atris signup`.

## What
- **package.json**: add a one-line description.
- **README**: add a "Sign Up" step between Install and How To Run, documenting `atris signup <handle>` exactly as it behaves (3–30 char handle → mints `<handle>@atrismail.com` starter account → saves active profile so `atris play` works next).

Docs only, 11 insertions. Publishing is a separate `npm publish` (gated on npm auth — not done here).

## Note for attribution
CLI signups land as `@atrismail` / provider `atrisos` (the agent bucket), so they're tagged `signup_source="agent"` by the backend attribution work (atrisos-backend #2091). If we want to measure CLI-origin humans distinctly later, that's a follow-up (pass a `cli` source from the signup command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)