### PR TITLE
fix: fail run phases on runner errors

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -766,6 +766,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 - **Entry point:** `commands/run.js:301-534` (runAtris function)
 - **Prompt builder:** `commands/run.js:117-195` (buildRunPrompt function) — generates phase-specific prompts (plan/do/review) with full context file paths
 - **Phase executor:** `commands/run.js:200-237` (executePhase function) — runs `buildRunnerCommand()` with prompt, executes via spawnSync in a detached process group, sweeps the configured runner tree on timeout/kill, and handles output
+- **Phase failure contract:** `commands/run.js` treats any non-zero configured-runner phase as a failed phase even when stdout exists; `formatPhaseFailure()` keeps captured stdout/stderr in the thrown error for logs, and `runAtris()` rethrows after writing run logs so supervisors see a non-zero command. Regression: `test/run-glass-logs.test.js`
 - **Glass run logs:** `commands/run.js:31-37` (getRunLogDir, getRunLogPath, writePhaseToRunLog) — persists plan/do/review phase reasoning to `atris/logs/runs/YYYY-MM-DD-<stamp>-cycle-N.md` as inspectable material; failed phases also logged as ERROR sections
 - **Run log browser:** `commands/run.js:543-629` (listRunLogs function) — `atris run logs [--tail N] [--cat FILE] [--json]` subcommand for browsing glass run logs
 - **Run log pruning:** `commands/run.js:637-681` (pruneRunLogs function) — `atris run prune-logs [--keep N] [--dry-run]` subcommand for cleaning up old run logs

--- a/commands/run.js
+++ b/commands/run.js
@@ -111,6 +111,15 @@ function execPhaseCommandSync(cmd, opts = {}) {
   }
 }
 
+function formatPhaseFailure(err) {
+  const parts = [err && err.message ? err.message : String(err || 'unknown error')];
+  const stdout = err && err.stdout ? String(err.stdout).trim() : '';
+  const stderr = err && err.stderr ? String(err.stderr).trim() : '';
+  if (stdout) parts.push(`stdout:\n${stdout}`);
+  if (stderr) parts.push(`stderr:\n${stderr}`);
+  return parts.join('\n\n');
+}
+
 /**
  * Build prompt for each phase with full context.
  * If priorCycleReview is provided (from the previous cycle's review phase),
@@ -248,9 +257,7 @@ function executePhase(phase, context, options = {}) {
     if (isPhaseKillError(err)) {
       throw new Error(`${phase} killed by ${err.signal || 'a signal'} before the ${timeout / 1000}s wall`);
     }
-    // execSync throws on non-zero exit but may still have output
-    if (err.stdout) return err.stdout;
-    throw err;
+    throw new Error(`${phase} failed: ${formatPhaseFailure(err)}`);
   }
 }
 
@@ -411,6 +418,7 @@ async function runAtris(options = {}) {
   const writtenRunLogs = [];
   let completedCycles = 0;
   let lastReviewOutput = null; // Carried to next cycle's plan — closes the loop
+  let failedCycleError = null;
 
   for (let cycle = 1; cycle <= cycles; cycle++) {
     if (verbose) {
@@ -527,6 +535,7 @@ async function runAtris(options = {}) {
         : `cycle ${cycle} done. next cycle.`);
 
     } catch (err) {
+      failedCycleError = err;
       console.error(`\n✗ Cycle ${cycle} failed: ${err.message}`);
       // Log the failure to the run log for forensic value
       try {
@@ -589,6 +598,10 @@ async function runAtris(options = {}) {
       }
     }
   } catch {}
+
+  if (failedCycleError) {
+    throw new Error(`run stopped after failed cycle: ${failedCycleError.message}`);
+  }
 }
 
 /**

--- a/test/run-glass-logs.test.js
+++ b/test/run-glass-logs.test.js
@@ -494,6 +494,19 @@ test('run.js execPhaseCommandSync handles non-zero exit codes', () => {
   assert.match(RUN_SRC, /err\.signal = result\.signal/);
 });
 
+test('run.js fails phases on non-zero exit even when stdout exists', () => {
+  assert.match(RUN_SRC, /function formatPhaseFailure\(err\)/);
+  assert.match(RUN_SRC, /stdout:\\n/);
+  assert.match(RUN_SRC, /throw new Error\(`\$\{phase\} failed: \$\{formatPhaseFailure\(err\)\}`\)/);
+  assert.doesNotMatch(RUN_SRC, /if \(err\.stdout\) return err\.stdout/);
+});
+
+test('run.js exits non-zero after a failed cycle is logged', () => {
+  assert.match(RUN_SRC, /let failedCycleError = null/);
+  assert.match(RUN_SRC, /failedCycleError = err/);
+  assert.match(RUN_SRC, /throw new Error\(`run stopped after failed cycle: \$\{failedCycleError\.message\}`\)/);
+});
+
 test('run.js execPhaseCommandSync handles spawn errors', () => {
   assert.match(RUN_SRC, /if \(result\.error\) throw result\.error/);
 });


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-executor-fail-autonomy-phases-on-non-zero-run-20260628-234741
Target: master