### PR TITLE
feat: show runner preflight in dry runs

### DIFF
--- a/commands/autopilot.js
+++ b/commands/autopilot.js
@@ -15,6 +15,8 @@ const { parseTodo } = require('../lib/todo');
 const {
   buildRunnerCommand,
   buildRunnerAvailabilityCommand,
+  describeRunnerSelection,
+  formatRunnerSelection,
   resolveClaudeRunnerBin,
 } = require('../lib/runner-command');
 const { findStalePages, findStaleTasks, healBrokenMapRefs } = require('./clean');
@@ -3022,9 +3024,14 @@ async function autopilotAtris(description, options = {}) {
     process.exit(1);
   }
 
-  try { execSync(buildRunnerAvailabilityCommand(), { stdio: 'pipe' }); } catch {
-    console.error(`${resolveClaudeRunnerBin()} CLI not found. Set ATRIS_RUNNER_BIN (or legacy ATRIS_CLAUDE_BIN), or install the configured runner first.`);
-    process.exit(1);
+  const runnerSelection = describeRunnerSelection();
+
+  if (!dryRun) {
+    try { execSync(buildRunnerAvailabilityCommand(), { stdio: 'pipe' }); } catch {
+      console.error(formatRunnerSelection(runnerSelection));
+      console.error(`${resolveClaudeRunnerBin()} CLI not found. Set ATRIS_RUNNER_BIN (or legacy ATRIS_CLAUDE_BIN), or install the configured runner first.`);
+      process.exit(1);
+    }
   }
 
   const durationMs = parseDuration(duration);
@@ -3042,6 +3049,12 @@ async function autopilotAtris(description, options = {}) {
     console.log('');
   } else {
     printTickStatus(cwd, { auto, durationLabel });
+  }
+  if (verbose) {
+    console.log(formatRunnerSelection(runnerSelection));
+    console.log('');
+  } else {
+    printPlainBlock(formatRunnerSelection(runnerSelection));
   }
 
   // Seed inbox if a description was given

--- a/commands/run.js
+++ b/commands/run.js
@@ -15,6 +15,8 @@ const { parseTodo } = require('../lib/todo');
 const {
   buildRunnerCommand,
   buildRunnerAvailabilityCommand,
+  describeRunnerSelection,
+  formatRunnerSelection,
   resolveClaudeRunnerBin,
 } = require('../lib/runner-command');
 const { cleanAtris } = require('./clean');
@@ -363,12 +365,18 @@ async function runAtris(options = {}) {
     process.exit(1);
   }
 
-  // Check configured runner CLI is available.
-  try {
-    execSync(buildRunnerAvailabilityCommand(), { stdio: 'pipe' });
-  } catch {
-    console.error(`${resolveClaudeRunnerBin()} CLI not found. Set ATRIS_RUNNER_BIN (or legacy ATRIS_CLAUDE_BIN), or install the configured runner first.`);
-    process.exit(1);
+  const runnerSelection = describeRunnerSelection();
+
+  // Check configured runner CLI is available before a live run. Dry-run is a
+  // preflight surface and must still work on machines without the runner.
+  if (!dryRun) {
+    try {
+      execSync(buildRunnerAvailabilityCommand(), { stdio: 'pipe' });
+    } catch {
+      console.error(formatRunnerSelection(runnerSelection));
+      console.error(`${resolveClaudeRunnerBin()} CLI not found. Set ATRIS_RUNNER_BIN (or legacy ATRIS_CLAUDE_BIN), or install the configured runner first.`);
+      process.exit(1);
+    }
   }
 
   console.log('');
@@ -388,6 +396,8 @@ async function runAtris(options = {}) {
     console.log(`phase reasoning will be saved to atris/logs/runs/ — you can read what i thought after.`);
     console.log('');
   }
+  console.log(formatRunnerSelection(runnerSelection));
+  console.log('');
 
   // Build context paths
   const context = {

--- a/lib/runner-command.js
+++ b/lib/runner-command.js
@@ -93,6 +93,88 @@ function resolveClaudeRunnerCommandTemplate() {
   return firstConfiguredEnv(['ATRIS_CLAUDE_COMMAND_TEMPLATE']);
 }
 
+function describeRunnerSelection({ model } = {}) {
+  const profileName = resolveRunnerProfileName();
+  const profile = profileName ? resolveRunnerProfile() : null;
+
+  const explicitModel = model != null ? String(model).trim() : '';
+  const runnerModel = firstConfiguredEnv(['ATRIS_RUNNER_MODEL']);
+  const legacyModel = firstConfiguredEnv(['ATRIS_CLAUDE_MODEL']);
+  let resolvedModel = DEFAULT_CLAUDE_RUNNER_MODEL;
+  let modelSource = 'default';
+  if (explicitModel) {
+    resolvedModel = explicitModel;
+    modelSource = 'explicit';
+  } else if (runnerModel) {
+    resolvedModel = runnerModel;
+    modelSource = 'ATRIS_RUNNER_MODEL';
+  } else if (profile && profile.model) {
+    resolvedModel = profile.model;
+    modelSource = `profile:${profileName}`;
+  } else if (legacyModel) {
+    resolvedModel = legacyModel;
+    modelSource = 'ATRIS_CLAUDE_MODEL';
+  }
+
+  const runnerBin = firstConfiguredEnv(['ATRIS_RUNNER_BIN']);
+  const legacyBin = firstConfiguredEnv(['ATRIS_CLAUDE_BIN']);
+  let resolvedBin = DEFAULT_CLAUDE_RUNNER_BIN;
+  let binSource = 'default';
+  if (runnerBin) {
+    resolvedBin = runnerBin;
+    binSource = 'ATRIS_RUNNER_BIN';
+  } else if (profile && profile.bin) {
+    resolvedBin = profile.bin;
+    binSource = `profile:${profileName}`;
+  } else if (legacyBin) {
+    resolvedBin = legacyBin;
+    binSource = 'ATRIS_CLAUDE_BIN';
+  }
+
+  const runnerTemplate = firstConfiguredEnv(['ATRIS_RUNNER_COMMAND_TEMPLATE']);
+  const legacyTemplate = firstConfiguredEnv(['ATRIS_CLAUDE_COMMAND_TEMPLATE']);
+  let commandTemplate = '';
+  let commandTemplateSource = 'default';
+  if (runnerTemplate) {
+    commandTemplate = runnerTemplate;
+    commandTemplateSource = 'ATRIS_RUNNER_COMMAND_TEMPLATE';
+  } else if (profile && profile.commandTemplate) {
+    commandTemplate = profile.commandTemplate;
+    commandTemplateSource = `profile:${profileName}`;
+  } else if (legacyTemplate) {
+    commandTemplate = legacyTemplate;
+    commandTemplateSource = 'ATRIS_CLAUDE_COMMAND_TEMPLATE';
+  }
+
+  return {
+    profile: profileName || null,
+    profileKnown: Boolean(profile),
+    bin: resolvedBin,
+    binSource,
+    model: resolvedModel,
+    modelSource,
+    commandTemplate,
+    commandTemplateSource,
+    commandTemplateActive: Boolean(commandTemplate),
+    availabilityCommand: `command -v ${shellWord(resolvedBin)}`,
+  };
+}
+
+function formatRunnerSelection(selection = describeRunnerSelection()) {
+  const profile = selection.profile || 'none';
+  const template = selection.commandTemplateActive
+    ? `${selection.commandTemplateSource}: ${selection.commandTemplate}`
+    : 'default prompt command';
+  return [
+    'Runner preflight:',
+    `  profile: ${profile}`,
+    `  binary: ${selection.bin} (${selection.binSource})`,
+    `  model: ${selection.model} (${selection.modelSource})`,
+    `  template: ${template}`,
+    `  availability: ${selection.availabilityCommand}`,
+  ].join('\n');
+}
+
 function buildRunnerAvailabilityCommand() {
   return `command -v ${shellWord(resolveClaudeRunnerBin())}`;
 }
@@ -151,6 +233,8 @@ module.exports = {
   resolveClaudeRunnerModel,
   resolveClaudeRunnerBin,
   resolveClaudeRunnerCommandTemplate,
+  describeRunnerSelection,
+  formatRunnerSelection,
   buildRunnerAvailabilityCommand,
   buildRunnerCommand,
 };

--- a/test/autopilot-runner-model.test.js
+++ b/test/autopilot-runner-model.test.js
@@ -3,10 +3,14 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const { buildRunnerCommand } = require('../lib/runner-command');
+const { scrubAgentEnv } = require('./helpers/agent-env');
 
+const CLI_PATH = path.join(__dirname, '..', 'bin', 'atris.js');
 const AUTOPILOT_SRC = fs.readFileSync(path.join(__dirname, '..', 'commands', 'autopilot.js'), 'utf8');
 const RUN_SRC = fs.readFileSync(path.join(__dirname, '..', 'commands', 'run.js'), 'utf8');
 const MISSION_SRC = fs.readFileSync(path.join(__dirname, '..', 'commands', 'mission.js'), 'utf8');
@@ -40,6 +44,31 @@ function withRunnerEnv(values, fn) {
   }
 }
 
+function makeAtrisWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-runner-preflight-'));
+  const atrisDir = path.join(dir, 'atris');
+  fs.mkdirSync(atrisDir, { recursive: true });
+  fs.writeFileSync(path.join(atrisDir, 'TODO.md'), '# TODO\n\n## Backlog\n\n## In Progress\n\n## Completed\n');
+  fs.writeFileSync(path.join(atrisDir, 'MAP.md'), '# MAP\n');
+  fs.writeFileSync(path.join(atrisDir, 'PERSONA.md'), 'Test operator.\n');
+  return dir;
+}
+
+function runCli(args, { cwd, env = {} } = {}) {
+  const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 15000,
+    env: {
+      ...scrubAgentEnv(),
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ...env,
+    },
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
 // --- T2/T3 wiring: the heartbeat paths route through the shared builder ---
 // (no raw `claude -p "$(cat ...)"` literal may survive, or the spawn would bypass
 // model resolution and inherit the CLI's mutable selection — retired-model-kills-loop-silently)
@@ -62,6 +91,58 @@ test('runner availability checks use the shared configured binary', () => {
   assert.doesNotMatch(RUN_SRC, /which claude/);
   assert.match(AUTOPILOT_SRC, /buildRunnerAvailabilityCommand\(/);
   assert.match(RUN_SRC, /buildRunnerAvailabilityCommand\(/);
+});
+
+test('run and autopilot print runner preflight before dry-run work', () => {
+  assert.match(AUTOPILOT_SRC, /describeRunnerSelection\(/);
+  assert.match(AUTOPILOT_SRC, /formatRunnerSelection\(runnerSelection\)/);
+  assert.match(RUN_SRC, /describeRunnerSelection\(/);
+  assert.match(RUN_SRC, /formatRunnerSelection\(runnerSelection\)/);
+});
+
+test('run --dry-run prints runner selection without requiring the runner binary', () => {
+  const cwd = makeAtrisWorkspace();
+  try {
+    const result = runCli(['run', '--dry-run', '--cycles=1'], {
+      cwd,
+      env: {
+        ATRIS_RUNNER_BIN: '/definitely/missing/runner',
+        ATRIS_RUNNER_MODEL: 'glm-5.2',
+        ATRIS_RUNNER_COMMAND_TEMPLATE: '{bin} --model {model} --prompt-file {promptFile}',
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Runner preflight:/);
+    assert.match(result.stdout, /binary: \/definitely\/missing\/runner \(ATRIS_RUNNER_BIN\)/);
+    assert.match(result.stdout, /model: glm-5\.2 \(ATRIS_RUNNER_MODEL\)/);
+    assert.match(result.stdout, /template: ATRIS_RUNNER_COMMAND_TEMPLATE: \{bin\} --model \{model\} --prompt-file \{promptFile\}/);
+    assert.match(result.stdout, /availability: command -v \/definitely\/missing\/runner/);
+    assert.match(result.stdout, /\[DRY RUN\] Would execute:/);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('autopilot --dry-run prints profile preflight without requiring the runner binary', () => {
+  const cwd = makeAtrisWorkspace();
+  try {
+    const result = runCli(['autopilot', '--dry-run', '--auto', '--iterations=1'], {
+      cwd,
+      env: {
+        ATRIS_RUNNER_PROFILE: 'atris-fast',
+        ATRIS_RUNNER_BIN: '/definitely/missing/runner',
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Runner preflight:/);
+    assert.match(result.stdout, /profile: atris-fast/);
+    assert.match(result.stdout, /binary: \/definitely\/missing\/runner \(ATRIS_RUNNER_BIN\)/);
+    assert.match(result.stdout, /model: atris:fast \(profile:atris-fast\)/);
+    assert.match(result.stdout, /template: profile:atris-fast: \{bin\} --fast \{prompt\}/);
+    assert.match(result.stdout, /availability: command -v \/definitely\/missing\/runner/);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test('runtime runner wording is config-neutral', () => {

--- a/test/runner-command.test.js
+++ b/test/runner-command.test.js
@@ -11,6 +11,8 @@ const {
   resolveClaudeRunnerModel,
   resolveClaudeRunnerBin,
   resolveClaudeRunnerCommandTemplate,
+  describeRunnerSelection,
+  formatRunnerSelection,
   buildRunnerAvailabilityCommand,
   buildRunnerCommand,
 } = require('../lib/runner-command');
@@ -157,7 +159,56 @@ test('generic runner env overrides the Atris Fast profile', () => {
 test('unknown runner profile throws a clear config error', () => {
   withRunnerEnv({ ATRIS_RUNNER_PROFILE: 'atris-9' }, () => {
     assert.throws(() => resolveRunnerProfile(), /Unknown ATRIS_RUNNER_PROFILE "atris-9"/);
+    assert.throws(() => describeRunnerSelection(), /Unknown ATRIS_RUNNER_PROFILE "atris-9"/);
     assert.throws(() => buildRunnerCommand({ promptFile: '/tmp/p.tmp' }), /Unknown ATRIS_RUNNER_PROFILE "atris-9"/);
+  });
+});
+
+test('describeRunnerSelection exposes the effective default runner preflight', () => {
+  withRunnerEnv({}, () => {
+    assert.deepEqual(describeRunnerSelection(), {
+      profile: null,
+      profileKnown: false,
+      bin: 'claude',
+      binSource: 'default',
+      model: 'opus',
+      modelSource: 'default',
+      commandTemplate: '',
+      commandTemplateSource: 'default',
+      commandTemplateActive: false,
+      availabilityCommand: 'command -v claude',
+    });
+  });
+});
+
+test('describeRunnerSelection shows profile values and generic env overrides', () => {
+  withRunnerEnv({
+    ATRIS_RUNNER_PROFILE: 'atris-fast',
+    ATRIS_RUNNER_BIN: '/opt/glm/runner',
+    ATRIS_RUNNER_MODEL: 'glm-5.2',
+    ATRIS_RUNNER_COMMAND_TEMPLATE: '{bin} --model {model} --prompt-file {promptFile}',
+  }, () => {
+    const selection = describeRunnerSelection();
+    assert.equal(selection.profile, 'atris-fast');
+    assert.equal(selection.bin, '/opt/glm/runner');
+    assert.equal(selection.binSource, 'ATRIS_RUNNER_BIN');
+    assert.equal(selection.model, 'glm-5.2');
+    assert.equal(selection.modelSource, 'ATRIS_RUNNER_MODEL');
+    assert.equal(selection.commandTemplate, '{bin} --model {model} --prompt-file {promptFile}');
+    assert.equal(selection.commandTemplateSource, 'ATRIS_RUNNER_COMMAND_TEMPLATE');
+    assert.equal(selection.availabilityCommand, 'command -v /opt/glm/runner');
+  });
+});
+
+test('formatRunnerSelection gives dry-runs a readable preflight receipt', () => {
+  withRunnerEnv({ ATRIS_RUNNER_PROFILE: 'atris-fast' }, () => {
+    const text = formatRunnerSelection(describeRunnerSelection());
+    assert.match(text, /Runner preflight:/);
+    assert.match(text, /profile: atris-fast/);
+    assert.match(text, /binary: ax \(profile:atris-fast\)/);
+    assert.match(text, /model: atris:fast \(profile:atris-fast\)/);
+    assert.match(text, /template: profile:atris-fast: \{bin\} --fast \{prompt\}/);
+    assert.match(text, /availability: command -v ax/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a shared runner preflight descriptor for profile, binary, model, command template, and availability command
- print that preflight from `atris run --dry-run` and `atris autopilot --dry-run` before any work selection
- let dry-run report runner config even when the runner binary is not installed, while live runs still enforce availability

## Verification
- `node --check lib/runner-command.js`
- `node --check commands/run.js`
- `node --check commands/autopilot.js`
- `git diff --check`
- `node --test test/runner-command.test.js test/autopilot-runner-model.test.js` (47/47 passing)
- manual temp-workspace dry-runs with `/definitely/missing/runner` showed runner preflight for both run and autopilot
- `npm test` (1432/1432 passing)