### PR TITLE
fix: use unique runner prompt temp files

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -88,6 +88,7 @@ rg "wikiCommand|printWikiHelp|wiki help paths" commands/wiki.js test/commands.te
 # Utilities
 rg "ensureValidCredentials" utils/auth.js   # Auth flow
 rg "apiRequestJson" utils/api.js            # API requests
+rg "writePromptTempFile|safePrefix" lib/prompt-temp.js test/prompt-temp.test.js # Unique runner prompt temp files with cleanup for concurrent loops
 rg "checkForUpdates|autoUpdate|shouldAutoUpdate|helpRequested|help invocations skip" bin/atris.js utils/update-check.js test/update-check-install-state.test.js test/commands.test.js  # Version checks, packaged auto-update, and help-side-effect skip
 
 # Documentation

--- a/commands/autopilot.js
+++ b/commands/autopilot.js
@@ -12,6 +12,7 @@ const { execSync, execFileSync, spawnSync } = require('child_process');
 const readline = require('readline');
 const { getLogPath, ensureLogDirectory, createLogFile } = require('../lib/journal');
 const { parseTodo } = require('../lib/todo');
+const { writePromptTempFile } = require('../lib/prompt-temp');
 const {
   buildRunnerCommand,
   buildRunnerAvailabilityCommand,
@@ -450,12 +451,11 @@ function executePhaseDetailed(phase, context, options = {}) {
   const { verbose = false, timeout = PHASE_TIMEOUT } = options;
 
   const prompt = buildPrompt(phase, context, options);
-  const tmpFile = path.join(process.cwd(), '.autopilot-prompt.tmp');
-  fs.writeFileSync(tmpFile, prompt);
+  const promptTemp = writePromptTempFile('autopilot-prompt', prompt);
 
   try {
     const cmd = options.cmdOverride
-      || buildRunnerCommand({ promptFile: tmpFile, allowedTools: 'Bash,Read,Write,Edit,Glob,Grep' });
+      || buildRunnerCommand({ promptFile: promptTemp.filePath, allowedTools: 'Bash,Read,Write,Edit,Glob,Grep' });
     const env = { ...process.env };
     delete env.CLAUDECODE;
     const output = execPhaseCommandSync(cmd, {
@@ -467,10 +467,8 @@ function executePhaseDetailed(phase, context, options = {}) {
       env
     });
 
-    try { fs.unlinkSync(tmpFile); } catch {}
     return { prompt, output: output || '' };
   } catch (err) {
-    try { fs.unlinkSync(tmpFile); } catch {}
     if (isPhaseTimeoutError(err)) {
       throw new Error(`${phase} phase timed out after ${timeout / 1000}s (configured runner hit the wall; any work it committed survives — reconcile from pre-tick HEADs)`);
     }
@@ -481,6 +479,8 @@ function executePhaseDetailed(phase, context, options = {}) {
       return { prompt, output: err.stdout };
     }
     throw err;
+  } finally {
+    promptTemp.cleanup();
   }
 }
 
@@ -1201,10 +1201,9 @@ function parseProposedBlock(lines) {
  * Kept thin so tests can inject a stub via options.planReviewExec.
  */
 function defaultPlanReviewExecutor(prompt, { cwd, timeout = 180000 } = {}) {
-  const tmpFile = path.join(cwd, '.autopilot-plan-review.tmp');
-  fs.writeFileSync(tmpFile, prompt);
+  const promptTemp = writePromptTempFile('autopilot-plan-review', prompt);
   try {
-    const cmd = buildRunnerCommand({ promptFile: tmpFile, allowedTools: 'Bash,Read,Grep,Glob' });
+    const cmd = buildRunnerCommand({ promptFile: promptTemp.filePath, allowedTools: 'Bash,Read,Grep,Glob' });
     const env = { ...process.env };
     delete env.CLAUDECODE;
     const output = execPhaseCommandSync(cmd, {
@@ -1220,7 +1219,7 @@ function defaultPlanReviewExecutor(prompt, { cwd, timeout = 180000 } = {}) {
     if (err.stdout) return err.stdout;
     throw err;
   } finally {
-    try { fs.unlinkSync(tmpFile); } catch {}
+    promptTemp.cleanup();
   }
 }
 
@@ -2896,12 +2895,11 @@ Output STRICT JSON ONLY — no prose, no markdown code fences, no commentary. Th
 
 Reply with the JSON array and nothing else.`;
 
-  const tmpFile = path.join(cwd, '.autopilot-horizons-prompt.tmp');
-  fs.writeFileSync(tmpFile, prompt);
+  const promptTemp = writePromptTempFile('autopilot-horizons-prompt', prompt);
 
   let output = '';
   try {
-    const cmd = buildRunnerCommand({ promptFile: tmpFile });
+    const cmd = buildRunnerCommand({ promptFile: promptTemp.filePath });
     const env = { ...process.env };
     delete env.CLAUDECODE;
     output = execPhaseCommandSync(cmd, {
@@ -2921,7 +2919,7 @@ Reply with the JSON array and nothing else.`;
     }
     throw err;
   } finally {
-    try { fs.unlinkSync(tmpFile); } catch {}
+    promptTemp.cleanup();
   }
 
   const start = output.indexOf('[');
@@ -3585,13 +3583,12 @@ Task: "${title}"${sourceHint}
 
 Search the codebase to verify. Reply: YES <reason> or NO <reason>`;
 
-  const tmpFile = path.join(cwd, '.staleness-prompt.tmp');
-  fs.writeFileSync(tmpFile, prompt);
+  const promptTemp = writePromptTempFile('staleness-prompt', prompt);
 
   try {
     const env = { ...process.env };
     delete env.CLAUDECODE;
-    const cmd = buildRunnerCommand({ promptFile: tmpFile, allowedTools: 'Bash,Read,Glob,Grep' });
+    const cmd = buildRunnerCommand({ promptFile: promptTemp.filePath, allowedTools: 'Bash,Read,Glob,Grep' });
     const output = execPhaseCommandSync(cmd, {
       cwd,
       encoding: 'utf8',
@@ -3601,8 +3598,6 @@ Search the codebase to verify. Reply: YES <reason> or NO <reason>`;
       env
     }).trim();
 
-    try { fs.unlinkSync(tmpFile); } catch {}
-
     // Parse YES/NO from the first line of output
     const firstLine = output.split('\n').find(l => /^\s*(YES|NO)\b/i.test(l)) || output.split('\n')[0] || '';
     const fresh = /^\s*YES\b/i.test(firstLine);
@@ -3610,9 +3605,10 @@ Search the codebase to verify. Reply: YES <reason> or NO <reason>`;
 
     return { fresh, reasoning };
   } catch (err) {
-    try { fs.unlinkSync(tmpFile); } catch {}
     // On timeout or crash, treat as unverifiable — conservative default
     return { fresh: false, reasoning: `Model check failed: ${(err.message || '').slice(0, 100)}` };
+  } finally {
+    promptTemp.cleanup();
   }
 }
 

--- a/commands/run.js
+++ b/commands/run.js
@@ -12,6 +12,7 @@ const path = require('path');
 const { execSync, spawnSync } = require('child_process');
 const { getLogPath, ensureLogDirectory, createLogFile } = require('../lib/journal');
 const { parseTodo } = require('../lib/todo');
+const { writePromptTempFile } = require('../lib/prompt-temp');
 const {
   buildRunnerCommand,
   buildRunnerAvailabilityCommand,
@@ -219,11 +220,10 @@ function executePhase(phase, context, options = {}) {
   const { verbose = false, timeout = PHASE_TIMEOUT, priorCycleReview } = options;
 
   const prompt = buildRunPrompt(phase, context, priorCycleReview);
-  const tmpFile = path.join(process.cwd(), '.run-prompt.tmp');
-  fs.writeFileSync(tmpFile, prompt);
+  const promptTemp = writePromptTempFile('run-prompt', prompt);
 
   try {
-    const cmd = buildRunnerCommand({ promptFile: tmpFile, allowedTools: 'Bash,Read,Write,Edit,Glob,Grep' });
+    const cmd = buildRunnerCommand({ promptFile: promptTemp.filePath, allowedTools: 'Bash,Read,Write,Edit,Glob,Grep' });
     // Strip CLAUDECODE env var to allow spawning from within a Claude Code session
     const env = { ...process.env };
     delete env.CLAUDECODE;
@@ -238,10 +238,8 @@ function executePhase(phase, context, options = {}) {
       env
     });
 
-    try { fs.unlinkSync(tmpFile); } catch {}
     return output || '';
   } catch (err) {
-    try { fs.unlinkSync(tmpFile); } catch {}
     if (isPhaseTimeoutError(err)) {
       throw new Error(`${phase} timed out after ${timeout / 1000}s`);
     }
@@ -251,6 +249,8 @@ function executePhase(phase, context, options = {}) {
     // execSync throws on non-zero exit but may still have output
     if (err.stdout) return err.stdout;
     throw err;
+  } finally {
+    promptTemp.cleanup();
   }
 }
 

--- a/lib/prompt-temp.js
+++ b/lib/prompt-temp.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function safePrefix(prefix) {
+  const cleaned = String(prefix || 'prompt').replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned || 'prompt';
+}
+
+function writePromptTempFile(prefix, prompt) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `atris-${safePrefix(prefix)}-`));
+  const filePath = path.join(dir, 'prompt.md');
+  fs.writeFileSync(filePath, String(prompt || ''), 'utf8');
+  return {
+    filePath,
+    cleanup() {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {}
+    },
+  };
+}
+
+module.exports = {
+  safePrefix,
+  writePromptTempFile,
+};

--- a/test/autopilot-runner-model.test.js
+++ b/test/autopilot-runner-model.test.js
@@ -57,6 +57,25 @@ test('autopilot.js and run.js build their spawn command via buildRunnerCommand',
   assert.match(RUN_SRC, /require\('\.\.\/lib\/runner-command'\)/);
 });
 
+test('runner prompt files use unique temp files instead of checkout-fixed paths', () => {
+  const fixedPromptPaths = [
+    '.run-prompt.tmp',
+    '.autopilot-prompt.tmp',
+    '.autopilot-plan-review.tmp',
+    '.autopilot-horizons-prompt.tmp',
+    '.staleness-prompt.tmp',
+  ];
+  for (const fixedPath of fixedPromptPaths) {
+    assert.doesNotMatch(RUN_SRC, new RegExp(fixedPath.replace(/\./g, '\\.')));
+    assert.doesNotMatch(AUTOPILOT_SRC, new RegExp(fixedPath.replace(/\./g, '\\.')));
+  }
+  assert.match(RUN_SRC, /writePromptTempFile\('run-prompt'/);
+  assert.match(AUTOPILOT_SRC, /writePromptTempFile\('autopilot-prompt'/);
+  assert.match(AUTOPILOT_SRC, /writePromptTempFile\('autopilot-plan-review'/);
+  assert.match(AUTOPILOT_SRC, /writePromptTempFile\('autopilot-horizons-prompt'/);
+  assert.match(AUTOPILOT_SRC, /writePromptTempFile\('staleness-prompt'/);
+});
+
 test('runner availability checks use the shared configured binary', () => {
   assert.doesNotMatch(AUTOPILOT_SRC, /which claude/);
   assert.doesNotMatch(RUN_SRC, /which claude/);

--- a/test/prompt-temp.test.js
+++ b/test/prompt-temp.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+
+const { safePrefix, writePromptTempFile } = require('../lib/prompt-temp');
+
+test('writePromptTempFile creates unique prompt files with the prompt content', () => {
+  const first = writePromptTempFile('run prompt', 'first prompt');
+  const second = writePromptTempFile('run prompt', 'second prompt');
+  try {
+    assert.notEqual(first.filePath, second.filePath);
+    assert.equal(fs.readFileSync(first.filePath, 'utf8'), 'first prompt');
+    assert.equal(fs.readFileSync(second.filePath, 'utf8'), 'second prompt');
+  } finally {
+    first.cleanup();
+    second.cleanup();
+  }
+});
+
+test('writePromptTempFile cleanup removes the temp file directory', () => {
+  const promptTemp = writePromptTempFile('staleness-prompt', 'check freshness');
+  const filePath = promptTemp.filePath;
+  assert.equal(fs.existsSync(filePath), true);
+  promptTemp.cleanup();
+  assert.equal(fs.existsSync(filePath), false);
+});
+
+test('safePrefix keeps temp prefixes shell-neutral', () => {
+  assert.equal(safePrefix('../bad prompt!!'), 'bad-prompt');
+  assert.equal(safePrefix(''), 'prompt');
+});


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-executor-make-runner-prompt-temp-files-unique-20260629-024932
Target: master