### PR TITLE
fix: use unique compile prompt temp files

### DIFF
--- a/commands/compile.js
+++ b/commands/compile.js
@@ -23,6 +23,7 @@ const {
   buildRunnerCommand,
   resolveClaudeRunnerBin,
 } = require('../lib/runner-command');
+const { writePromptTempFile } = require('../lib/prompt-temp');
 
 const DEFAULT_THRESHOLD = 0.99;
 const SAMPLE_RECORDS_FOR_BUILD = 25;
@@ -288,11 +289,10 @@ function executeBuild(root, name, options = {}) {
 
   fs.mkdirSync(processDir(root, name), { recursive: true });
   const prompt = buildCompilePrompt(root, name, records, notes);
-  const tmpFile = path.join(root, '.compile-prompt.tmp');
-  fs.writeFileSync(tmpFile, prompt);
+  const promptTemp = writePromptTempFile('compile-prompt', prompt);
 
   try {
-    const cmd = cmdOverride || buildRunnerCommand({ promptFile: tmpFile, allowedTools: 'Read,Write,Edit,Glob,Grep' });
+    const cmd = cmdOverride || buildRunnerCommand({ promptFile: promptTemp.filePath, allowedTools: 'Read,Write,Edit,Glob,Grep' });
     const env = { ...process.env };
     delete env.CLAUDECODE;
     execSync(cmd, {
@@ -304,7 +304,7 @@ function executeBuild(root, name, options = {}) {
       env,
     });
   } finally {
-    try { fs.unlinkSync(tmpFile); } catch {}
+    promptTemp.cleanup();
   }
 
   if (!fs.existsSync(runnerPath(root, name))) {

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -81,6 +81,11 @@ test('compile build uses the shared runner command instead of raw claude', () =>
   assert.match(COMPILE_SRC, /buildRunnerCommand\(/);
 });
 
+test('compile build prompt uses unique temp files instead of a checkout-fixed path', () => {
+  assert.doesNotMatch(COMPILE_SRC, /\.compile-prompt\.tmp/);
+  assert.match(COMPILE_SRC, /writePromptTempFile\('compile-prompt'/);
+});
+
 test('records: append + read round-trip with timestamps', () => {
   const root = makeRoot();
   appendRecord(root, 'demo', { input: { n: 1 }, output: { doubled: 2 } });


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-executor-make-compile-runner-prompt-temp-file-20260629-025852
Target: codex/codex-executor-make-runner-prompt-temp-files-unique-20260629-024932