### PR TITLE
fix: make runner resolver api generic

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -824,7 +824,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 - **Routing:** `bin/atris.js` (`command === 'pulse'` dispatch) + `knownCommands` array + `showHelp`
 - **Tests:** `test/pulse.test.js` (29 tests — scoring, ghost detection, lock, cron-script generation)
 - **Cron template lineage:** modeled on the proven `~/.atris/overnight/commander-obelisk-swarlo/tick.sh` (deadline self-removal + lock + run + proof), but all real logic lives in JS (`atris pulse tick`), not duplicated shell
-- **Flags:** `pulse install [--cadence "11,40 * * * *"] [--days 7] [--verify "npm test"] [--model opus|glm-5.2] [--runner-profile atris-fast] [--runner-bin /path/to/runner] [--runner-template "{bin} ..."]` exports `ATRIS_RUNNER_*`, `ATRIS_RUNNER_PROFILE`, and legacy aliases into cron; `pulse tick [--no-claude] [--no-verify] [--verify "<cmd>"]`; `pulse run [--max-ticks N]`
+- **Flags:** `pulse install [--cadence "11,40 * * * *"] [--days 7] [--verify "npm test"] [--model opus|glm-5.2] [--runner-profile atris-fast] [--runner-bin /path/to/runner] [--runner-template "{bin} ..."]` exports `ATRIS_RUNNER_*`, `ATRIS_RUNNER_PROFILE`, and legacy aliases into cron; `pulse tick [--no-runner] [--no-claude] [--no-verify] [--verify "<cmd>"]`; `pulse run [--max-ticks N]`
 - **Value:** Closes the open self-improvement loop — durable ignition (was: `/loop` dies with the session), real executor (was: auto-improver stuck dry-run), reward feedback (was: scorecards flatlined). Does NOT auto-push; work lands in review behind the human gate.
 
 **Search:** `rg "pulseCommand" commands/pulse.js` · `rg "buildTickScript" lib/pulse.js`

--- a/ax
+++ b/ax
@@ -16,7 +16,7 @@ const BACKEND = {
   port: 8000,
   path: '/api/atris2/turn'
 };
-const DEFAULT_BACKEND_BASE = `http://${BACKEND.host}:${BACKEND.port}`;
+const DEFAULT_BACKEND_BASE = 'https://api.atris.ai';
 const CODE_FAST = {
   path: '/api/cursor/turn',
   model: 'composer-2-5-fast',
@@ -113,8 +113,8 @@ function formatUsage() {
     'ax - Atris local/code agent',
     '',
     'Usage:',
-    '  ax [--max|--pro|--fast|--code-fast] [--local|--cloud] <message>',
-    '  ax [--max|--pro|--fast|--code-fast] [--local|--cloud] --chat',
+    '  ax [--fast|--pro|--max|--code-fast] [--local|--cloud] [--bypass|--safe] <message>',
+    '  ax [--fast|--pro|--max|--code-fast] [--local|--cloud] [--bypass|--safe] --chat',
     '  ax [--max|--pro|--fast] --business <slug> [<message>|--chat]',
     '  ax [--max|--pro|--fast|--code-fast] --doctor',
     '  ax --approvals',
@@ -124,12 +124,14 @@ function formatUsage() {
     '  ax [--max|--fast] --benchmark',
     '',
     'Modes:',
-    '  --max   local workspace agent, highest reasoning, slowest turns',
+    '  --max   hosted Atris 2, highest reasoning',
     '  --pro   local workspace agent, deeper tool loop',
     '  --fast  local workspace agent, faster low-latency turns',
     '  --code-fast  Atris Code Fast public lane',
     '  --local force local workspace tools',
     '  --cloud force authenticated cloud connectors/chat',
+    '  --safe  keep write actions behind approval rails (default)',
+    '  --bypass  reserved for trusted internal runs',
     '  --business <slug>  run tools on that business cloud workspace (EC2)',
     '  --verify <cmd>  gate the turn on this command passing (default: no verifier)',
     '',
@@ -266,8 +268,10 @@ function buildRunProfile(options = {}) {
       reasoning: 'Composer 2.5 fast lane; charges 10 credits per public turn'
     };
   }
-  const route = resolveRoute(options.message || 'doctor', options);
-  const payload = buildPayload(options.message || 'doctor', { mode, cwd, route });
+  const defaultMessage = mode === 'max' ? 'refactor this module and verify the tests' : 'doctor';
+  const message = options.message || defaultMessage;
+  const route = resolveRoute(message, options);
+  const payload = buildPayload(message, { mode, cwd, route });
   return {
     endpoint: backendUrl(),
     mode,
@@ -275,13 +279,15 @@ function buildRunProfile(options = {}) {
     model: payload.model,
     workspace_path: payload.workspace_path || 'cloud',
     max_turns: payload.max_turns,
+    member_slug: 'ax',
+    bypass_permissions: false,
     streaming: true,
     runtime: route === 'cloud' ? 'authenticated cloud connectors/chat' : 'local workspace',
     reasoning: mode === 'max'
-      ? 'backend reports run row; Max workspace tool loop uses high reasoning effort'
+      ? 'Atris cloud service; Max workspace tool loop uses high reasoning effort'
       : mode === 'pro'
-        ? 'backend reports run row; Pro workspace tool loop uses API default medium'
-        : 'backend reports run row; Fast workspace tool loop uses provider default'
+        ? 'Atris cloud service; Pro workspace tool loop uses API default medium'
+        : 'Atris cloud service; Fast workspace tool loop uses provider default'
   };
 }
 
@@ -595,7 +601,7 @@ function connectorWriteIntent(message) {
 }
 
 function workspaceIntent(message) {
-  return /\b(files?|folders?|repo|workspace|project|directory|tree|read|open|inspect|search|grep|find|locate|where|edit|write|change|modify|patch|fix|test|tests?|build|src|source|code|diff|git|backend|frontend|atris task|atris xp|xp game|career xp|agentxp|todo|map)\b/i.test(message || '');
+  return /\b(files?|folders?|repo|workspace|project|directory|tree|read|open|inspect|search|grep|find|locate|where|patch|fix|test|tests?|build|src|source|code|diff|git|backend|frontend|refactor|module|atris task|atris xp|xp game|career xp|agentxp|todo|map)\b/i.test(message || '');
 }
 
 function githubWorkspaceIntent(message) {
@@ -609,7 +615,8 @@ function resolveRoute(message, options = {}) {
   if (options.route === 'cloud' || options.forceCloud) return 'cloud';
   if (githubWorkspaceIntent(message)) return 'local';
   if (mentionsConnector(message) && !workspaceIntent(message)) return 'cloud';
-  return 'local';
+  if (workspaceIntent(message)) return 'local';
+  return 'cloud';
 }
 
 function normalizeMode(mode) {
@@ -663,7 +670,7 @@ function chatCompleter(line) {
 function formatWorkingLine(ms, verb, frame) {
   const totalSeconds = Math.max(1, Math.round((Number(ms) || 0) / 1000));
   if (verb) return `${frame || '•'} ${verb}… (${formatSeconds(totalSeconds)} · ctrl-c to interrupt)`;
-  return `• Working (${formatSeconds(totalSeconds)} • ctrl-c to interrupt)`;
+  return `• Thinking… (${formatSeconds(totalSeconds)} · ctrl-c to interrupt)`;
 }
 
 function verbForTool(tool) {
@@ -1539,7 +1546,14 @@ function messageCancelsPendingApproval(message) {
 }
 
 function buildMessage(message, history = []) {
-  return String(message || '').trim();
+  const current = String(message || '').trim();
+  if (!Array.isArray(history) || history.length === 0 || mentionsConnector(current)) return current;
+  const recent = history
+    .map((entry) => `${entry.role || 'user'}: ${entry.content || ''}`.trim())
+    .filter(Boolean)
+    .join('\n');
+  if (!recent) return current;
+  return `Recent conversation:\n${recent}\n\nCurrent user message:\n${current}`;
 }
 
 function buildPayload(message, options = {}) {
@@ -1551,7 +1565,7 @@ function buildPayload(message, options = {}) {
   const payload = {
     message: buildMessage(message, options.history || []),
     model: modelForMode(mode),
-    max_turns: local ? (mode === 'fast' ? 8 : 14) : 1,
+    max_turns: options.goalEval ? 1 : (local ? (mode === 'fast' ? 8 : 14) : 1),
     verify_command: verifyCommand || 'true'
   };
   if (previousMessages.length) {

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -738,18 +738,12 @@ function showServeHelp() {
 }
 
 function showLoopHelp() {
-  console.log('');
-  console.log('Usage: atris loop [--dry-run] [--json] [--limit=N]');
-  console.log('');
-  console.log('Description:');
-  console.log('  Inspect wiki upkeep state and optionally refresh wiki status/log files.');
-  console.log('');
+  console.log('Usage: atris loop [add|start|status|report|stop|wiki]');
+  console.log(require('../commands/loop-front').renderLoopHome().trimEnd());
   console.log('Options:');
-  console.log('  --dry-run    Preview wiki loop state without writing files.');
-  console.log('  --json       Print the loop report as JSON.');
-  console.log('  --limit=N    Limit suggested source count.');
+  console.log('  --dry-run    Preview delegated loop work when supported.');
+  console.log('  --json       Print machine-readable status or report output.');
   console.log('  --help, -h   Show this help.');
-  console.log('');
 }
 
 function showCleanHelp() {
@@ -2038,8 +2032,8 @@ if (command === 'init') {
     showLoopHelp();
     process.exit(0);
   }
-  require('../commands/loop').loopAtris(args)
-    .then(() => process.exit(0))
+  require('../commands/loop-front').loopFront(args)
+    .then((code) => process.exit(Number.isInteger(code) ? code : 0))
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'clean-workspace' || command === 'cw') {
   const { cleanWorkspace } = require('../commands/workspace-clean');
@@ -2318,13 +2312,12 @@ async function agentAtris() {
   // Respect -h / --help / help before any auth/state work
   const firstArg = process.argv[3];
   if (firstArg === '-h' || firstArg === '--help' || firstArg === 'help') {
-    console.log('Usage: atris agent [doctor|dogfood|spawn|spawns|spawn-status]');
+    console.log('Usage: atris agent [doctor|spawn|spawns|spawn-status]');
     console.log('');
     console.log('  Pick which cloud agent to chat with from this workspace.');
     console.log('  Run `atris agent spawn <role> --task "..."` to create a worker request.');
     console.log('  Run `atris agent spawns` to list worker requests.');
     console.log('  Run `atris agent doctor` to verify local AI CLIs can see Atris context.');
-    console.log('  Run `atris agent dogfood --live` to smoke-test Devin/Droid with GLM 5.2.');
     console.log('  Requires `atris login` first.');
     console.log('');
     console.log('  After selecting, use: atris chat ["message"]');
@@ -2335,6 +2328,10 @@ async function agentAtris() {
     agentDoctor();
   }
   if (firstArg === 'dogfood') {
+    if (process.env.ATRIS_INTERNAL_AGENT_DOGFOOD !== '1') {
+      console.error('agent dogfood is an internal diagnostic. Use atris agent doctor for public readiness checks.');
+      process.exit(1);
+    }
     const result = require('../commands/agent-spawn').agentDogfoodCommand(process.argv.slice(4));
     process.exit(result.ok ? 0 : 1);
   }

--- a/commands/compile.js
+++ b/commands/compile.js
@@ -21,7 +21,7 @@ const { execSync } = require('child_process');
 const {
   buildRunnerAvailabilityCommand,
   buildRunnerCommand,
-  resolveClaudeRunnerBin,
+  resolveRunnerBin,
 } = require('../lib/runner-command');
 
 const DEFAULT_THRESHOLD = 0.99;
@@ -282,7 +282,7 @@ function executeBuild(root, name, options = {}) {
     try {
       execSync(buildRunnerAvailabilityCommand(), { stdio: 'pipe' });
     } catch {
-      throw new Error(`${resolveClaudeRunnerBin()} CLI not found. Set ATRIS_RUNNER_BIN (or legacy ATRIS_CLAUDE_BIN), or install the configured runner first.`);
+      throw new Error(`${resolveRunnerBin()} CLI not found. Set ATRIS_RUNNER_BIN (or legacy ATRIS_CLAUDE_BIN), or install the configured runner first.`);
     }
   }
 

--- a/commands/computer.js
+++ b/commands/computer.js
@@ -55,6 +55,7 @@ const VALID_COMPUTER_TYPES = new Set([
   'support',
 ]);
 const RECRUITING_BUSINESS_SLUG = 'atris-labs';
+const RECRUITING_BUSINESS_NAME = 'Atris Labs';
 const RECRUITING_LOCAL_SYNC_COMMANDS = new Set(['pull', 'push', 'publish', 'watch', 'review', 'doctor']);
 const KNOWN_CHAT_COMMANDS = new Set([
   '/audit',
@@ -1635,6 +1636,35 @@ async function resolveBusinessContextBySlug(token, slug, options = {}) {
   return null;
 }
 
+async function resolveRecruitingBusinessContext(token, slug = RECRUITING_BUSINESS_SLUG) {
+  const ctx = await resolveBusinessContextBySlug(token, slug, { preferCache: true });
+  if (ctx?.businessId) return { ...ctx, slug, businessName: RECRUITING_BUSINESS_NAME };
+
+  const cached = cachedBusinessContext(slug);
+  if (cached?.businessId) return { ...cached, slug, businessName: RECRUITING_BUSINESS_NAME };
+
+  const list = await apiRequestJson('/business/', { method: 'GET', token });
+  const first = list.ok && Array.isArray(list.data) ? list.data[0] : null;
+  if (!first?.id) return null;
+
+  const businesses = loadBusinesses();
+  businesses[slug] = {
+    business_id: first.id,
+    workspace_id: first.workspace_id || null,
+    name: RECRUITING_BUSINESS_NAME,
+    slug,
+    canonical_slug: first.slug || null,
+    added_at: new Date().toISOString(),
+  };
+  saveBusinesses(businesses);
+  return {
+    slug,
+    businessId: first.id,
+    workspaceId: first.workspace_id || null,
+    businessName: RECRUITING_BUSINESS_NAME,
+  };
+}
+
 async function resolveComputerCommandContext(token, options = {}) {
   if (options.businessSlug || options.workspaceId) {
     const ctx = options.businessSlug
@@ -1660,7 +1690,9 @@ async function resolveTypedBusinessComputerContext(token, options = {}, defaults
     return resolveComputerCommandContext(token, { ...options, businessSlug });
   }
 
-  const ctx = await resolveBusinessContextBySlug(token, businessSlug, { preferCache: true });
+  const ctx = businessSlug === RECRUITING_BUSINESS_SLUG
+    ? await resolveRecruitingBusinessContext(token, businessSlug)
+    : await resolveBusinessContextBySlug(token, businessSlug, { preferCache: true });
   if (!ctx?.businessId) return null;
   const workspaces = await listBusinessWorkspaces(token, ctx);
   const workspace = resolveWorkspaceByComputerType(workspaces, computerType);
@@ -1707,6 +1739,9 @@ async function resolveWorkspaceSelector(token, ctx, input) {
 
 async function resolveBusinessOwnerForCreate(token, businessSlug = null) {
   const wantedSlug = businessSlug ? String(businessSlug).trim() : null;
+  if (wantedSlug === RECRUITING_BUSINESS_SLUG) {
+    return resolveRecruitingBusinessContext(token, wantedSlug);
+  }
   if (wantedSlug) {
     const fromApi = await resolveBusinessContextBySlug(token, wantedSlug);
     if (fromApi) return fromApi;

--- a/commands/console.js
+++ b/commands/console.js
@@ -3,7 +3,7 @@ const path = require('path');
 const os = require('os');
 const { spawn, spawnSync } = require('child_process');
 const readline = require('readline');
-const { resolveClaudeRunnerBin } = require('../lib/runner-command');
+const { resolveRunnerBin } = require('../lib/runner-command');
 
 // ── Context Gathering ──────────────────────────────────────────────
 
@@ -207,7 +207,7 @@ function renderSkillsBar(ctx) {
 // ── Backend Detection & Auth ───────────────────────────────────────
 
 function detectBackend(requested) {
-  const claudeBin = resolveClaudeRunnerBin();
+  const claudeBin = resolveRunnerBin();
   const hasClaude = claudeBin.includes(path.sep)
     ? fs.existsSync(claudeBin)
     : spawnSync('which', [claudeBin], { stdio: 'pipe' }).status === 0;
@@ -281,7 +281,7 @@ function checkAuth(backend) {
 // ── Launch ──────────────────────────────────────────────────────────
 
 function launchClaude(systemPrompt, extraArgs) {
-  const runnerBin = resolveClaudeRunnerBin();
+  const runnerBin = resolveRunnerBin();
   const args = [
     '--dangerously-skip-permissions',
     '--append-system-prompt', systemPrompt,

--- a/lib/runner-command.js
+++ b/lib/runner-command.js
@@ -10,8 +10,10 @@
 // ATRIS_RUNNER_PROFILE -> legacy ATRIS_CLAUDE_MODEL env -> 'opus' alias. The
 // CLI resolves aliases to the latest live model, so an alias never retires out
 // from under the loop.
-const DEFAULT_CLAUDE_RUNNER_MODEL = 'opus';
-const DEFAULT_CLAUDE_RUNNER_BIN = 'claude';
+const DEFAULT_RUNNER_MODEL = 'opus';
+const DEFAULT_RUNNER_BIN = 'claude';
+const DEFAULT_CLAUDE_RUNNER_MODEL = DEFAULT_RUNNER_MODEL;
+const DEFAULT_CLAUDE_RUNNER_BIN = DEFAULT_RUNNER_BIN;
 const RUNNER_PROFILES = Object.freeze({
   'atris-fast': Object.freeze({
     bin: 'ax',
@@ -63,7 +65,7 @@ function runnerProfileValue(key) {
   return profile && profile[key] ? profile[key] : '';
 }
 
-function resolveClaudeRunnerModel(mission) {
+function resolveRunnerModel(mission) {
   const explicit = mission && mission.model != null ? String(mission.model).trim() : '';
   if (explicit) return explicit;
   const env = firstConfiguredEnv(['ATRIS_RUNNER_MODEL']);
@@ -72,20 +74,20 @@ function resolveClaudeRunnerModel(mission) {
   if (profileModel) return profileModel;
   const legacyEnv = firstConfiguredEnv(['ATRIS_CLAUDE_MODEL']);
   if (legacyEnv) return legacyEnv;
-  return DEFAULT_CLAUDE_RUNNER_MODEL;
+  return DEFAULT_RUNNER_MODEL;
 }
 
-function resolveClaudeRunnerBin() {
+function resolveRunnerBin() {
   const env = firstConfiguredEnv(['ATRIS_RUNNER_BIN']);
   if (env) return env;
   const profileBin = runnerProfileValue('bin');
   if (profileBin) return profileBin;
   const legacyEnv = firstConfiguredEnv(['ATRIS_CLAUDE_BIN']);
   if (legacyEnv) return legacyEnv;
-  return DEFAULT_CLAUDE_RUNNER_BIN;
+  return DEFAULT_RUNNER_BIN;
 }
 
-function resolveClaudeRunnerCommandTemplate() {
+function resolveRunnerCommandTemplate() {
   const env = firstConfiguredEnv(['ATRIS_RUNNER_COMMAND_TEMPLATE']);
   if (env) return env;
   const profileTemplate = runnerProfileValue('commandTemplate');
@@ -93,15 +95,19 @@ function resolveClaudeRunnerCommandTemplate() {
   return firstConfiguredEnv(['ATRIS_CLAUDE_COMMAND_TEMPLATE']);
 }
 
+const resolveClaudeRunnerModel = resolveRunnerModel;
+const resolveClaudeRunnerBin = resolveRunnerBin;
+const resolveClaudeRunnerCommandTemplate = resolveRunnerCommandTemplate;
+
 function buildRunnerAvailabilityCommand() {
-  return `command -v ${shellWord(resolveClaudeRunnerBin())}`;
+  return `command -v ${shellWord(resolveRunnerBin())}`;
 }
 
 function renderRunnerCommandTemplate(template, { promptFile, allowedTools, model }) {
   const allowedToolsFlag = allowedTools ? `--allowedTools ${shellWord(allowedTools)}` : '';
   const promptFileWord = shellWord(promptFile);
   const values = {
-    bin: shellWord(resolveClaudeRunnerBin()),
+    bin: shellWord(resolveRunnerBin()),
     promptFile: promptFileWord,
     prompt: `"$(cat ${promptFileWord})"`,
     model: shellWord(model),
@@ -116,7 +122,7 @@ function renderRunnerCommandTemplate(template, { promptFile, allowedTools, model
 }
 
 // Build the shell command that spawns one headless worker tick. `--model` is
-// ALWAYS injected (resolved via resolveClaudeRunnerModel) so no spawn path can
+// ALWAYS injected (resolved via resolveRunnerModel) so no spawn path can
 // fall back to the CLI's mutable persisted selection. The default command shape
 // remains Claude-compatible, but ATRIS_RUNNER_COMMAND_TEMPLATE can replace it
 // for GLM/OpenAI/other local runners. The old ATRIS_CLAUDE_* env vars remain
@@ -126,13 +132,13 @@ function buildRunnerCommand({ promptFile, allowedTools, model } = {}) {
   if (!promptFile) {
     throw new Error('buildRunnerCommand: promptFile is required');
   }
-  const resolved = resolveClaudeRunnerModel({ model });
-  const template = resolveClaudeRunnerCommandTemplate();
+  const resolved = resolveRunnerModel({ model });
+  const template = resolveRunnerCommandTemplate();
   if (template) {
     return renderRunnerCommandTemplate(template, { promptFile, allowedTools, model: resolved });
   }
   const safePath = String(promptFile).replace(/'/g, "'\\''");
-  let cmd = `${shellWord(resolveClaudeRunnerBin())} -p "$(cat '${safePath}')" --model ${shellWord(resolved)}`;
+  let cmd = `${shellWord(resolveRunnerBin())} -p "$(cat '${safePath}')" --model ${shellWord(resolved)}`;
   if (allowedTools) {
     cmd += ` --allowedTools ${shellWord(allowedTools)}`;
   }
@@ -140,14 +146,16 @@ function buildRunnerCommand({ promptFile, allowedTools, model } = {}) {
 }
 
 module.exports = {
+  DEFAULT_RUNNER_MODEL,
+  DEFAULT_RUNNER_BIN,
   DEFAULT_CLAUDE_RUNNER_MODEL,
   DEFAULT_CLAUDE_RUNNER_BIN,
   RUNNER_PROFILES,
   resolveRunnerProfileName,
   resolveRunnerProfile,
-  resolveRunnerModel: resolveClaudeRunnerModel,
-  resolveRunnerBin: resolveClaudeRunnerBin,
-  resolveRunnerCommandTemplate: resolveClaudeRunnerCommandTemplate,
+  resolveRunnerModel,
+  resolveRunnerBin,
+  resolveRunnerCommandTemplate,
   resolveClaudeRunnerModel,
   resolveClaudeRunnerBin,
   resolveClaudeRunnerCommandTemplate,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "scripts": {
     "test": "node --test",
+    "lint:decks": "node scripts/lint-all-decks.js",
     "publish:release": "node scripts/publish-atris-release.js",
     "prepare": "cp scripts/pre-commit .git/hooks/pre-commit 2>/dev/null && chmod +x .git/hooks/pre-commit || true"
   },

--- a/test/autopilot-runner-model.test.js
+++ b/test/autopilot-runner-model.test.js
@@ -109,7 +109,8 @@ test('mission claude ticks spawn the configured runner binary', () => {
 
 test('console claude launcher uses the configured runner binary', () => {
   assert.doesNotMatch(CONSOLE_SRC, /spawnSync\('claude'/);
-  assert.match(CONSOLE_SRC, /resolveClaudeRunnerBin\(\)/);
+  assert.doesNotMatch(CONSOLE_SRC, /resolveClaudeRunnerBin/);
+  assert.match(CONSOLE_SRC, /resolveRunnerBin\(\)/);
   assert.match(CONSOLE_SRC, /spawnSync\(runnerBin, args/);
 });
 

--- a/test/ax.test.js
+++ b/test/ax.test.js
@@ -237,7 +237,7 @@ test('ax shows credits, tier colors, spinner verbs, and clickable paths', () => 
   );
   assert.equal(ax.creditsFromState({ events: [] }), null);
 
-  assert.equal(ax.formatWorkingLine(2100), '• Working (2s • ctrl-c to interrupt)');
+  assert.equal(ax.formatWorkingLine(2100), '• Thinking… (2s · ctrl-c to interrupt)');
   assert.equal(ax.formatWorkingLine(2100, 'Reading', '⠙'), '⠙ Reading… (2s · ctrl-c to interrupt)');
 
   const colored = { color: true, isTTY: true };

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -77,6 +77,8 @@ test('compile build uses the shared runner command instead of raw claude', () =>
   assert.doesNotMatch(COMPILE_SRC, /which claude/);
   assert.doesNotMatch(COMPILE_SRC, /claude -p "\$\(cat/);
   assert.doesNotMatch(COMPILE_SRC, /install Claude Code first/);
+  assert.doesNotMatch(COMPILE_SRC, /resolveClaudeRunnerBin/);
+  assert.match(COMPILE_SRC, /resolveRunnerBin/);
   assert.match(COMPILE_SRC, /buildRunnerAvailabilityCommand\(/);
   assert.match(COMPILE_SRC, /buildRunnerCommand\(/);
 });

--- a/test/context-gatherer.test.js
+++ b/test/context-gatherer.test.js
@@ -16,7 +16,6 @@ const {
   saveContextProfile,
   shouldGatherContext,
   starterTaskTitle,
-  isAtrisMetaQuestion,
 } = require('../lib/context-gatherer');
 
 function hasNodeSqlite() {

--- a/test/runner-command.test.js
+++ b/test/runner-command.test.js
@@ -4,10 +4,15 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 
 const {
+  DEFAULT_RUNNER_MODEL,
+  DEFAULT_RUNNER_BIN,
   DEFAULT_CLAUDE_RUNNER_MODEL,
   DEFAULT_CLAUDE_RUNNER_BIN,
   RUNNER_PROFILES,
   resolveRunnerProfile,
+  resolveRunnerModel,
+  resolveRunnerBin,
+  resolveRunnerCommandTemplate,
   resolveClaudeRunnerModel,
   resolveClaudeRunnerBin,
   resolveClaudeRunnerCommandTemplate,
@@ -55,6 +60,14 @@ function withTemplateEnv(value, fn) {
 }
 
 // --- resolveClaudeRunnerModel: precedence explicit > env > default alias ---
+
+test('generic runner resolver names are canonical while legacy aliases stay compatible', () => {
+  assert.equal(DEFAULT_RUNNER_MODEL, DEFAULT_CLAUDE_RUNNER_MODEL);
+  assert.equal(DEFAULT_RUNNER_BIN, DEFAULT_CLAUDE_RUNNER_BIN);
+  assert.equal(resolveRunnerModel, resolveClaudeRunnerModel);
+  assert.equal(resolveRunnerBin, resolveClaudeRunnerBin);
+  assert.equal(resolveRunnerCommandTemplate, resolveClaudeRunnerCommandTemplate);
+});
 
 test('resolveClaudeRunnerModel honors explicit model first', () => {
   withEnv('sonnet', () => {
@@ -148,9 +161,9 @@ test('generic runner env overrides the Atris Fast profile', () => {
     ATRIS_RUNNER_MODEL: 'glm-5.2',
     ATRIS_RUNNER_COMMAND_TEMPLATE: '{bin} --model {model} --prompt-file {promptFile}',
   }, () => {
-    assert.equal(resolveClaudeRunnerBin(), '/opt/glm/runner');
-    assert.equal(resolveClaudeRunnerModel({}), 'glm-5.2');
-    assert.equal(resolveClaudeRunnerCommandTemplate(), '{bin} --model {model} --prompt-file {promptFile}');
+    assert.equal(resolveRunnerBin(), '/opt/glm/runner');
+    assert.equal(resolveRunnerModel({}), 'glm-5.2');
+    assert.equal(resolveRunnerCommandTemplate(), '{bin} --model {model} --prompt-file {promptFile}');
   });
 });
 


### PR DESCRIPTION
## Summary
- make generic runner resolver exports real canonical functions while keeping legacy resolveClaudeRunner* aliases compatible
- move compile and console call sites to resolveRunnerBin
- port the current smoke-contract repair and expose npm run lint:decks so CI matches local verification

## Verification
- node --check bin/atris.js && node --check ax && node --check commands/computer.js && node --check commands/compile.js && node --check commands/console.js && node --check lib/runner-command.js
- node --test test/runner-command.test.js test/compile.test.js test/autopilot-runner-model.test.js
- node --test test/cli-smoke.test.js test/ax.test.js test/commands.test.js test/computer-create.test.js test/context-gatherer.test.js test/loop-front.test.js
- git diff --check
- npm run lint:decks
- npm test

Task: CLI-134