### PR TITLE
[codex] Add mission run visible goal verifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@ Always-on agents should move proof-backed work to Review, complete their native
 goal, then continue the mission loop with the next goal. They must not run
 `atris task accept` or claim AgentXP unless a human approved the proof.
 
+Codex agents with native goal tools should run `atris mission goal --json`
+before choosing work. If the payload includes `goal.visible_goal`, mirror
+`goal.objective` into the visible chat goal when the current goal is empty,
+complete, or already matching; never complete unrelated active goals just to
+make room.
+
 ## Workflow
 
 ```

--- a/atris/AGENTS.md
+++ b/atris/AGENTS.md
@@ -56,6 +56,12 @@ Always-on agents should move proof-backed work to Review, complete their native
 goal, then continue the mission loop with the next goal. They must not run
 `atris task accept` or claim Career XP unless a human approved the proof.
 
+Codex agents with native goal tools should run `atris mission goal --json`
+before choosing work. If the payload includes `goal.visible_goal`, mirror
+`goal.objective` into the visible chat goal when the current goal is empty,
+complete, or already matching; never complete unrelated active goals just to
+make room.
+
 Do not write new operating doctrine here first. Add it to Atris policy, skills,
 wiki, or `atris/atris.md`, then regenerate this adapter if needed.
 

--- a/atris/features/codex-goal-replacement/build.md
+++ b/atris/features/codex-goal-replacement/build.md
@@ -6,6 +6,8 @@ Implemented:
 
 - `selectCodexGoalMission()` chooses the active mission that should become the visible Codex goal.
 - `refreshCodexGoalController()` writes `.atris/state/codex_goal.json` and `atris/status/codex-goal.md`.
+- `goal.visible_goal` declares the exact chat-runtime bridge: read the current goal, keep matching goals, create when the slot is empty, complete after proof, then refresh the next candidate.
+- `atris/skills/atris/SKILL.md` tells Codex runtimes to consume `goal.visible_goal` before choosing work.
 - Mission `run`, `tick`, and `complete` refresh the controller after state changes.
 - `goal-loop` provides a bounded overnight runner around the cheap heartbeat.
 
@@ -34,6 +36,9 @@ create_goal(nextObjective)
 
 1. Read `.atris/state/codex_goal.json`.
 2. If `action` is `codex_goal_candidate` or `codex_goal_heartbeat`, read `goal.objective`.
-3. If `goal.mission_id` differs from the visible goal's mission id, replace the visible Codex `/goal`.
-4. Preserve the prior goal history for audit.
-5. Do not require direct edits to Codex local state databases.
+3. Read `goal.visible_goal`.
+4. If the current visible goal already matches `goal.objective`, keep working.
+5. If the slot is empty or the prior goal is complete, call `create_goal({ objective: goal.objective })`.
+6. After proof or verifier pass, call `update_goal({ status: "complete" })`, rerun `atris mission goal --json`, then create the next visible goal candidate.
+7. Preserve the prior goal history for audit.
+8. Do not require direct edits to Codex local state databases.

--- a/atris/features/codex-goal-replacement/idea.md
+++ b/atris/features/codex-goal-replacement/idea.md
@@ -2,11 +2,12 @@
 
 ## Problem
 
-Atris missions can now choose the next Codex goal candidate, but this Codex runtime cannot write that candidate into the visible `/goal` UI after a goal is already active.
+Atris missions can now choose the next Codex goal candidate, but the candidate needs an explicit bridge contract before this Codex runtime can mirror it into the visible `/goal` UI.
 
 ## Success Criteria
 
 - Atris owns mission selection and writes `.atris/state/codex_goal.json`.
+- The candidate includes `goal.visible_goal`, a runtime-readable bridge for the chat goal tools.
 - Codex owns the visible thread goal state.
 - When the active mission finishes, Codex can replace the visible `/goal` with `codex_goal.json.goal.objective`.
 - Replacement is atomic: the UI shows one current goal, not a stale completed goal plus a hidden local candidate.
@@ -16,4 +17,5 @@ Atris missions can now choose the next Codex goal candidate, but this Codex runt
 - `atris mission goal --json` emits `codex_goal_candidate`.
 - `atris mission goal --heartbeat --json` refreshes cheap overnight state.
 - `atris mission goal-loop --max-wall 28800 --no-claude --json` polls cheaply and runs one due mission step only when due.
-- `create_goal(...)` currently fails while the thread already has an active goal.
+- This Codex session can complete a prior visible goal and then create a new visible goal.
+- `create_goal(...)` still fails while a different thread goal is active, so the bridge must wait for proof or an empty goal slot.

--- a/atris/features/codex-goal-replacement/validate.md
+++ b/atris/features/codex-goal-replacement/validate.md
@@ -13,6 +13,8 @@ Expected:
 - Mission tests pass.
 - `goal-loop` returns `action: codex_goal_loop`.
 - `final_state.goal.objective` is the next Codex-visible goal candidate when a mission exists.
+- `final_state.goal.visible_goal.schema` is `atris.visible_chat_goal_bridge.v1`.
+- `atris/skills/atris/SKILL.md` includes the visible chat goal mirror procedure.
 - `.atris/state/codex_goal.json` is updated.
 
 ## Platform Acceptance Check
@@ -20,9 +22,12 @@ Expected:
 Given an active Codex thread goal and a different `.atris/state/codex_goal.json.goal.objective`:
 
 1. Runtime reads the candidate.
-2. Runtime replaces the visible `/goal` text with the candidate objective.
-3. `get_goal()` returns the new objective.
-4. No direct mutation of `~/.codex` state is required.
+2. Runtime reads `goal.visible_goal`.
+3. Runtime completes the current visible goal only after proof or a safe handoff.
+4. Runtime creates the visible `/goal` with the candidate objective.
+5. Runtime reruns `atris mission goal --json` after completion to fetch the next candidate.
+6. `get_goal()` returns the new objective.
+7. No direct mutation of `~/.codex` state is required.
 
 ## Current Blocker
 
@@ -32,4 +37,4 @@ The runtime available in this session exposes:
 - `create_goal`
 - `update_goal(status: complete)`
 
-It does not expose `replace_goal` or `set_goal`, and `create_goal` rejects while this thread already has an active goal.
+It does not expose `replace_goal` or `set_goal`, and `create_goal` rejects while this thread already has a different active goal. The supported path is complete-after-proof, refresh, then create the next objective.

--- a/atris/skills/atris/SKILL.md
+++ b/atris/skills/atris/SKILL.md
@@ -33,11 +33,33 @@ Key behaviors:
 - Use `atris task` for claims, proof, ready, and accept
 - Use functional/feature members as task owners; record engines only as `executed_by`
 - Treat TODO.md as a rendered view; regenerate it instead of hand-editing tasks
+- In Codex runtimes with native goal tools, mirror `atris mission goal --json` into the visible chat goal via `goal.visible_goal`
+
+## Visible Chat Goal Mirror
+
+Before choosing work in an Atris repo, run:
+
+```bash
+atris mission goal --json
+```
+
+If it returns `action: codex_goal_candidate` or `codex_goal_heartbeat` with
+`goal.visible_goal`, treat that as the desired native chat goal:
+
+1. Call `get_goal` when the runtime exposes it.
+2. If the active goal already equals `goal.objective`, keep working.
+3. If there is no active goal or the prior goal is complete, call `create_goal` with `goal.objective`.
+4. If a different active goal is still in progress, do not complete it just to make room; report that `goal.visible_goal.status` is waiting for the visible goal slot.
+5. After proof is ready, call `update_goal({ status: "complete" })`, rerun `atris mission goal --json`, then create the next visible goal candidate when a slot is available.
+
+Native goal completion is not task acceptance. Agents may complete their native
+goal after proof is ready; only a human should run `atris task accept`.
 
 ## Steps
 
 1. Run `atris atris.md` on first interaction to show workspace status
 2. Read `atris/MAP.md` before any file search to find file:line refs
-3. Run `atris task list` or `atris task next` to find current work
-4. Claim tasks with `atris task claim <id> --as <functional-member>`
-5. Move completed work to review with `atris task ready <id> --proof "..."`
+3. Run `atris mission goal --json` and mirror `goal.visible_goal` into the native chat goal when the runtime supports it
+4. Run `atris task list` or `atris task next` to find current work
+5. Claim tasks with `atris task claim <id> --as <functional-member>`
+6. Move completed work to review with `atris task ready <id> --proof "..."`

--- a/commands/mission.js
+++ b/commands/mission.js
@@ -768,6 +768,36 @@ function missingVerifierWarning(mission) {
   };
 }
 
+function missionRunSmokeVerifier() {
+  const script = [
+    "const fs=require('fs')",
+    "const os=require('os')",
+    "const path=require('path')",
+    "const {spawnSync}=require('child_process')",
+    "const root=fs.mkdtempSync(path.join(os.tmpdir(),'atris-mission-run-verifier-'))",
+    "process.on('exit',()=>fs.rmSync(root,{recursive:true,force:true}))",
+    "fs.mkdirSync(path.join(root,'atris'),{recursive:true})",
+    "const r=spawnSync('atris',['mission','run','verifier smoke objective','--json'],{cwd:root,encoding:'utf8',env:{...process.env,ATRIS_SKIP_UPDATE_CHECK:'1'}})",
+    "if(r.status!==0){process.stderr.write(r.stderr||r.stdout);process.exit(1)}",
+    "const p=JSON.parse(r.stdout)",
+    "if(p.action!=='mission_run_started')process.exit(2)",
+    "if(p.mission?.runner!=='codex_goal')process.exit(3)",
+    "if(p.codex_goal_state?.goal?.visible_goal?.schema!=='atris.visible_chat_goal_bridge.v1')process.exit(4)",
+  ].join(';');
+  return `node -e ${JSON.stringify(script)}`;
+}
+
+function inferRunObjectiveVerifier(objective, root = process.cwd()) {
+  const text = String(objective || '').toLowerCase();
+  if (!/\bmission\s+run\b/.test(text)) return '';
+  const sourceTest = path.join(root, 'test', 'mission-status.test.js');
+  const sourceCommand = path.join(root, 'commands', 'mission.js');
+  if (fs.existsSync(sourceTest) && fs.existsSync(sourceCommand)) {
+    return 'node --test test/mission-status.test.js';
+  }
+  return missionRunSmokeVerifier();
+}
+
 function startMission(args) {
   const asJson = wantsJson(args);
   const mission = missionFromArgs(args);
@@ -816,6 +846,75 @@ function startMission(args) {
       ...warnings.map((warning) => `Warning: ${warning.message}`),
       ...(saved.xp_task ? [`AgentXP task: ${saved.xp_task.ref}`] : []),
       ...(saved.worktree ? [`Next: cd ${saved.worktree.path} && atris mission tick ${saved.id}`] : [`Next: atris mission tick ${saved.id}`]),
+    ],
+    asJson,
+  );
+}
+
+function startMissionFromRunObjective(objective, args) {
+  const asJson = wantsJson(args);
+  const verifier = readFlag(args, '--verify', inferRunObjectiveVerifier(objective));
+  const stopCondition = readFlag(
+    args,
+    '--stop',
+    verifier ? 'verifier passes and visible goal lands' : 'visible goal lands and proof is ready',
+  );
+  const startArgs = [
+    objective,
+    '--owner',
+    readFlag(args, '--owner', process.env.ATRIS_AGENT_ID || 'mission-lead'),
+    '--runner',
+    readFlag(args, '--runner', 'codex_goal'),
+    '--lane',
+    readFlag(args, '--lane', 'workspace'),
+    '--cadence',
+    readFlag(args, '--cadence', 'manual'),
+    '--stop',
+    stopCondition,
+  ];
+  if (verifier) startArgs.push('--verify', verifier);
+  const model = readFlag(args, '--model', '');
+  if (model) startArgs.push('--model', model);
+  if (hasFlag(args, '--always-on')) startArgs.push('--always-on');
+  if (hasFlag(args, '--xp-task') || hasFlag(args, '--agent-xp')) startArgs.push('--xp-task');
+
+  const mission = missionFromArgs(startArgs);
+  const warnings = [missingVerifierWarning(mission)].filter(Boolean);
+  ensureMemberMissionFile(mission.owner, process.cwd(), mission.objective);
+  const { mission: saved } = saveMission(mission, process.cwd(), 'mission_started', { objective: mission.objective, source: 'mission_run_objective' });
+  const memberState = renderMemberMissionState(saved.owner);
+  const logPath = appendMemberLog(saved.owner, 'Mission started from run', {
+    mission: saved.objective,
+    cadence: saved.cadence,
+    runner: saved.runner,
+    lane: saved.lane,
+    verifier: saved.verifier,
+  });
+  const worktreeBaseline = captureMissionWorktreeBaseline(saved, process.cwd());
+  const codexGoalState = refreshCodexGoalController(process.cwd());
+  printJsonOrText(
+    {
+      ok: true,
+      action: 'mission_run_started',
+      mission: saved,
+      warnings,
+      state_path: statePaths().missionsJsonl,
+      member_state: memberState,
+      log_path: logPath,
+      worktree_baseline: worktreeBaseline ? {
+        path: path.relative(process.cwd(), missionBaselinePath(saved.id)),
+        dirty_count: worktreeBaseline.dirty_count,
+        dirty_hash: worktreeBaseline.dirty_hash,
+      } : null,
+      codex_goal_state: codexGoalState,
+      next_command: codexGoalState.goal?.next_command || `atris mission tick ${saved.id} --verify`,
+    },
+    [
+      `Started mission: ${saved.objective}`,
+      `Owner: ${saved.owner}`,
+      `Runner: ${saved.runner}`,
+      ...(codexGoalState.goal ? [`Visible goal: ${codexGoalState.goal.objective}`] : []),
+      ...warnings.map((warning) => `Warning: ${warning.message}`),
     ],
     asJson,
   );
@@ -1491,7 +1590,7 @@ function selectCodexGoalMission(root = process.cwd(), now = new Date()) {
 }
 
 function codexGoalObjective(mission) {
-  return `Advance Atris mission ${mission.id}: ${mission.objective}`;
+  return mission.objective;
 }
 
 function codexGoalNextCommand(mission) {
@@ -1513,14 +1612,40 @@ function codexGoalNextCommand(mission) {
   return `atris mission tick ${mission.id} --summary "<what changed>"`;
 }
 
+function codexVisibleGoalBridge(mission, goalObjective) {
+  return {
+    schema: 'atris.visible_chat_goal_bridge.v1',
+    runtime: 'codex',
+    source: 'atris_mission',
+    mission_id: mission.id,
+    desired_objective: goalObjective,
+    status: 'needs_runtime_write',
+    state_file: '.atris/state/codex_goal.json',
+    status_file: 'atris/status/codex-goal.md',
+    operations: {
+      read_current_goal: 'get_goal',
+      keep_if_matching: 'if current goal objective equals goal.objective, continue the mission',
+      create_when_empty_or_completed: 'create_goal({ objective: goal.objective })',
+      complete_after_proof: 'update_goal({ status: "complete" })',
+      refresh_next_candidate: 'atris mission goal --json',
+    },
+    guardrails: [
+      'Do not complete a human-set active goal unless it matches this mission goal or the mission receipt proves handoff.',
+      'If create_goal fails because another goal is active, keep this bridge waiting for the visible goal slot.',
+    ],
+  };
+}
+
 function codexGoalToolContract(mission) {
   return {
     current_policy: 'keep one visible Codex /goal active for the selected Atris mission',
     read_current_goal: 'get_goal',
     complete_current_goal: 'update_goal({ status: "complete" })',
     select_next_goal: 'atris mission goal --json',
-    set_next_goal: 'replace_goal(goal.objective) or create_goal(goal.objective) after the completed goal slot is reusable',
-    platform_requirement: 'Codex runtime must expose replace_goal/set_goal, or allow create_goal after update_goal completes the prior goal.',
+    set_next_goal: 'use goal.visible_goal: create_goal({ objective: goal.objective }) when no active goal blocks the slot',
+    visible_goal_bridge: 'goal.visible_goal',
+    platform_requirement: 'Codex runtime must expose replace_goal/set_goal, or allow update_goal({ status: "complete" }) followed by create_goal({ objective }).',
+    runtime_tool_sequence: 'get_goal -> update_goal({ status: "complete" }) after proof -> atris mission goal --json -> create_goal({ objective: goal.objective })',
     blocked_without_platform_goal_write: true,
     mission_id: mission.id,
   };
@@ -1561,6 +1686,12 @@ function writeCodexGoalState(payload, root = process.cwd()) {
     lines.push(`- reason: ${state.goal.reason}`);
     lines.push(`- objective: ${state.goal.objective}`);
     lines.push(`- next: ${state.goal.next_command}`);
+    if (state.goal.visible_goal) {
+      lines.push(`- visible goal: ${state.goal.visible_goal.status}`);
+      lines.push(`- visible goal desired: ${state.goal.visible_goal.desired_objective}`);
+      lines.push(`- visible goal create: ${state.goal.visible_goal.operations.create_when_empty_or_completed}`);
+      lines.push(`- visible goal complete: ${state.goal.visible_goal.operations.complete_after_proof}`);
+    }
     lines.push(`- platform write blocked: ${state.goal.codex_tool_contract.blocked_without_platform_goal_write}`);
   } else {
     lines.push('- mission: none');
@@ -1591,8 +1722,9 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
   const { mission, reason } = selected;
   const taskSpine = missionTaskSpine(mission);
   const missionView = missionStatusView(mission);
+  const objective = codexGoalObjective(mission);
   const goal = {
-    objective: codexGoalObjective(mission),
+    objective,
     mission_id: mission.id,
     mission_objective: mission.objective,
     mission_status: mission.status,
@@ -1602,6 +1734,7 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
     reason,
     next_command: codexGoalNextCommand(mission),
     replace_after: 'After proof or verifier pass, run atris mission goal --json again and replace the Codex /goal with the returned objective.',
+    visible_goal: codexVisibleGoalBridge(mission, objective),
     codex_tool_contract: codexGoalToolContract(mission),
   };
   const heartbeat = heartbeatMode ? codexGoalHeartbeat(goal, mission) : undefined;
@@ -2037,7 +2170,11 @@ async function runMission(args) {
   const maxTicks = Math.max(1, Number(maxTicksFlag) || MISSION_RUN_DEFAULTS.maxTicks);
   const maxWallSeconds = Math.max(60, Number(readFlag(args, '--max-wall', '')) || MISSION_RUN_DEFAULTS.maxWallSeconds);
   const cadenceOverride = readFlag(args, '--cadence', '');
-  const ref = stripKnownFlags(args, ['--max-ticks', '--max-wall', '--cadence'], ['--json', '--due', '--no-claude', '--no-verify', '--complete-on-pass', '--no-drain'])[0] || '';
+  const ref = stripKnownFlags(
+    args,
+    ['--max-ticks', '--max-wall', '--cadence', '--owner', '--runner', '--lane', '--verify', '--stop', '--model'],
+    ['--json', '--due', '--no-claude', '--no-verify', '--complete-on-pass', '--no-drain', '--always-on', '--xp-task', '--agent-xp'],
+  ).join(' ').trim();
 
   let mission = dueMode && !ref ? selectDueMission() : resolveMission(ref);
   if (!mission && dueMode && !ref) {
@@ -2048,8 +2185,12 @@ async function runMission(args) {
     );
     return;
   }
+  if (!mission && ref && /\s/.test(ref) && !String(ref).startsWith('mission-')) {
+    startMissionFromRunObjective(ref, args);
+    return;
+  }
   if (!mission) {
-    exitMissionError(ref ? `Mission "${ref}" not found.` : 'Usage: atris mission run <id> [--max-ticks 4] [--max-wall 3600]', 1, asJson);
+    exitMissionError(ref ? `Mission "${ref}" not found.` : 'Usage: atris mission run <id|objective> [--max-ticks 4] [--max-wall 3600]', 1, asJson);
   }
   if (['complete', 'stopped'].includes(mission.status)) {
     if (asJson) {
@@ -2863,7 +3004,7 @@ Autonomy recipe:
   1. Pick an owner member: atris member create <member>  (if missing)
   2. Start a current-agent mission with a verifier:
      atris mission start "ship one proof" --owner <member> --runner codex_goal --lane code --verify "npm test" --stop "verifier passes" --xp-task
-  3. Codex sessions: atris mission goal --json, then set /goal to goal.objective
+  3. Codex sessions: atris mission goal --json, then mirror goal.visible_goal into the native chat goal
      Overnight controller: atris mission goal --heartbeat --json
      Bounded overnight runner: atris mission goal-loop --max-wall 28800 --no-claude --json
   4. Do one bounded step, then record it:

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -502,6 +502,31 @@ test('mission run terminal skips are JSON-readable', () => {
   }
 });
 
+test('mission run with an objective starts a visible-goal mission', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const run = runCli(['mission', 'run', 'atris mission run', '--json'], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    assert.equal(run.stderr, '');
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, 'mission_run_started');
+    assert.equal(payload.mission.objective, 'atris mission run');
+    assert.equal(payload.mission.runner, 'codex_goal');
+    assert.match(payload.mission.verifier, /atris-mission-run-verifier/);
+    assert.match(payload.mission.verifier, /verifier smoke objective/);
+    assert.equal(payload.mission.stop_condition, 'verifier passes and visible goal lands');
+    assert.equal(payload.warnings.length, 0);
+    assert.equal(payload.codex_goal_state.action, 'codex_goal_candidate');
+    assert.equal(payload.codex_goal_state.goal.objective, 'atris mission run');
+    assert.equal(payload.codex_goal_state.goal.visible_goal.schema, 'atris.visible_chat_goal_bridge.v1');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('mission run --due selects an active verifier mission for loop heartbeats', () => {
   const dir = makeTempDir();
   try {
@@ -669,18 +694,36 @@ test('mission goal emits the Codex goal candidate from mission state', () => {
     assert.equal(payload.goal.reason, 'due');
     assert.equal(fs.realpathSync(payload.state_path), fs.realpathSync(path.join(dir, '.atris', 'state', 'codex_goal.json')));
     assert.equal(fs.realpathSync(payload.status_path), fs.realpathSync(path.join(dir, 'atris', 'status', 'codex-goal.md')));
-    assert.match(payload.goal.objective, new RegExp(`Advance Atris mission ${mission.id}: codex visible goal mission`));
+    assert.equal(payload.goal.objective, 'codex visible goal mission');
     assert.equal(payload.goal.next_command, `atris mission attach-task ${mission.id} --json`);
     assert.equal(payload.goal.task_spine.has_task, false);
     assert.equal(payload.goal.task_spine.ensure_task_command, `atris mission attach-task ${mission.id} --json`);
     assert.match(payload.goal.replace_after, /replace the Codex \/goal/);
+    assert.equal(payload.goal.visible_goal.schema, 'atris.visible_chat_goal_bridge.v1');
+    assert.equal(payload.goal.visible_goal.runtime, 'codex');
+    assert.equal(payload.goal.visible_goal.source, 'atris_mission');
+    assert.equal(payload.goal.visible_goal.mission_id, mission.id);
+    assert.equal(payload.goal.visible_goal.desired_objective, payload.goal.objective);
+    assert.equal(payload.goal.visible_goal.status, 'needs_runtime_write');
+    assert.equal(payload.goal.visible_goal.operations.read_current_goal, 'get_goal');
+    assert.equal(
+      payload.goal.visible_goal.operations.create_when_empty_or_completed,
+      'create_goal({ objective: goal.objective })',
+    );
+    assert.equal(
+      payload.goal.visible_goal.operations.complete_after_proof,
+      'update_goal({ status: "complete" })',
+    );
+    assert.equal(payload.goal.visible_goal.operations.refresh_next_candidate, 'atris mission goal --json');
     assert.deepEqual(payload.goal.codex_tool_contract, {
       current_policy: 'keep one visible Codex /goal active for the selected Atris mission',
       read_current_goal: 'get_goal',
       complete_current_goal: 'update_goal({ status: "complete" })',
       select_next_goal: 'atris mission goal --json',
-      set_next_goal: 'replace_goal(goal.objective) or create_goal(goal.objective) after the completed goal slot is reusable',
-      platform_requirement: 'Codex runtime must expose replace_goal/set_goal, or allow create_goal after update_goal completes the prior goal.',
+      set_next_goal: 'use goal.visible_goal: create_goal({ objective: goal.objective }) when no active goal blocks the slot',
+      visible_goal_bridge: 'goal.visible_goal',
+      platform_requirement: 'Codex runtime must expose replace_goal/set_goal, or allow update_goal({ status: "complete" }) followed by create_goal({ objective }).',
+      runtime_tool_sequence: 'get_goal -> update_goal({ status: "complete" }) after proof -> atris mission goal --json -> create_goal({ objective: goal.objective })',
       blocked_without_platform_goal_write: true,
       mission_id: mission.id,
     });
@@ -688,7 +731,10 @@ test('mission goal emits the Codex goal candidate from mission state', () => {
     assert.equal(state.schema, 'atris.codex_goal_controller.v1');
     assert.equal(state.action, 'codex_goal_candidate');
     assert.equal(state.goal.mission_id, mission.id);
-    assert.match(fs.readFileSync(payload.status_path, 'utf8'), /Codex Goal Controller/);
+    const status = fs.readFileSync(payload.status_path, 'utf8');
+    assert.match(status, /Codex Goal Controller/);
+    assert.match(status, /visible goal: needs_runtime_write/);
+    assert.match(status, /visible goal create: create_goal\(\{ objective: goal\.objective \}\)/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -902,6 +948,7 @@ test('mission goal heartbeat refreshes controller state without heavy work', () 
     assert.equal(state.action, 'codex_goal_heartbeat');
     assert.equal(state.heartbeat.heavy_work_performed, false);
     assert.equal(state.goal.mission_id, mission.id);
+    assert.equal(state.goal.visible_goal.status, 'needs_runtime_write');
   } finally {
     cleanupTempDir(dir);
   }
@@ -1182,7 +1229,7 @@ test('mission help documents status filters', () => {
     assert.match(help.stdout, /mission goal \[--heartbeat\] \[--json\]/);
     assert.match(help.stdout, /mission goal-loop \[--max-wall 28800\] \[--max-iterations 32\] \[--no-claude\] \[--json\]/);
     assert.match(help.stdout, /Autonomy recipe:/);
-    assert.match(help.stdout, /Codex sessions: atris mission goal --json, then set \/goal to goal\.objective/);
+    assert.match(help.stdout, /Codex sessions: atris mission goal --json, then mirror goal\.visible_goal into the native chat goal/);
     assert.match(help.stdout, /Overnight controller: atris mission goal --heartbeat --json/);
     assert.match(help.stdout, /Bounded overnight runner: atris mission goal-loop --max-wall 28800 --no-claude --json/);
     assert.match(help.stdout, /Headless: start with --runner claude --cadence "15m" --always-on/);


### PR DESCRIPTION
We did: made `atris mission run "<objective>"` create a Codex-visible mission goal and infer a verifier for mission-run work.

This means: the simple command now starts a proof-backed recursive goal loop instead of creating an opaque mission with no verifier.

We tested it by running `node -c commands/mission.js`, `node --test test/mission-status.test.js`, `git diff --check`, and a global `atris mission run "atris mission run" --json` smoke. Result: 30/30 mission tests passed and the global smoke produced a verifier-backed visible-goal mission.

Next: review, merge, then publish the CLI package so the global in-place patch is no longer special.