### PR TITLE
Gate bare mission run input

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const readline = require('readline');
 const { spawn, spawnSync } = require('child_process');
 const {
   resolveClaudeRunnerModel,
@@ -139,6 +140,58 @@ function printJsonOrText(payload, lines, asJson) {
     return;
   }
   for (const line of lines) console.log(line);
+}
+
+function missionRunInputRequired(asJson = false) {
+  const payload = {
+    ok: false,
+    action: 'mission_input_required',
+    prompt: 'What mission should Atris run?',
+    owner_prompt: 'Which team member should own it?',
+    example: 'atris mission run "make onboarding magical" --owner mission-lead',
+  };
+  if (asJson) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.error('What mission should Atris run?');
+    console.error('Try: atris mission run "make onboarding magical" --owner mission-lead');
+  }
+  process.exit(1);
+}
+
+function askLine(rl, question) {
+  return new Promise((resolve) => rl.question(question, (answer) => resolve(String(answer || '').trim())));
+}
+
+function removeValueFlag(args, name) {
+  const out = [];
+  const prefix = `${name}=`;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = String(args[i]);
+    if (arg === name) {
+      if (args[i + 1] && !String(args[i + 1]).startsWith('--')) i += 1;
+      continue;
+    }
+    if (arg.startsWith(prefix)) continue;
+    out.push(args[i]);
+  }
+  return out;
+}
+
+async function promptMissionRunInput(args) {
+  const defaultOwner = readFlag(args, '--owner', process.env.ATRIS_AGENT_ID || 'mission-lead');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const objective = await askLine(rl, 'Mission: ');
+    if (!objective) missionRunInputRequired(false);
+    const owner = await askLine(rl, `Team member [${defaultOwner}]: `);
+    return {
+      objective,
+      args: [...removeValueFlag(args, '--owner'), '--owner', owner || defaultOwner],
+    };
+  } finally {
+    rl.close();
+  }
 }
 
 function loadTaskDb(asJson = false) {
@@ -2176,6 +2229,15 @@ async function runMission(args) {
     ['--json', '--due', '--no-claude', '--no-verify', '--complete-on-pass', '--no-drain', '--always-on', '--xp-task', '--agent-xp'],
   ).join(' ').trim();
 
+  if (!dueMode && !ref) {
+    if (asJson || !process.stdin.isTTY || !process.stderr.isTTY) {
+      missionRunInputRequired(asJson);
+    }
+    const prompted = await promptMissionRunInput(args);
+    startMissionFromRunObjective(prompted.objective, prompted.args);
+    return;
+  }
+
   let mission = dueMode && !ref ? selectDueMission() : resolveMission(ref);
   if (!mission && dueMode && !ref) {
     printJsonOrText(
@@ -2994,9 +3056,9 @@ atris mission - durable goal + loop + owner + proof state
   atris mission goal [--heartbeat] [--json]
   atris mission goal-loop [--max-wall 28800] [--max-iterations 32] [--no-claude] [--json]
   atris mission tick <id> [--verify] [--complete-on-pass] [--summary "..."] [--json]
-  atris mission run <id|--due> [--max-ticks 4] [--max-wall 3600] [--cadence "15m"]
+  atris mission run ["objective"|id|--due] [--owner <member>] [--max-ticks 4] [--max-wall 3600] [--cadence "15m"]
                                 [--no-claude] [--no-verify] [--complete-on-pass] [--no-drain] [--json]
-                       (always-on runs drain the review lane each tick; --no-drain skips)
+                       (bare run prompts for mission + owner; --due runs the saved queue)
   atris mission complete <id> --proof "..."
   atris mission stop <id> [--pause] [--reason "..."]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.30.2",
+  "version": "3.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.30.2",
+      "version": "3.30.3",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.30.2",
+  "version": "3.30.3",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -476,7 +476,7 @@ test('mission required arguments are JSON-readable', () => {
   }
 });
 
-test('mission run terminal skips are JSON-readable', () => {
+test('mission run terminal skips are JSON-readable when mission is explicit', () => {
   const dir = makeTempDir();
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
@@ -484,7 +484,7 @@ test('mission run terminal skips are JSON-readable', () => {
     const stop = runCli(['mission', 'stop', stopped.id, '--reason', 'done', '--json'], { cwd: dir });
     assert.equal(stop.status, 0, stop.stderr || stop.stdout);
 
-    const run = runCli(['mission', 'run', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', stopped.id, '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.equal(run.stderr, '');
     const runPayload = JSON.parse(run.stdout);
@@ -522,6 +522,26 @@ test('mission run with an objective starts a visible-goal mission', () => {
     assert.equal(payload.codex_goal_state.action, 'codex_goal_candidate');
     assert.equal(payload.codex_goal_state.goal.objective, 'atris mission run');
     assert.equal(payload.codex_goal_state.goal.visible_goal.schema, 'atris.visible_chat_goal_bridge.v1');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('bare mission run asks for input instead of resuming an old mission', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    startMission(dir, 'old saved mission');
+
+    const run = runCli(['mission', 'run', '--json'], { cwd: dir });
+    assert.equal(run.status, 1);
+    assert.equal(run.stderr, '');
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.action, 'mission_input_required');
+    assert.equal(payload.prompt, 'What mission should Atris run?');
+    assert.equal(payload.owner_prompt, 'Which team member should own it?');
+    assert.match(payload.example, /atris mission run "make onboarding magical"/);
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/repo-shape.test.js
+++ b/test/repo-shape.test.js
@@ -30,7 +30,7 @@ test('npm package includes runtime workspace templates', () => {
 });
 
 test('npm package metadata matches the reviewed release version', () => {
-  assert.equal(packageJson.version, '3.30.2');
+  assert.equal(packageJson.version, '3.30.3');
   assert.equal(packageLock.version, packageJson.version);
   assert.equal(packageLock.packages[''].version, packageJson.version);
 });


### PR DESCRIPTION
What happened\n- Bare `atris mission run` no longer silently resumes an old mission.\n- In a human terminal it prompts for mission + team member.\n- In script/JSON mode it returns `mission_input_required`.\n- `atris mission run "objective"` still creates the visible-goal mission; `--due` keeps the queue-runner behavior.\n\nWhat this means for the product\n- The magic button cannot hijack stale work.\n- A blank click asks what mission to run; a sentence click starts the goal loop.\n\nTested\n- `node -c commands/mission.js`\n- `git diff --check`\n- `node --test test/mission-status.test.js test/check-command-regression.test.js test/repo-shape.test.js` => 51/51 passed\n- `node scripts/check-command-regression.js` => no regressions\n- `npm run publish:release -- --dry-run` => atris@3.30.3 dry-run passed