### PR TITLE
Seed next goal after mission run

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -851,6 +851,94 @@ function inferRunObjectiveVerifier(objective, root = process.cwd()) {
   return missionRunSmokeVerifier();
 }
 
+function markMissionRunContinuation(mission) {
+  return {
+    ...mission,
+    started_from: 'mission_run_objective',
+    continue_on_complete: true,
+    continuation_policy: 'decide_and_start_next_useful_mission',
+  };
+}
+
+function continuationObjective(parent) {
+  return `Decide and start the next useful mission after: ${parent.objective}`;
+}
+
+function findActiveContinuationMission(parent, root = process.cwd()) {
+  return listMissions(root).find((mission) => (
+    mission.parent_mission_id === parent.id
+    && mission.started_from === 'mission_run_continuation'
+    && !TERMINAL_STATUSES.has(mission.status)
+  )) || null;
+}
+
+function seedMissionRunContinuation(parent, root = process.cwd(), proof = '') {
+  if (!parent || parent.status !== 'complete') return null;
+  if (parent.continue_on_complete !== true) return null;
+  if (parent.continuation_seeded_mission_id) return {
+    inserted: false,
+    reason: 'already_seeded',
+    mission_id: parent.continuation_seeded_mission_id,
+  };
+
+  const existing = findActiveContinuationMission(parent, root);
+  if (existing) return { inserted: false, reason: 'active_continuation_exists', mission: existing };
+
+  const owner = parent.owner || process.env.ATRIS_AGENT_ID || 'mission-lead';
+  const objective = continuationObjective(parent);
+  const mission = missionFromArgs([
+    objective,
+    '--owner',
+    owner,
+    '--runner',
+    'codex_goal',
+    '--lane',
+    parent.lane || 'workspace',
+    '--cadence',
+    'manual',
+    '--stop',
+    'next useful mission is started, or no useful next mission remains',
+  ]);
+  const nextMission = {
+    ...mission,
+    started_from: 'mission_run_continuation',
+    parent_mission_id: parent.id,
+    parent_objective: parent.objective,
+    continue_on_complete: false,
+    continuation_policy: 'choose_next_mission',
+    parent_proof: proof || parent.receipt_path || null,
+    next_action: `decide next mission, then run: atris mission run "<next useful mission>" --owner ${owner}`,
+  };
+
+  ensureMemberMissionFile(nextMission.owner, root, nextMission.objective);
+  const { mission: saved } = saveMission(nextMission, root, 'mission_continuation_started', {
+    parent_mission_id: parent.id,
+    parent_objective: parent.objective,
+    proof: proof || null,
+  });
+  const worktreeBaseline = captureMissionWorktreeBaseline(saved, root);
+  const seededAt = stampIso();
+  const { mission: updatedParent } = saveMission({
+    ...parent,
+    continuation_seeded_mission_id: saved.id,
+    continuation_seeded_at: seededAt,
+    continuation_seeded_objective: saved.objective,
+  }, root, 'mission_continuation_seeded', {
+    continuation_mission_id: saved.id,
+    continuation_objective: saved.objective,
+  });
+  return {
+    inserted: true,
+    mission: saved,
+    parent: updatedParent,
+    worktree_baseline: worktreeBaseline ? {
+      path: path.relative(root, missionBaselinePath(saved.id, root)),
+      dirty_count: worktreeBaseline.dirty_count,
+      dirty_hash: worktreeBaseline.dirty_hash,
+    } : null,
+  };
+}
+
 function startMission(args) {
   const asJson = wantsJson(args);
   const mission = missionFromArgs(args);
@@ -931,7 +1019,7 @@ function startMissionFromRunObjective(objective, args) {
   if (hasFlag(args, '--always-on')) startArgs.push('--always-on');
   if (hasFlag(args, '--xp-task') || hasFlag(args, '--agent-xp')) startArgs.push('--xp-task');
 
-  const mission = missionFromArgs(startArgs);
+  const mission = markMissionRunContinuation(missionFromArgs(startArgs));
   const warnings = [missingVerifierWarning(mission)].filter(Boolean);
   ensureMemberMissionFile(mission.owner, process.cwd(), mission.objective);
   const { mission: saved } = saveMission(mission, process.cwd(), 'mission_started', { objective: mission.objective, source: 'mission_run_objective' });
@@ -2345,6 +2433,7 @@ async function runMission(args) {
     const startedAt = Date.now();
     let backoffAttempt = 0;
     let lastRateLimit = null;
+    let continuationGoal = null;
 
     const sessionLabel = skipWorker
       ? 'caller-session'
@@ -2557,6 +2646,10 @@ async function runMission(args) {
         verifier: verifierResult ? (verifierResult.passed ? 'passed' : 'failed') : 'not_run',
         receipt: receiptPath,
       });
+      if (newStatus === 'complete') {
+        continuationGoal = seedMissionRunContinuation(mission, cwd, receiptPath);
+        if (continuationGoal?.parent) mission = continuationGoal.parent;
+      }
       refreshCodexGoalController(cwd);
 
       console.error(`[tick ${tickIdx}] status=${result.status} reason=${result.reason} verifier=${verifierResult ? (verifierResult.passed ? 'pass' : 'fail') : 'skip'} -> ${receiptPath || '-'}`);
@@ -2634,7 +2727,7 @@ async function runMission(args) {
     const codexGoalState = refreshCodexGoalController(cwd);
 
     printJsonOrText(
-      { ok: true, action: 'mission_run', mission, ran_ticks: ranTicks, tick_count: ticks.length, ticks, pause_reason: pauseReason, session_id: sessionId, summary_receipt: finalReceipt, worktree: summaryWorktree, codex_goal_state: codexGoalState },
+      { ok: true, action: 'mission_run', mission, ran_ticks: ranTicks, tick_count: ticks.length, ticks, pause_reason: pauseReason, session_id: sessionId, summary_receipt: finalReceipt, worktree: summaryWorktree, codex_goal_state: codexGoalState, continuation_goal: continuationGoal },
       [
         `Ran mission ${mission.id}`,
         `  objective: ${mission.objective}`,
@@ -2643,6 +2736,7 @@ async function runMission(args) {
         pauseReason ? `  pause: ${pauseReason}` : null,
         `  session: ${sessionId || '(none)'}`,
         `  summary receipt: ${finalReceipt}`,
+        continuationGoal?.mission ? `  next goal: ${continuationGoal.mission.objective}` : null,
       ].filter(Boolean),
       asJson,
     );
@@ -2771,15 +2865,20 @@ function tickMission(args) {
       receipt: receiptPath,
       summary: summary || undefined,
     });
+    const continuationGoal = saved.status === 'complete'
+      ? seedMissionRunContinuation(saved, cwd, receiptPath)
+      : null;
+    const outputMission = continuationGoal?.parent || saved;
     const codexGoalState = refreshCodexGoalController(process.cwd());
     printJsonOrText(
-      { ok: true, action: 'mission_tick', mission: saved, tick: tickRecord, verifier_result: verifierResult, receipt_path: receiptPath, log_path: logPath, codex_goal_state: codexGoalState },
+      { ok: true, action: 'mission_tick', mission: outputMission, tick: tickRecord, verifier_result: verifierResult, receipt_path: receiptPath, log_path: logPath, codex_goal_state: codexGoalState, continuation_goal: continuationGoal },
       [
-        `Ticked mission: ${saved.objective}`,
-        `State: ${saved.status}`,
+        `Ticked mission: ${outputMission.objective}`,
+        `State: ${outputMission.status}`,
         `Tick: ${tickIdx}`,
-        `Next: ${saved.next_action}`,
+        `Next: ${outputMission.next_action}`,
         ...(receiptPath ? [`Receipt: ${receiptPath}`] : []),
+        ...(continuationGoal?.mission ? [`Next goal: ${continuationGoal.mission.objective}`] : []),
       ],
       asJson,
     );
@@ -2861,24 +2960,28 @@ function completeMission(args) {
     result: completion.result,
   };
   const { mission: saved } = saveMission(next, process.cwd(), 'mission_completed', { proof, completion_gate: next.completion_gate });
-  const logPath = appendMemberLog(saved.owner, 'Mission completed', { mission: saved.objective, proof });
+  const continuationGoal = seedMissionRunContinuation(saved, process.cwd(), proof);
+  const outputMission = continuationGoal?.parent || saved;
+  const logPath = appendMemberLog(outputMission.owner, 'Mission completed', { mission: outputMission.objective, proof });
   const codexGoalState = refreshCodexGoalController(process.cwd());
   printJsonOrText(
     {
       ok: true,
       action: 'mission_completed',
-      mission: saved,
+      mission: outputMission,
       landing: completion.landing,
       result: completion.result,
       log_path: logPath,
       codex_goal_state: codexGoalState,
       xp_next_command: xpNextCommand,
+      continuation_goal: continuationGoal,
     },
     [
-      `Completed mission: ${saved.objective}`,
+      `Completed mission: ${outputMission.objective}`,
       ...missionResultLines(completion),
       `Proof: ${proof}`,
       ...(xpNextCommand ? [`AgentXP: ${xpNextCommand}`] : []),
+      ...(continuationGoal?.mission ? [`Next goal: ${continuationGoal.mission.objective}`] : []),
     ],
     asJson,
   );
@@ -3059,6 +3162,7 @@ atris mission - durable goal + loop + owner + proof state
   atris mission run ["objective"|id|--due] [--owner <member>] [--max-ticks 4] [--max-wall 3600] [--cadence "15m"]
                                 [--no-claude] [--no-verify] [--complete-on-pass] [--no-drain] [--json]
                        (bare run prompts for mission + owner; --due runs the saved queue)
+                       (mission-run completions seed the next visible goal: decide and start the next useful mission)
   atris mission complete <id> --proof "..."
   atris mission stop <id> [--pause] [--reason "..."]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.30.3",
+  "version": "3.30.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.30.3",
+      "version": "3.30.4",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.30.3",
+  "version": "3.30.4",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -527,6 +527,51 @@ test('mission run with an objective starts a visible-goal mission', () => {
   }
 });
 
+test('completed mission run seeds the next useful goal', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const run = runCli([
+      'mission',
+      'run',
+      'ship fuzzy intent',
+      '--owner',
+      'mission-lead',
+      '--verify',
+      'node -e "process.exit(0)"',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const started = JSON.parse(run.stdout);
+    assert.equal(started.mission.started_from, 'mission_run_objective');
+    assert.equal(started.mission.continue_on_complete, true);
+
+    const tick = runCli(['mission', 'tick', started.mission.id, '--verify', '--complete-on-pass', '--json'], { cwd: dir });
+    assert.equal(tick.status, 0, tick.stderr || tick.stdout);
+    const payload = JSON.parse(tick.stdout);
+    assert.equal(payload.mission.status, 'complete');
+    assert.equal(payload.continuation_goal.inserted, true);
+    assert.equal(payload.continuation_goal.mission.started_from, 'mission_run_continuation');
+    assert.equal(payload.continuation_goal.mission.parent_mission_id, started.mission.id);
+    assert.equal(
+      payload.continuation_goal.mission.objective,
+      'Decide and start the next useful mission after: ship fuzzy intent',
+    );
+    assert.equal(payload.codex_goal_state.action, 'codex_goal_candidate');
+    assert.equal(payload.codex_goal_state.goal.mission_id, payload.continuation_goal.mission.id);
+    assert.equal(payload.codex_goal_state.goal.objective, payload.continuation_goal.mission.objective);
+
+    const goal = runCli(['mission', 'goal', '--json'], { cwd: dir });
+    assert.equal(goal.status, 0, goal.stderr || goal.stdout);
+    const goalPayload = JSON.parse(goal.stdout);
+    assert.equal(goalPayload.action, 'codex_goal_candidate');
+    assert.equal(goalPayload.goal.mission_id, payload.continuation_goal.mission.id);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('bare mission run asks for input instead of resuming an old mission', () => {
   const dir = makeTempDir();
   try {

--- a/test/repo-shape.test.js
+++ b/test/repo-shape.test.js
@@ -30,7 +30,7 @@ test('npm package includes runtime workspace templates', () => {
 });
 
 test('npm package metadata matches the reviewed release version', () => {
-  assert.equal(packageJson.version, '3.30.3');
+  assert.equal(packageJson.version, '3.30.4');
   assert.equal(packageLock.version, packageJson.version);
   assert.equal(packageLock.packages[''].version, packageJson.version);
 });


### PR DESCRIPTION
## What changed
- `atris mission run "..."` now marks fuzzy-intent missions as continuation-capable.
- When one of those missions completes, Atris seeds a new visible Codex goal: `Decide and start the next useful mission after: ...`.
- The child mission points the operator/agent at the next command: `atris mission run "<next useful mission>" --owner <owner>`.

## Why
This makes `atris mission run` behave like the magic button: run a fuzzy mission, prove it, then keep the next visible goal alive instead of going dormant.

## Proof
- `node -c commands/mission.js && git diff --check`
- `node --test test/mission-status.test.js test/check-command-regression.test.js test/repo-shape.test.js` passed 52/52
- `node scripts/check-command-regression.js` passed with no regressions vs `atris@latest`
- `npm run publish:release -- --dry-run` passed for `atris@3.30.4`

## Notes
The continuation child is a planner goal, not an infinite auto-spawn. It asks Atris/Codex to decide and start the next useful mission, or stop when no useful next mission remains.