### PR TITLE
Auto-complete continuation planner on next mission

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -872,6 +872,61 @@ function findActiveContinuationMission(parent, root = process.cwd()) {
   )) || null;
 }
 
+function findActiveMissionRunContinuation(root = process.cwd(), excludeId = '') {
+  const excluded = String(excludeId || '');
+  const candidates = listMissions(root)
+    .filter((mission) => (
+      mission.id !== excluded
+      && mission.started_from === 'mission_run_continuation'
+      && mission.continuation_policy === 'choose_next_mission'
+      && !TERMINAL_STATUSES.has(mission.status)
+    ));
+  candidates.sort((a, b) => missionSortTime(b) - missionSortTime(a));
+  return candidates[0] || null;
+}
+
+function completeActiveContinuationForStartedMission(nextMission, root = process.cwd()) {
+  const continuation = findActiveMissionRunContinuation(root, nextMission?.id);
+  if (!continuation || !nextMission) return null;
+  if (continuation.objective === nextMission.objective) return null;
+
+  const proof = `Started next mission ${nextMission.id}: ${nextMission.objective}`;
+  const completionGate = { ok: true, source: 'mission_run_continuation', forced: false };
+  const baseNext = {
+    ...continuation,
+    status: 'complete',
+    completed_at: stampIso(),
+    proof,
+    completion_gate: completionGate,
+    continued_by_mission_id: nextMission.id,
+    continued_by_objective: nextMission.objective,
+    next_action: 'mission complete',
+  };
+  const completion = missionCompletionReceipt(baseNext, proof);
+  const { mission: saved } = saveMission({
+    ...baseNext,
+    landing: completion.landing,
+    result: completion.result,
+  }, root, 'mission_continuation_completed', {
+    proof,
+    continued_by_mission_id: nextMission.id,
+    continued_by_objective: nextMission.objective,
+  });
+  appendMemberLog(saved.owner, 'Mission continuation completed', {
+    mission: saved.objective,
+    continued_by: nextMission.id,
+    proof,
+  }, root);
+  return {
+    completed: true,
+    mission: saved,
+    continued_by: {
+      mission_id: nextMission.id,
+      objective: nextMission.objective,
+    },
+  };
+}
+
 function seedMissionRunContinuation(parent, root = process.cwd(), proof = '') {
   if (!parent || parent.status !== 'complete') return null;
   if (parent.continue_on_complete !== true) return null;
@@ -1032,6 +1087,7 @@ function startMissionFromRunObjective(objective, args) {
     verifier: saved.verifier,
   });
   const worktreeBaseline = captureMissionWorktreeBaseline(saved, process.cwd());
+  const completedContinuationGoal = completeActiveContinuationForStartedMission(saved, process.cwd());
   const codexGoalState = refreshCodexGoalController(process.cwd());
   printJsonOrText(
     {
@@ -1047,6 +1103,7 @@ function startMissionFromRunObjective(objective, args) {
         dirty_count: worktreeBaseline.dirty_count,
         dirty_hash: worktreeBaseline.dirty_hash,
       } : null,
+      completed_continuation_goal: completedContinuationGoal,
       codex_goal_state: codexGoalState,
       next_command: codexGoalState.goal?.next_command || `atris mission tick ${saved.id} --verify`,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.30.4",
+      "version": "3.30.5",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.30.4",
+  "version": "3.30.5",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -567,6 +567,29 @@ test('completed mission run seeds the next useful goal', () => {
     const goalPayload = JSON.parse(goal.stdout);
     assert.equal(goalPayload.action, 'codex_goal_candidate');
     assert.equal(goalPayload.goal.mission_id, payload.continuation_goal.mission.id);
+
+    const next = runCli([
+      'mission',
+      'run',
+      'make the next mission real',
+      '--owner',
+      'mission-lead',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(next.status, 0, next.stderr || next.stdout);
+    const nextPayload = JSON.parse(next.stdout);
+    assert.equal(nextPayload.mission.objective, 'make the next mission real');
+    assert.equal(nextPayload.completed_continuation_goal.completed, true);
+    assert.equal(nextPayload.completed_continuation_goal.mission.id, payload.continuation_goal.mission.id);
+    assert.equal(nextPayload.completed_continuation_goal.mission.status, 'complete');
+    assert.equal(nextPayload.completed_continuation_goal.mission.continued_by_mission_id, nextPayload.mission.id);
+    assert.equal(nextPayload.codex_goal_state.goal.mission_id, nextPayload.mission.id);
+
+    const continuationStatus = runCli(['mission', 'status', payload.continuation_goal.mission.id, '--json'], { cwd: dir });
+    assert.equal(continuationStatus.status, 0, continuationStatus.stderr || continuationStatus.stdout);
+    const continuationPayload = JSON.parse(continuationStatus.stdout);
+    assert.equal(continuationPayload.missions[0].status, 'complete');
+    assert.equal(continuationPayload.missions[0].continued_by_mission_id, nextPayload.mission.id);
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/repo-shape.test.js
+++ b/test/repo-shape.test.js
@@ -30,7 +30,7 @@ test('npm package includes runtime workspace templates', () => {
 });
 
 test('npm package metadata matches the reviewed release version', () => {
-  assert.equal(packageJson.version, '3.30.4');
+  assert.equal(packageJson.version, '3.30.5');
   assert.equal(packageLock.version, packageJson.version);
   assert.equal(packageLock.packages[''].version, packageJson.version);
 });


### PR DESCRIPTION
## What changed
- When `atris mission run "<next intent>"` starts a new mission while an active mission-run continuation planner exists, Atris now completes that planner automatically.
- The completed planner stores `continued_by_mission_id` and `continued_by_objective`, so the chain is inspectable.
- The run JSON includes `completed_continuation_goal`, and the visible-goal candidate moves to the newly started mission.

## Why
This removes the manual cleanup gap in the magic-button loop: parent mission completes -> planner goal appears -> next fuzzy mission starts -> planner goal lands automatically.

## Proof
- `node -c commands/mission.js && git diff --check`
- `node --test test/mission-status.test.js test/check-command-regression.test.js test/repo-shape.test.js` passed 52/52
- `node scripts/check-command-regression.js` passed with no regressions vs `atris@latest`
- `npm run publish:release -- --dry-run` passed for `atris@3.30.5`