### PR TITLE
Make mission run accept member or fuzzy intent

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -10,6 +10,8 @@ const {
   resolveClaudeRunnerBin,
 } = require('../lib/runner-command');
 const {
+  FUNCTIONAL_MEMBER_TOPICS,
+  listWorkspaceMemberSlugs,
   normalizeOwnerSlug,
   resolveFunctionalOwner,
 } = require('../lib/functional-owner');
@@ -142,19 +144,48 @@ function printJsonOrText(payload, lines, asJson) {
   for (const line of lines) console.log(line);
 }
 
-function missionRunInputRequired(asJson = false) {
+const MISSION_RUN_VALUE_FLAGS = [
+  '--max-ticks',
+  '--max-wall',
+  '--cadence',
+  '--owner',
+  '--runner',
+  '--lane',
+  '--verify',
+  '--stop',
+  '--model',
+];
+const MISSION_RUN_BOOLEAN_FLAGS = [
+  '--json',
+  '--due',
+  '--no-claude',
+  '--no-verify',
+  '--complete-on-pass',
+  '--no-drain',
+  '--always-on',
+  '--xp-task',
+  '--agent-xp',
+];
+const DEFAULT_MISSION_RUN_OWNER_SLUGS = new Set(
+  FUNCTIONAL_MEMBER_TOPICS.map(topic => normalizeOwnerSlug(topic.owner)),
+);
+
+function missionRunInputRequired(asJson = false, owner = '') {
+  const defaultOwner = normalizeOwnerSlug(owner || process.env.ATRIS_AGENT_ID || 'mission-lead') || 'mission-lead';
   const payload = {
     ok: false,
     action: 'mission_input_required',
     prompt: 'What mission should Atris run?',
+    owner: defaultOwner,
     owner_prompt: 'Which team member should own it?',
-    example: 'atris mission run "make onboarding magical" --owner mission-lead',
+    example: `atris mission run "make onboarding magical" --owner ${defaultOwner}`,
   };
   if (asJson) {
     console.log(JSON.stringify(payload, null, 2));
   } else {
     console.error('What mission should Atris run?');
-    console.error('Try: atris mission run "make onboarding magical" --owner mission-lead');
+    if (defaultOwner) console.error(`Team member: ${defaultOwner}`);
+    console.error(`Try: atris mission run "make onboarding magical" --owner ${defaultOwner}`);
   }
   process.exit(1);
 }
@@ -176,6 +207,38 @@ function removeValueFlag(args, name) {
     out.push(args[i]);
   }
   return out;
+}
+
+function missionRunOwnerRef(ref, root = process.cwd()) {
+  const owner = normalizeOwnerSlug(ref);
+  if (!owner || /\s/.test(String(ref || ''))) return null;
+  if (listWorkspaceMemberSlugs(root).has(owner)) return owner;
+  if (DEFAULT_MISSION_RUN_OWNER_SLUGS.has(owner)) return owner;
+  return null;
+}
+
+function missionRunArgsWithOwner(args, owner) {
+  return [...removeValueFlag(args, '--owner'), '--owner', owner];
+}
+
+function missionRunInputFromArgs(args, root = process.cwd()) {
+  const positionals = stripKnownFlags(args, MISSION_RUN_VALUE_FLAGS, MISSION_RUN_BOOLEAN_FLAGS);
+  const explicitOwner = Boolean(readFlag(args, '--owner', ''));
+  if (!explicitOwner && positionals.length > 0) {
+    const owner = missionRunOwnerRef(positionals[0], root);
+    if (owner) {
+      return {
+        ref: positionals.slice(1).join(' ').trim(),
+        args: missionRunArgsWithOwner(args, owner),
+        owner,
+      };
+    }
+  }
+  return {
+    ref: positionals.join(' ').trim(),
+    args,
+    owner: readFlag(args, '--owner', ''),
+  };
 }
 
 async function promptMissionRunInput(args) {
@@ -2368,17 +2431,15 @@ async function runMission(args) {
   const maxTicks = Math.max(1, Number(maxTicksFlag) || MISSION_RUN_DEFAULTS.maxTicks);
   const maxWallSeconds = Math.max(60, Number(readFlag(args, '--max-wall', '')) || MISSION_RUN_DEFAULTS.maxWallSeconds);
   const cadenceOverride = readFlag(args, '--cadence', '');
-  const ref = stripKnownFlags(
-    args,
-    ['--max-ticks', '--max-wall', '--cadence', '--owner', '--runner', '--lane', '--verify', '--stop', '--model'],
-    ['--json', '--due', '--no-claude', '--no-verify', '--complete-on-pass', '--no-drain', '--always-on', '--xp-task', '--agent-xp'],
-  ).join(' ').trim();
+  const input = missionRunInputFromArgs(args);
+  const ref = input.ref;
+  const runArgs = input.args;
 
   if (!dueMode && !ref) {
     if (asJson || !process.stdin.isTTY || !process.stderr.isTTY) {
-      missionRunInputRequired(asJson);
+      missionRunInputRequired(asJson, input.owner);
     }
-    const prompted = await promptMissionRunInput(args);
+    const prompted = await promptMissionRunInput(runArgs);
     startMissionFromRunObjective(prompted.objective, prompted.args);
     return;
   }
@@ -2392,8 +2453,8 @@ async function runMission(args) {
     );
     return;
   }
-  if (!mission && ref && /\s/.test(ref) && !String(ref).startsWith('mission-')) {
-    startMissionFromRunObjective(ref, args);
+  if (!mission && ref && !String(ref).startsWith('mission-')) {
+    startMissionFromRunObjective(ref, runArgs);
     return;
   }
   if (!mission) {
@@ -3216,9 +3277,9 @@ atris mission - durable goal + loop + owner + proof state
   atris mission goal [--heartbeat] [--json]
   atris mission goal-loop [--max-wall 28800] [--max-iterations 32] [--no-claude] [--json]
   atris mission tick <id> [--verify] [--complete-on-pass] [--summary "..."] [--json]
-  atris mission run ["objective"|id|--due] [--owner <member>] [--max-ticks 4] [--max-wall 3600] [--cadence "15m"]
+  atris mission run ["objective"|<member> ["objective"]|id|--due] [--owner <member>] [--max-ticks 4] [--max-wall 3600] [--cadence "15m"]
                                 [--no-claude] [--no-verify] [--complete-on-pass] [--no-drain] [--json]
-                       (bare run prompts for mission + owner; --due runs the saved queue)
+                       (bare/member-only run prompts; one-word fuzzy intent starts a new visible-goal mission; --due runs the saved queue)
                        (mission-run completions seed the next visible goal: decide and start the next useful mission)
   atris mission complete <id> --proof "..."
   atris mission stop <id> [--pause] [--reason "..."]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.30.5",
+  "version": "3.30.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.30.5",
+      "version": "3.30.6",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.30.5",
+  "version": "3.30.6",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -413,10 +413,10 @@ test('mission action missing lookups are JSON-readable', () => {
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
     const cases = [
-      ['tick', ['mission', 'tick', 'missing-mission', '--json']],
-      ['run', ['mission', 'run', 'missing-mission', '--json']],
-      ['complete', ['mission', 'complete', 'missing-mission', '--proof', 'probe', '--json']],
-      ['stop', ['mission', 'stop', 'missing-mission', '--json']],
+      ['tick', ['mission', 'tick', 'mission-missing', '--json']],
+      ['run', ['mission', 'run', 'mission-missing', '--json']],
+      ['complete', ['mission', 'complete', 'mission-missing', '--proof', 'probe', '--json']],
+      ['stop', ['mission', 'stop', 'mission-missing', '--json']],
     ];
 
     for (const [name, args] of cases) {
@@ -425,14 +425,14 @@ test('mission action missing lookups are JSON-readable', () => {
       assert.equal(result.stderr, '', name);
       assert.deepEqual(JSON.parse(result.stdout), {
         ok: false,
-        error: 'Mission "missing-mission" not found.',
+        error: 'Mission "mission-missing" not found.',
       }, name);
     }
 
-    const humanTick = runCli(['mission', 'tick', 'missing-mission'], { cwd: dir });
+    const humanTick = runCli(['mission', 'tick', 'mission-missing'], { cwd: dir });
     assert.equal(humanTick.status, 1);
     assert.equal(humanTick.stdout, '');
-    assert.match(humanTick.stderr, /Mission "missing-mission" not found\./);
+    assert.match(humanTick.stderr, /Mission "mission-missing" not found\./);
   } finally {
     cleanupTempDir(dir);
   }
@@ -527,6 +527,41 @@ test('mission run with an objective starts a visible-goal mission', () => {
   }
 });
 
+test('mission run accepts one-word fuzzy intent as a new mission', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const run = runCli(['mission', 'run', 'improve', '--json'], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.action, 'mission_run_started');
+    assert.equal(payload.mission.objective, 'improve');
+    assert.equal(payload.mission.runner, 'codex_goal');
+    assert.equal(payload.codex_goal_state.goal.objective, 'improve');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run accepts owner prefix before fuzzy intent', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris', 'team', 'validator'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'atris', 'team', 'validator', 'MEMBER.md'), '# Validator\n', 'utf8');
+
+    const run = runCli(['mission', 'run', 'validator', 'check proof', '--json'], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.action, 'mission_run_started');
+    assert.equal(payload.mission.objective, 'check proof');
+    assert.equal(payload.mission.owner, 'validator');
+    assert.equal(payload.mission.owner_resolution, 'explicit_functional_owner');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('completed mission run seeds the next useful goal', () => {
   const dir = makeTempDir();
   try {
@@ -608,8 +643,26 @@ test('bare mission run asks for input instead of resuming an old mission', () =>
     assert.equal(payload.ok, false);
     assert.equal(payload.action, 'mission_input_required');
     assert.equal(payload.prompt, 'What mission should Atris run?');
+    assert.equal(payload.owner, 'mission-lead');
     assert.equal(payload.owner_prompt, 'Which team member should own it?');
     assert.match(payload.example, /atris mission run "make onboarding magical"/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run with owner only asks for the missing mission', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris', 'team', 'mission-lead'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'atris', 'team', 'mission-lead', 'MEMBER.md'), '# Mission Lead\n', 'utf8');
+
+    const run = runCli(['mission', 'run', 'mission-lead', '--json'], { cwd: dir });
+    assert.equal(run.status, 1);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.action, 'mission_input_required');
+    assert.equal(payload.owner, 'mission-lead');
+    assert.match(payload.example, /--owner mission-lead/);
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/repo-shape.test.js
+++ b/test/repo-shape.test.js
@@ -30,7 +30,7 @@ test('npm package includes runtime workspace templates', () => {
 });
 
 test('npm package metadata matches the reviewed release version', () => {
-  assert.equal(packageJson.version, '3.30.5');
+  assert.equal(packageJson.version, '3.30.6');
   assert.equal(packageLock.version, packageJson.version);
   assert.equal(packageLock.packages[''].version, packageJson.version);
 });


### PR DESCRIPTION
What changed
- atris mission run improve now starts a visible-goal mission from one-word fuzzy intent.
- atris mission run validator "check proof" now treats validator as owner and check proof as the mission.
- atris mission run mission-lead now asks for the missing mission instead of trying to run a missing id.

Proof
- node --test test/mission-status.test.js test/check-command-regression.test.js test/repo-shape.test.js passed 55/55.
- node scripts/check-command-regression.js passed with no command regressions.
- npm run publish:release -- --dry-run passed for atris 3.30.6.
- git diff --check passed.

Watchout
- Explicit missing mission ids should use the mission-* shape; plain words are now treated as fuzzy intent by design.