### PR TITLE
fix: route default ax chat to hosted backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Integrates with any agent.
 
 ```bash
 cd your-project
-ax chat ax --fast
+ax --fast --chat
 ax --fast "hello"
 ax --pro "help me plan this task"
 ax --max "reason through this hard decision"

--- a/ax
+++ b/ax
@@ -598,7 +598,15 @@ function connectorWriteIntent(message) {
 }
 
 function workspaceIntent(message) {
-  return /\b(files?|folders?|repo|workspace|project|directory|tree|read|open|inspect|search|grep|find|locate|where|edit|write|change|modify|patch|fix|test|tests?|build|src|source|code|diff|git|backend|frontend|atris task|atris xp|xp game|career xp|agentxp|todo|map)\b/i.test(message || '');
+  return Boolean(workspaceIntentReason(message));
+}
+
+function workspaceIntentReason(message) {
+  const text = String(message || '');
+  if (/\b(files?|folders?|repo|workspace|project|directory|tree|src|source|code|diff|git|backend|frontend|atris task|atris xp|xp game|career xp|agentxp|todo|map|tests?)\b/i.test(text)) return 'prompt mentions workspace, file, code, or repo terms';
+  if (/(^|\s|["'`])(?:\.{0,2}\/)?[\w.-]+\/[\w./-]+|[\w.-]+\.(?:js|jsx|ts|tsx|mjs|cjs|json|md|py|rb|go|rs|java|css|scss|html|yml|yaml|toml|env|txt)\b/i.test(text)) return 'prompt names a file path or filename';
+  if (/\b(read|open|inspect|search|grep|find|locate|where|edit|write|change|modify|patch|fix|test|build|refactor)\b.*\b(this|file|folder|repo|workspace|project|directory|module|component|package|readme|source|code|branch|suite|build|bug)\b/i.test(text)) return 'prompt asks to operate on workspace material';
+  return '';
 }
 
 function githubWorkspaceIntent(message) {
@@ -608,12 +616,17 @@ function githubWorkspaceIntent(message) {
 }
 
 function resolveRoute(message, options = {}) {
-  if (options.route === 'local' || options.forceLocal) return 'local';
-  if (options.route === 'cloud' || options.forceCloud) return 'cloud';
-  if (githubWorkspaceIntent(message)) return 'local';
-  if (mentionsConnector(message) && !workspaceIntent(message)) return 'cloud';
-  if (workspaceIntent(message)) return 'local';
-  return 'cloud';
+  return routeDecision(message, options).route;
+}
+
+function routeDecision(message, options = {}) {
+  if (options.route === 'local' || options.forceLocal) return { route: 'local', reason: 'explicit --local' };
+  if (options.route === 'cloud' || options.forceCloud) return { route: 'cloud', reason: 'explicit --cloud' };
+  if (githubWorkspaceIntent(message)) return { route: 'local', reason: 'prompt asks for GitHub repo mutation' };
+  const reason = workspaceIntentReason(message);
+  if (mentionsConnector(message) && !reason) return { route: 'cloud', reason: 'connector request uses hosted Atris' };
+  if (reason) return { route: 'local', reason };
+  return { route: 'cloud', reason: 'default hosted chat' };
 }
 
 function shouldPreflightRuntime(route, options = {}, mode = 'fast') {
@@ -1978,7 +1991,7 @@ async function chat(options = {}) {
   if (logger) output.write(`${formatAuxRow('log', formatPathSubject(logger.path, output), output)}\n\n`);
 
   const runtimePreflight = { localReady: false };
-  const ensureRuntimeReady = async (routeForTurn = 'local') => {
+  const ensureRuntimeReady = async (routeForTurn = 'local', decision = {}) => {
     if (!shouldPreflightRuntime(routeForTurn, options, mode)) {
       return true;
     }
@@ -1992,7 +2005,7 @@ async function chat(options = {}) {
       return true;
     }
     output.write(`${formatRuntimeHealth(health, output)}\n\n`);
-    output.write(`${formatBackendHint()}\n`);
+    output.write(`${formatBackendHint({ routeReason: decision.reason, explicitLocal: decision.reason === 'explicit --local' })}\n`);
     output.write(`${formatDoneLine(Date.now() - startedAt)}\n\n`);
     return false;
   };
@@ -2078,8 +2091,11 @@ async function chat(options = {}) {
     }
 
     const pendingTaskPreview = latestPendingTaskPreview(history);
-    const route = pendingTaskPreview ? 'cloud' : resolveRoute(trimmed, { route: options.route });
-    if (!(await ensureRuntimeReady(route))) return false;
+    const decision = pendingTaskPreview
+      ? { route: 'cloud', reason: 'pending approval stays on hosted Atris' }
+      : routeDecision(trimmed, { route: options.route });
+    const route = decision.route;
+    if (!(await ensureRuntimeReady(route, decision))) return false;
     const turnFunction = options.turnFunction || turnFunctionForMode(mode);
     const result = await turnFunction(trimmed, { mode, cwd, history, output, route, business: options.business, verify: options.verify, conversationId });
     if (result.output && !result.output.endsWith('\n')) output.write('\n');
@@ -2137,17 +2153,21 @@ async function chat(options = {}) {
   if (logger) logger.close(0);
 }
 
-function printBackendHint() {
+function printBackendHint(options = {}) {
   console.log('');
-  console.log(formatBackendHint());
+  console.log(formatBackendHint(options));
 }
 
-function backendStartCommand() {
-  return 'Run without --local for hosted chat, or set AX_BACKEND_URL to your AtrisOS backend.';
+function backendStartCommand(options = {}) {
+  if (options.explicitLocal) return 'Start your AtrisOS backend, or retry with --cloud for hosted chat.';
+  return 'Start your AtrisOS backend for local workspace, or retry with --cloud for hosted cloud scratch.';
 }
 
-function formatBackendHint() {
-  return `Local workspace mode needs a running AtrisOS backend:\n${backendStartCommand()}`;
+function formatBackendHint(options = {}) {
+  const lines = ['This requires local workspace mode, but no AtrisOS backend is running.'];
+  if (options.routeReason && !options.explicitLocal) lines.push(`Routed local because ${options.routeReason}.`);
+  lines.push(backendStartCommand(options));
+  return lines.join('\n');
 }
 
 function bufferedOutput() {
@@ -2286,7 +2306,8 @@ async function runSelfTest(options = {}) {
     const text = chunks.join('');
     assertSelfTest(healthCalls === 1, 'offline preflight repeated unexpectedly');
     assertSelfTest(/backend\s+offline/.test(text), 'offline backend status missing');
-    assertSelfTest(/Local workspace mode needs a running AtrisOS backend:/.test(text), 'local backend hint missing');
+    assertSelfTest(/This requires local workspace mode, but no AtrisOS backend is running\./.test(text), 'local backend hint missing');
+    assertSelfTest(/retry with --cloud for hosted chat/.test(text), 'cloud retry hint missing');
     assertSelfTest(!/\/Users\/keshavrao/.test(text), 'local backend hint leaked a developer path');
     assertSelfTest(!/secret-token/.test(text), 'offline preflight leaked error detail');
   }, results, output);
@@ -3011,8 +3032,11 @@ async function main() {
     console.log(formatDoneLine(result.durationMs, creditsFromState(result)));
   } catch (error) {
     console.error(`x ${error.message}`);
-    const shouldShowBackendHint = forceLocal || (prompt && route !== 'cloud' && resolveRoute(prompt, { route: route === 'auto' ? undefined : route }) === 'local');
-    if (shouldShowBackendHint) printBackendHint();
+    const decision = prompt
+      ? routeDecision(prompt, { route: route === 'auto' ? undefined : route })
+      : { route: forceLocal ? 'local' : 'cloud', reason: forceLocal ? 'explicit --local' : 'default hosted chat' };
+    const shouldShowBackendHint = decision.route === 'local';
+    if (shouldShowBackendHint) printBackendHint({ routeReason: decision.reason, explicitLocal: forceLocal || decision.reason === 'explicit --local' });
     process.exit(1);
   }
 }

--- a/ax
+++ b/ax
@@ -17,6 +17,7 @@ const BACKEND = {
   path: '/api/atris2/turn'
 };
 const DEFAULT_BACKEND_BASE = `http://${BACKEND.host}:${BACKEND.port}`;
+const CLOUD_BACKEND_BASE = 'https://api.atris.ai';
 const CODE_FAST = {
   path: '/api/cursor/turn',
   model: 'composer-2-5-fast',
@@ -124,11 +125,11 @@ function formatUsage() {
     '  ax [--max|--fast] --benchmark',
     '',
     'Modes:',
-    '  --max   local workspace agent, highest reasoning, slowest turns',
-    '  --pro   local workspace agent, deeper tool loop',
-    '  --fast  local workspace agent, faster low-latency turns',
+    '  --max   highest reasoning, slowest turns',
+    '  --pro   deeper tool loop',
+    '  --fast  faster low-latency turns',
     '  --code-fast  Atris Code Fast public lane',
-    '  --local force local workspace tools',
+    '  --local force local workspace tools with your own AtrisOS backend',
     '  --cloud force authenticated cloud connectors/chat',
     '  --business <slug>  run tools on that business cloud workspace (EC2)',
     '  --verify <cmd>  gate the turn on this command passing (default: no verifier)',
@@ -209,19 +210,20 @@ function createRunLogger({ cwd = process.cwd(), mode = 'pro', kind = 'play', out
   };
 }
 
-function backendBaseUrl() {
-  return (process.env.AX_BACKEND_URL
+function backendBaseUrl(options = {}) {
+  const explicitBase = process.env.AX_BACKEND_URL
     || process.env.OBELISK_LOCAL_ATRIS2_BACKEND_URL
-    || process.env.OBELISK_ATRIS2_BACKEND_URL
-    || DEFAULT_BACKEND_BASE).replace(/\/$/, '');
+    || process.env.OBELISK_ATRIS2_BACKEND_URL;
+  if (explicitBase) return explicitBase.replace(/\/$/, '');
+  return options.route === 'cloud' ? CLOUD_BACKEND_BASE : DEFAULT_BACKEND_BASE;
 }
 
-function backendUrl() {
-  return new URL(BACKEND.path, backendBaseUrl()).toString();
+function backendUrl(options = {}) {
+  return new URL(BACKEND.path, backendBaseUrl(options)).toString();
 }
 
-function backendPathUrl(pathname) {
-  return new URL(pathname, backendBaseUrl()).toString();
+function backendPathUrl(pathname, options = {}) {
+  return new URL(pathname, backendBaseUrl(options)).toString();
 }
 
 function codeFastBaseUrl() {
@@ -266,10 +268,11 @@ function buildRunProfile(options = {}) {
       reasoning: 'Composer 2.5 fast lane; charges 10 credits per public turn'
     };
   }
-  const route = resolveRoute(options.message || 'doctor', options);
-  const payload = buildPayload(options.message || 'doctor', { mode, cwd, route });
+  const profileMessage = options.message || 'what files are here?';
+  const route = resolveRoute(profileMessage, options);
+  const payload = buildPayload(profileMessage, { mode, cwd, route });
   return {
-    endpoint: backendUrl(),
+    endpoint: backendUrl({ route }),
     mode,
     route,
     model: payload.model,
@@ -302,7 +305,7 @@ function formatRunProfile(profile, options = {}) {
 async function buildRuntimeHealth(options = {}) {
   const healthRes = options.healthRes
     ? await Promise.resolve(options.healthRes)
-    : await requestJson(ATRIS2_HEALTH_PATH, { token: '', timeoutMs: options.timeoutMs || 1500 });
+    : await requestJson(ATRIS2_HEALTH_PATH, { token: '', timeoutMs: options.timeoutMs || 1500, route: options.route || 'local' });
   const data = healthRes.ok && healthRes.data && typeof healthRes.data === 'object' ? healthRes.data : {};
   const models = Array.isArray(data.models) ? data.models : [];
   const fast = models.find(row => row && row.id === 'atris:fast') || null;
@@ -335,7 +338,7 @@ function formatRuntimeHealth(health, options = {}) {
     ['fast', fastReady ? 'ready' : 'not ready'],
     ['approvals', permissionReady ? 'ready' : 'offline'],
   ];
-  if (!backendReachable) rows.push(['fix', 'start local backend, then rerun ax --doctor']);
+  if (!backendReachable) rows.push(['fix', 'local backend offline; use hosted mode or start your AtrisOS backend']);
   return rows.map(([label, value]) => formatAuxRow(label, value, options)).join('\n');
 }
 
@@ -378,17 +381,17 @@ function authUserId() {
   }
 }
 
-function isLoopbackBackend() {
+function isLoopbackBackend(options = {}) {
   try {
-    const parsed = new URL(backendBaseUrl());
+    const parsed = new URL(backendBaseUrl(options));
     return ['127.0.0.1', 'localhost', '::1'].includes(parsed.hostname);
   } catch (_) {
     return false;
   }
 }
 
-function requestJson(pathname, { token = authToken(), timeoutMs = 6000 } = {}) {
-  const url = backendPathUrl(pathname);
+function requestJson(pathname, { token = authToken(), timeoutMs = 6000, route } = {}) {
+  const url = backendPathUrl(pathname, { route });
   const parsed = new URL(url);
   const transport = parsed.protocol === 'https:' ? https : http;
   return new Promise((resolve) => {
@@ -422,8 +425,8 @@ function requestJson(pathname, { token = authToken(), timeoutMs = 6000 } = {}) {
   });
 }
 
-function postJson(pathname, body, { token = authToken(), timeoutMs = 30000 } = {}) {
-  const url = backendPathUrl(pathname);
+function postJson(pathname, body, { token = authToken(), timeoutMs = 30000, route } = {}) {
+  const url = backendPathUrl(pathname, { route });
   const parsed = new URL(url);
   const transport = parsed.protocol === 'https:' ? https : http;
   const postData = JSON.stringify(body || {});
@@ -524,7 +527,7 @@ function cachedIntegrationStatus(options = {}) {
 
 async function buildConnectionContext(options = {}) {
   const token = options.token || authToken();
-  const localStatusUserId = isLoopbackBackend() ? authUserId() : '';
+  const localStatusUserId = isLoopbackBackend({ route: options.route }) ? authUserId() : '';
   const statusPath = localStatusUserId
     ? `${ATRIS2_CONNECTION_STATUS_PATH}?connection_user_id=${encodeURIComponent(localStatusUserId)}`
     : CONNECTION_STATUS_PATH;
@@ -532,9 +535,9 @@ async function buildConnectionContext(options = {}) {
     options.statusRes
       ? Promise.resolve(options.statusRes)
       : localStatusUserId || token
-        ? requestJson(statusPath, { token: localStatusUserId ? '' : token })
+        ? requestJson(statusPath, { token: localStatusUserId ? '' : token, route: options.route })
         : Promise.resolve({ ok: false, data: null }),
-    options.contractRes ? Promise.resolve(options.contractRes) : requestJson(CONNECTION_CAPABILITIES_PATH, { token: '' })
+    options.contractRes ? Promise.resolve(options.contractRes) : requestJson(CONNECTION_CAPABILITIES_PATH, { token: '', route: options.route })
   ]);
   const statusData = statusRes.ok && statusRes.data && typeof statusRes.data === 'object' ? statusRes.data : {};
   const backendStatuses = statusData.statuses && typeof statusData.statuses === 'object' ? statusData.statuses : statusData;
@@ -609,7 +612,13 @@ function resolveRoute(message, options = {}) {
   if (options.route === 'cloud' || options.forceCloud) return 'cloud';
   if (githubWorkspaceIntent(message)) return 'local';
   if (mentionsConnector(message) && !workspaceIntent(message)) return 'cloud';
-  return 'local';
+  if (workspaceIntent(message)) return 'local';
+  return 'cloud';
+}
+
+function shouldPreflightRuntime(route, options = {}, mode = 'fast') {
+  if (options.skipRuntimePreflight || options.turnFunction || options.business || normalizeMode(mode) === 'code-fast') return false;
+  return route !== 'cloud';
 }
 
 function normalizeMode(mode) {
@@ -1323,11 +1332,11 @@ function creditsFromApprovalExecution(response) {
   return Number.isFinite(credits) && credits > 0 ? credits : null;
 }
 
-async function postApprovalExecution(approvalRequest, { model = 'atris:fast', token = authToken() } = {}) {
+async function postApprovalExecution(approvalRequest, { model = 'atris:fast', token = authToken(), route = 'cloud' } = {}) {
   return postJson(APPROVAL_EXECUTE_PATH, {
     model,
     approval_request: approvalRequest,
-  }, { token });
+  }, { token, route });
 }
 
 async function executeApprovalRequest(approvalRequest, {
@@ -1716,9 +1725,9 @@ async function postTurn(message, options = {}) {
     || mentionsConnector(message)
     || /\b(can you use|can you access|connected|connections?|integrations?|tools?|capabilities)\b/i.test(message || '');
   const connectionContext = options.connectionContext || (shouldSendConnectionContext
-    ? await buildConnectionContext({ token, localWorkspace: local })
+    ? await buildConnectionContext({ token, localWorkspace: local, route })
     : null);
-  const connectionUserId = !local && isLoopbackBackend() ? authUserId() : '';
+  const connectionUserId = !local && isLoopbackBackend({ route }) ? authUserId() : '';
   const payload = buildPayload(message, { ...options, route, connectionContext, connectionUserId });
   const postData = JSON.stringify(payload);
   const output = options.output || process.stdout;
@@ -1726,7 +1735,7 @@ async function postTurn(message, options = {}) {
   // SSE traffic in between, so the socket-idle timeout needs more headroom.
   const baseTimeoutMs = payload.model === 'atris:max' ? 300000 : payload.model === 'atris:pro' ? 180000 : 60000;
   const timeoutMs = options.business ? Math.max(baseTimeoutMs, 180000) : baseTimeoutMs;
-  const turnUrl = new URL(backendUrl());
+  const turnUrl = new URL(backendUrl({ route }));
   const transport = turnUrl.protocol === 'https:' ? https : http;
   const state = {
     events: [],
@@ -1968,19 +1977,18 @@ async function chat(options = {}) {
   output.write(`${formatHeader({ mode, cwd, chat: true }, output)}\n\n`);
   if (logger) output.write(`${formatAuxRow('log', formatPathSubject(logger.path, output), output)}\n\n`);
 
-  const runtimePreflight = { ready: false };
-  const ensureRuntimeReady = async () => {
-    if (runtimePreflight.ready) return true;
-    if (options.skipRuntimePreflight || options.turnFunction || options.business || normalizeMode(mode) === 'code-fast') {
-      runtimePreflight.ready = true;
+  const runtimePreflight = { localReady: false };
+  const ensureRuntimeReady = async (routeForTurn = 'local') => {
+    if (!shouldPreflightRuntime(routeForTurn, options, mode)) {
       return true;
     }
+    if (runtimePreflight.localReady) return true;
     const startedAt = Date.now();
     const health = options.runtimeHealth
       ? await Promise.resolve(options.runtimeHealth({ mode }))
-      : await buildRuntimeHealth({ timeoutMs: options.preflightTimeoutMs || 1200 });
+      : await buildRuntimeHealth({ timeoutMs: options.preflightTimeoutMs || 1200, route: 'local' });
     if (runtimeReadyForChat(health, mode)) {
-      runtimePreflight.ready = true;
+      runtimePreflight.localReady = true;
       return true;
     }
     output.write(`${formatRuntimeHealth(health, output)}\n\n`);
@@ -2025,7 +2033,7 @@ async function chat(options = {}) {
       return false;
     }
     if (pendingApprovalRequest && normalizeMode(mode) !== 'code-fast' && messageApprovesPendingApproval(trimmed)) {
-      if (!(await ensureRuntimeReady())) return false;
+      if (!(await ensureRuntimeReady('cloud'))) return false;
       const startedAt = Date.now();
       const approvalState = {
         events: [],
@@ -2070,8 +2078,8 @@ async function chat(options = {}) {
     }
 
     const pendingTaskPreview = latestPendingTaskPreview(history);
-    const route = pendingTaskPreview ? 'cloud' : options.route;
-    if (!(await ensureRuntimeReady())) return false;
+    const route = pendingTaskPreview ? 'cloud' : resolveRoute(trimmed, { route: options.route });
+    if (!(await ensureRuntimeReady(route))) return false;
     const turnFunction = options.turnFunction || turnFunctionForMode(mode);
     const result = await turnFunction(trimmed, { mode, cwd, history, output, route, business: options.business, verify: options.verify, conversationId });
     if (result.output && !result.output.endsWith('\n')) output.write('\n');
@@ -2135,11 +2143,11 @@ function printBackendHint() {
 }
 
 function backendStartCommand() {
-  return `cd /Users/keshavrao/arena/atrisos-backend/backend && ATRIS2_ALLOW_LOCAL_WORKSPACE=1 ENVIRONMENT=development ENV=development ../venv/bin/uvicorn main:app --host ${BACKEND.host} --port ${BACKEND.port}`;
+  return 'Run without --local for hosted chat, or set AX_BACKEND_URL to your AtrisOS backend.';
 }
 
 function formatBackendHint() {
-  return `Start backend:\n${backendStartCommand()}`;
+  return `Local workspace mode needs a running AtrisOS backend:\n${backendStartCommand()}`;
 }
 
 function bufferedOutput() {
@@ -2257,6 +2265,7 @@ async function runSelfTest(options = {}) {
     try {
       await chat({
         mode: 'fast',
+        route: 'local',
         cwd: os.tmpdir(),
         input: Readable.from(['hi\n', 'exit\n']),
         output: chatOutput,
@@ -2277,7 +2286,8 @@ async function runSelfTest(options = {}) {
     const text = chunks.join('');
     assertSelfTest(healthCalls === 1, 'offline preflight repeated unexpectedly');
     assertSelfTest(/backend\s+offline/.test(text), 'offline backend status missing');
-    assertSelfTest(/Start backend:/.test(text) && /uvicorn main:app/.test(text), 'start-backend command missing');
+    assertSelfTest(/Local workspace mode needs a running AtrisOS backend:/.test(text), 'local backend hint missing');
+    assertSelfTest(!/\/Users\/keshavrao/.test(text), 'local backend hint leaked a developer path');
     assertSelfTest(!/secret-token/.test(text), 'offline preflight leaked error detail');
   }, results, output);
 
@@ -3001,7 +3011,8 @@ async function main() {
     console.log(formatDoneLine(result.durationMs, creditsFromState(result)));
   } catch (error) {
     console.error(`x ${error.message}`);
-    printBackendHint();
+    const shouldShowBackendHint = forceLocal || (prompt && route !== 'cloud' && resolveRoute(prompt, { route: route === 'auto' ? undefined : route }) === 'local');
+    if (shouldShowBackendHint) printBackendHint();
     process.exit(1);
   }
 }
@@ -3071,6 +3082,7 @@ module.exports = {
   renderStreamingMarkdown,
   renderTerminalMarkdown,
   resolveRoute,
+  shouldPreflightRuntime,
   runBenchmark,
   runSelfTest,
   runtimeReadyForChat,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.30.6",
+  "version": "3.30.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.30.6",
+      "version": "3.30.7",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.30.7",
+  "version": "3.30.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.30.7",
+      "version": "3.30.8",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.30.6",
+  "version": "3.30.7",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.30.7",
+  "version": "3.30.8",
   "main": "bin/atris.js",
   "bin": {
     "atris": "bin/atris.js",

--- a/test/ax.test.js
+++ b/test/ax.test.js
@@ -11,6 +11,8 @@ test('ax routes workspace questions to local Atris 2 tools', () => {
   assert.equal(ax.resolveRoute('what files are here?'), 'local');
   assert.equal(ax.resolveRoute('search src for the input component'), 'local');
   assert.equal(ax.resolveRoute('fix the xp game tests'), 'local');
+  assert.equal(ax.resolveRoute('hi'), 'cloud');
+  assert.equal(ax.resolveRoute('thanks'), 'cloud');
 
   const payload = ax.buildPayload('what files are here?', {
     mode: 'fast',
@@ -108,11 +110,11 @@ test('ax doctor formats runtime readiness without model ids or secrets', async (
 
   assert.equal(offline.backend.reachable, false);
   assert.match(offlineText, /backend\s+offline/);
-  assert.match(offlineText, /start local backend/);
+  assert.match(offlineText, /local backend offline/);
   assert.doesNotMatch(offlineText, modelPattern);
 });
 
-test('ax chat fails fast when the Atris2 backend is offline', async () => {
+test('ax chat fails fast when explicit local mode is offline', async () => {
   const previousAuto = process.env.AX_AUTO_LOG;
   process.env.AX_AUTO_LOG = '0';
   const chunks = [];
@@ -127,6 +129,7 @@ test('ax chat fails fast when the Atris2 backend is offline', async () => {
   try {
     await ax.chat({
       mode: 'fast',
+      route: 'local',
       cwd: os.tmpdir(),
       input: Readable.from(['hi\n', 'exit\n']),
       output,
@@ -148,9 +151,51 @@ test('ax chat fails fast when the Atris2 backend is offline', async () => {
   const text = chunks.join('');
   assert.equal(healthCalls, 1);
   assert.match(text, /backend\s+offline/);
-  assert.match(text, /Start backend:/);
-  assert.match(text, /uvicorn main:app/);
+  assert.match(text, /Local workspace mode needs a running AtrisOS backend:/);
+  assert.match(text, /Run without --local for hosted chat/);
+  assert.doesNotMatch(text, /\/Users\/keshavrao/);
   assert.doesNotMatch(text, /secret-token/);
+});
+
+test('ax chat sends simple default turns to hosted route without local preflight', async () => {
+  const previousAuto = process.env.AX_AUTO_LOG;
+  process.env.AX_AUTO_LOG = '0';
+  const chunks = [];
+  const output = {
+    isTTY: false,
+    write(chunk) {
+      chunks.push(String(chunk));
+      return true;
+    },
+  };
+  let healthCalls = 0;
+  let turnRoute = '';
+  try {
+    await ax.chat({
+      mode: 'fast',
+      cwd: os.tmpdir(),
+      input: Readable.from(['hi\n', 'exit\n']),
+      output,
+      runtimeHealth: async () => {
+        healthCalls += 1;
+        throw new Error('default cloud chat should not preflight local backend');
+      },
+      turnFunction: async (_message, options) => {
+        turnRoute = options.route;
+        options.output.write('Hello.');
+        return { events: [], output: 'Hello.', durationMs: 3 };
+      },
+    });
+  } finally {
+    if (previousAuto === undefined) delete process.env.AX_AUTO_LOG;
+    else process.env.AX_AUTO_LOG = previousAuto;
+  }
+
+  const text = chunks.join('');
+  assert.equal(healthCalls, 0);
+  assert.equal(turnRoute, 'cloud');
+  assert.match(text, /Hello\./);
+  assert.doesNotMatch(text, /backend\s+offline|Start backend|uvicorn/);
 });
 
 test('ax self-test verifies harness invariants without backend calls', async () => {
@@ -381,6 +426,9 @@ test('ax can force local or cloud routing', () => {
   assert.equal(ax.resolveRoute('what is on my calendar?', { route: 'local' }), 'local');
   assert.equal(ax.buildPayload('what is on my calendar?', { route: 'local', cwd: '/tmp/project' }).workspace_path, '/tmp/project');
   assert.equal(ax.buildPayload('what files are here?', { route: 'cloud', cwd: '/tmp/project' }).workspace_path, undefined);
+  assert.equal(ax.backendUrl({ route: 'cloud' }), 'https://api.atris.ai/api/atris2/turn');
+  assert.equal(ax.shouldPreflightRuntime('cloud', {}, 'fast'), false);
+  assert.equal(ax.shouldPreflightRuntime('local', {}, 'fast'), true);
 });
 
 test('ax sends a no-op verify_command unless --verify opts in', () => {

--- a/test/ax.test.js
+++ b/test/ax.test.js
@@ -11,8 +11,14 @@ test('ax routes workspace questions to local Atris 2 tools', () => {
   assert.equal(ax.resolveRoute('what files are here?'), 'local');
   assert.equal(ax.resolveRoute('search src for the input component'), 'local');
   assert.equal(ax.resolveRoute('fix the xp game tests'), 'local');
+  assert.equal(ax.resolveRoute('write to README.md'), 'local');
+  assert.equal(ax.resolveRoute('write a python file'), 'local');
+  assert.equal(ax.resolveRoute('edit package.json'), 'local');
+  assert.equal(ax.resolveRoute('write code in this repo'), 'local');
   assert.equal(ax.resolveRoute('hi'), 'cloud');
   assert.equal(ax.resolveRoute('thanks'), 'cloud');
+  assert.equal(ax.resolveRoute('write an essay about san francisco'), 'cloud');
+  assert.equal(ax.resolveRoute('write a poem about the ocean'), 'cloud');
 
   const payload = ax.buildPayload('what files are here?', {
     mode: 'fast',
@@ -151,8 +157,50 @@ test('ax chat fails fast when explicit local mode is offline', async () => {
   const text = chunks.join('');
   assert.equal(healthCalls, 1);
   assert.match(text, /backend\s+offline/);
-  assert.match(text, /Local workspace mode needs a running AtrisOS backend:/);
-  assert.match(text, /Run without --local for hosted chat/);
+  assert.match(text, /This requires local workspace mode, but no AtrisOS backend is running\./);
+  assert.match(text, /retry with --cloud for hosted chat/);
+  assert.doesNotMatch(text, /\/Users\/keshavrao/);
+  assert.doesNotMatch(text, /secret-token/);
+});
+
+test('ax chat explains auto-local route reason when local backend is offline', async () => {
+  const previousAuto = process.env.AX_AUTO_LOG;
+  process.env.AX_AUTO_LOG = '0';
+  const chunks = [];
+  const output = {
+    isTTY: false,
+    write(chunk) {
+      chunks.push(String(chunk));
+      return true;
+    },
+  };
+  let healthCalls = 0;
+  try {
+    await ax.chat({
+      mode: 'fast',
+      cwd: os.tmpdir(),
+      input: Readable.from(['write a python file\n', 'exit\n']),
+      output,
+      runtimeHealth: async () => {
+        healthCalls += 1;
+        return {
+          schema: 'ax.runtime_health.v1',
+          backend: { ready: false, reachable: false, status: 0, error: 'ECONNREFUSED secret-token' },
+          fast: { ready: false, route_ready: false },
+          permissions: { ready: false },
+        };
+      },
+    });
+  } finally {
+    if (previousAuto === undefined) delete process.env.AX_AUTO_LOG;
+    else process.env.AX_AUTO_LOG = previousAuto;
+  }
+
+  const text = chunks.join('');
+  assert.equal(healthCalls, 1);
+  assert.match(text, /Routed local because prompt mentions workspace, file, code, or repo terms\./);
+  assert.match(text, /retry with --cloud for hosted cloud scratch/);
+  assert.doesNotMatch(text, /Run without --local/);
   assert.doesNotMatch(text, /\/Users\/keshavrao/);
   assert.doesNotMatch(text, /secret-token/);
 });

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -122,7 +122,11 @@ console.log(JSON.stringify({
     const mission = JSON.parse(started.stdout).mission;
     const run = runCli(['mission', 'run', mission.id, '--max-ticks', '1', '--json'], {
       cwd: dir,
-      env: { PATH: `${binDir}:${process.env.PATH}` },
+      env: {
+        PATH: `${binDir}:${process.env.PATH}`,
+        ATRIS_RUNNER_BIN: fakeClaude,
+        ATRIS_CLAUDE_BIN: fakeClaude,
+      },
     });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const payload = JSON.parse(run.stdout);
@@ -901,7 +905,8 @@ test('mission goal emits the Codex goal candidate from mission state', () => {
       set_next_goal: 'use goal.visible_goal: create_goal({ objective: goal.objective }) when no active goal blocks the slot',
       visible_goal_bridge: 'goal.visible_goal',
       platform_requirement: 'Codex runtime must expose replace_goal/set_goal, or allow update_goal({ status: "complete" }) followed by create_goal({ objective }).',
-      runtime_tool_sequence: 'get_goal -> update_goal({ status: "complete" }) after proof -> atris mission goal --json -> create_goal({ objective: goal.objective })',
+      phase_change_refresh: 'before changed follow-up work, run atris mission goal --json and mirror the returned visible goal',
+      runtime_tool_sequence: 'get_goal -> update_goal({ status: "complete" }) after proof or phase change -> atris mission goal --json -> create_goal({ objective: goal.objective })',
       blocked_without_platform_goal_write: true,
       mission_id: mission.id,
     });

--- a/test/repo-shape.test.js
+++ b/test/repo-shape.test.js
@@ -30,7 +30,7 @@ test('npm package includes runtime workspace templates', () => {
 });
 
 test('npm package metadata matches the reviewed release version', () => {
-  assert.equal(packageJson.version, '3.30.6');
+  assert.equal(packageJson.version, '3.30.7');
   assert.equal(packageLock.version, packageJson.version);
   assert.equal(packageLock.packages[''].version, packageJson.version);
 });

--- a/test/repo-shape.test.js
+++ b/test/repo-shape.test.js
@@ -30,7 +30,7 @@ test('npm package includes runtime workspace templates', () => {
 });
 
 test('npm package metadata matches the reviewed release version', () => {
-  assert.equal(packageJson.version, '3.30.7');
+  assert.equal(packageJson.version, '3.30.8');
   assert.equal(packageLock.version, packageJson.version);
   assert.equal(packageLock.packages[''].version, packageJson.version);
 });


### PR DESCRIPTION
## Summary
- default simple ax turns now route to hosted Atris instead of localhost
- explicit --local still uses local workspace mode, with no developer path leak
- bumps npm package to 3.30.7 for customer release

## Proof
- node --test test/ax.test.js && node --check ax && AX_AUTO_LOG=0 node ax --self-test
- node -c commands/mission.js && node --test test/mission-status.test.js test/check-command-regression.test.js test/repo-shape.test.js && node scripts/check-command-regression.js && npm run publish:release -- --dry-run
- npm pack -> clean temp install -> ax --fast hi: PASS, no backend offline / Start backend / uvicorn / dev path