### PR TITLE
[codex] Standardize mission proof landings

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -29,7 +29,7 @@ For details, read `atris/wiki/concepts/owner-computer-model.md` before changing 
 ```bash
 # Core CLI logic
 rg "async function interactiveEntry|async function atrisDevEntry|shouldGatherContext|renderContextGathererPrompt" bin/atris.js lib/context-gatherer.js    # Main entry points: cold-start dispatcher, first-contact context gatherer, legacy natural-language mode
-rg "modelForMode|buildPayload|resolveRoute|formatUsage|normalizeChatCommandArgs|async function chat|postTurn|runAxSpawnCommand|runAxYoutubeCommand|runChatDogfood|extractYoutubeUrl|AX Cloud-First Standard|verify-ax-cloud-standard" ax test/cli-smoke.test.js test/ax.test.js scripts/verify-ax-cloud-standard.js atris/team/codex-executor/MEMBER.md  # ax Atris2 local coding-agent CLI: cloud-first by default, explicit --local workspace opt-in, Fast/Pro modes, SSE streaming, workspace_path, chat subcommand alias, chat history, doctor/help, durable worker spawn aliases, local YouTube URL routing, and safe 25-loop --dogfood-chat checklist
+rg "modelForMode|buildPayload|connectorTurnPolicy|formatApprovalReceipt|formatTaskPreviewRows|resolveRoute|formatUsage|normalizeChatCommandArgs|async function chat|postTurn|runAxSpawnCommand|runAxYoutubeCommand|runChatDogfood|extractYoutubeUrl|AX Cloud-First Standard|verify-ax-cloud-standard" ax test/cli-smoke.test.js test/ax.test.js scripts/verify-ax-cloud-standard.js atris/team/codex-executor/MEMBER.md  # ax Atris2 local coding-agent CLI: cloud-first by default, explicit --local workspace opt-in, Fast/Pro modes, SSE streaming, workspace_path, chat subcommand alias, chat history, connector turn isolation, Gmail approval previews, doctor/help, durable worker spawn aliases, local YouTube URL routing, and safe 25-loop --dogfood-chat checklist
 rg "atrisFastChat|atrisFastOnce|streamProChat|text_delta|Usage: atris fast" bin/atris.js utils/api.js test/commands.test.js test/api-stream.test.js  # Atris2 Fast one-shot chat CLI and SSE text_delta streaming
 rg "brainstormAtris|Usage: atris brainstorm|brainstorm help" commands/brainstorm.js test/commands.test.js  # Brainstorm command + workspace-free help
 rg "function planAtris" commands/workflow.js   # Plan command (line 66)
@@ -75,7 +75,7 @@ rg "computerCreate|computerActivate|computerDelete|parseComputerCreateArgs|parse
 rg "cmdAdd|cmdImport|cmdClaim|cmdReady|cmdAccept|cmdReviews|cmdDone|cmdNext|readEndgameAgentAction|liveTaskWithTitle|getTaskDb" commands/task.js  # Local agent task plane, proof-ready review, human accept, task-next Endgame seed dedupe, and compact certified review queue
 rg "taskReviewEvidenceCommands|taskReviewVerificationFocus|taskReviewObjective|commands_to_verify" commands/task.js test/commands.test.js  # Task review-chat verifier packet: extracts proof commands/files, uses task-owned objective/title instead of stale workspace goal fallback, and regression coverage
 rg "worktreeCommand|startWorktree|shipWorktree|parseWorktrees|swarloClaim" commands/worktree.js  # Member-scoped isolated Git worktrees, optional Swarlo claim, and guarded ship flow
-rg "missionCommand|lintMissionVerifier|normalizeMissionState|selectCodexGoalMission|selectDueMission|missionIsRunnable|codex_goal.json|codex_goal_request.json|active_goal_conflict|paused_goal_conflict|native-goal-status|codexRuntimeGoalStateFromOptions|writeDirectRunCodexGoalRequest|codexGoalActiveConflictPayload|runMission|tickMission|watchMission|missionHeartbeatLines|inferRunObjectiveLoopOptions|budget_contract|spend-full-budget|overnight_loop|choose_next_mission|missionChoosesNextMission|chooseNextMissionTarget|continuationTargetKey|handledContinuationTargetKeys|chooseNextMissionCommand|ackMissionGoal|attachMissionTask|acquireMissionLock" commands/mission.js test/mission-verifier.test.js test/mission-status.test.js test/mission-heartbeat.test.js  # Durable mission start/status/Codex-goal/tick/run plus direct-run visible-goal conflict handoff, paused native-goal reconciliation, verifier lint/status filters, runnable mission selection that skips human-gated missions, task-backed caller-session due picks, time budget contracts, overnight/self-improve run-objective inference, continuation-goal state-backed next-mission selection and handoff commands with stale handled-target filtering, native-goal ack/task-spine race locking, and terminal next-action normalization
+rg "missionCommand|lintMissionVerifier|normalizeMissionState|selectCodexGoalMission|selectDueMission|missionIsRunnable|missionTaskHumanAcceptWaiting|missionCanSeedContinuation|seedNextMoveContinuationGoal|missionMemberTasteProfile|readMissionTasteMemory|missionValuePreview|chooseNextMissionPlan|buildMissionGoalChain|advanceMissionGoalChain|missionGoalChainLines|missionGoalChainNextAction|missionReceiptLanding|normalizeMissionReceiptResult|missionVerifierHighLevelTestText|codex_goal.json|codex_goal_request.json|active_goal_conflict|paused_goal_conflict|native-goal-status|codexRuntimeGoalStateFromOptions|writeDirectRunCodexGoalRequest|codexGoalActiveConflictPayload|runMission|tickMission|watchMission|missionHeartbeatLines|inferRunObjectiveLoopOptions|budget_contract|spend-full-budget|overnight_loop|choose_next_mission|missionChoosesNextMission|chooseNextMissionTarget|continuationTargetKey|handledContinuationTargetKeys|chooseNextMissionCommand|ackMissionGoal|attachMissionTask|acquireMissionLock" commands/mission.js test/mission-verifier.test.js test/mission-status.test.js test/mission-heartbeat.test.js  # Durable mission start/status/Codex-goal/tick/run plus direct-run visible-goal conflict handoff, validated child-goal chains, default result.landing receipts with high-level verifier meaning, paused native-goal reconciliation, verifier lint/status filters, runnable mission selection that skips human-gated missions, task-backed caller-session due picks, time budget contracts, overnight/self-improve run-objective inference, continuation-goal state-backed next-mission selection with member taste filters, taste memory from thinking.md/member MISSION/recent logs/task history, Feynman previews, planning/review certified continuation seeding, stale completed-handoff skip, native-goal ack/task-spine race locking, and terminal next-action normalization
 rg "timelineMission|missionLandingTimeline|missionTimelineMarkdown|missionTimelinePruneSummaryMarkdown|schema_display|summary_display|navigation_display|filter_display|empty_state_display|timeline_meta_display|timeline_meta|timeline_display|proof_display|receipt_display|export_display|prune_display|actions_display|status_display|artifact_display|operator_commands|commands|mission_labels|mission_display|display|labels|counts|booleans|artifact|current_landing_display|current_landing|current_landing_label|history_label|history_without_current_display|history_without_current|history_without_current_count|has_history_without_current|next_move|next|generated_at|generated|prune_preview" commands/mission.js test/mission-status.test.js lib/runs-prune.js  # Mission timeline: saved landing list, schema display, summary display, navigation display, filter display, empty-state display, truncation metadata/display, timeline display items, proof display, receipt display, export display, prune display, actions display, status display, artifact display, mission labels/display, display copy, commands/labels/counts/booleans/artifact/generated/next/current-landing/history objects, current landing label, duplicate-free history label/count/toggle, next move, operator commands, markdown export, generated timestamp, full-history --all, and automatic prune dry-run summary
 rg "buildMissionRoom|chat_zone|task_plan_preview|member_route|timeline_preview|result.landing|writeThinkingMemory|collectMissionRoomContext|proactive_next_mission|missionName|Mission Room landing" lib/mission-room.js commands/mission.js scripts/verify-mission-room.js test/mission-status.test.js atris/thinking.md # Mission Room: messy input -> chat zone first, task-first preview, editable member route, human timeline preview, real business-move naming, logs/thinking context, pending result.landing, approval packet, landing-style verifier, receipt
 rg "Ship Cash Proof Mission Room|verify-ship-cash-proof-mission-room|one-screen Mission Room proof|What Keshav Approves" atris/reports/2026-06-30-ship-cash-proof-mission-room.md scripts/verify-ship-cash-proof-mission-room.js # Cash Proof Mission Room: one-screen approval landing, no-send boundary, linked Mission Room receipt, verifier
@@ -110,8 +110,8 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 **Purpose:** Universal entry point - accepts any input and routes intelligently
 
 - **Entry point:** `bin/atris.js:922-933` (knownCommands dispatch)
-- **Cold-start handler:** `bin/atris.js:1024` (`interactiveEntry`; active missions/work outrank completed history)
-- **Legacy handler:** `bin/atris.js:2868` (`atrisDevEntry` function)
+- **Cold-start handler:** `bin/atris.js:1035` (`interactiveEntry`; active missions/work outrank completed history)
+- **Legacy handler:** `bin/atris.js:2920` (`atrisDevEntry` function)
 - **Regression:** `test/commands.test.js:4974-4987` covers parseable JSON errors for unknown top-level commands
 - **How it works:**
 - No args → Cold start (shows context, waits for input)
@@ -533,7 +533,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 - `--verbose` / `-v`: Legacy visual task board
 - `--quick` / `-q`: One-line emoji summary
 - `--json`: Structured JSON (date, backlog, inProgress, completed, inbox, completions, lessons, team)
-- **Routing:** `bin/atris.js:1915-1919` (`statusCmd` local path), `bin/atris.js:1461-1465` routes slug status to `commands/context-sync.js:55` (`businessStatus`)
+- **Routing:** `bin/atris.js:1967-1971` (`statusCmd` local path), `bin/atris.js:1461-1465` routes slug status to `commands/context-sync.js:55` (`businessStatus`)
 - **Value:** Parallel work visibility + machine-readable output for scripting
 
 **Search:** `rg "statusAtris|showStatusHelp|status and analytics --help" bin/atris.js commands/status.js test/commands.test.js`
@@ -941,7 +941,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 
 **Purpose:** Install latest Atris version from npm
 
-- **Entry point:** `bin/atris.js:2266-2318` (upgradeAtris function)
+- **Entry point:** `bin/atris.js:2318-2370` (upgradeAtris function)
 - **Dispatch/help:** `bin/atris.js:1432-1438` handles `upgrade --help` before npm checks or global installs
 - **Logic:**
 - Shows current version
@@ -992,7 +992,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 
 **Purpose:** Real-time conversation with selected agent
 
-- **Entry point:** `bin/atris.js:2559-2616` (chatAtris function)
+- **Entry point:** `bin/atris.js:2611-2668` (chatAtris function)
 - **Requires:** Valid credentials + selected agent
 - **Modes:**
 - One-shot: `atris chat "message"`
@@ -1072,7 +1072,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 
 **Purpose:** Auto-advance to next workflow step based on journal state
 
-- **Entry point:** `bin/atris.js:1024` (interactiveEntry function)
+- **Entry point:** `bin/atris.js:1035` (interactiveEntry function)
 - **Help:** `bin/atris.js:689-699` (`showNextHelp`) and `bin/atris.js:1366-1373` route `next --help` before `interactiveEntry`
 - **Regression:** `test/commands.test.js:4310-4324` covers next help without context panels or temp state creation
 - **Logic:** Same as natural language entry - loads context, detects state, advances
@@ -1121,7 +1121,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
-- **Entry point:** `bin/atris.js:1024` (`interactiveEntry`)
+- **Entry point:** `bin/atris.js:1035` (`interactiveEntry`)
 - **Helper:** `lib/context-gatherer.js`
 - **State:** `.atris/state/context_profile.json`
 - **Regression:** `test/context-gatherer.test.js`, `test/cli-smoke.test.js`

--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -63,6 +63,7 @@ rg "verifyAtris|verifyRubric|showVerifyHelp|verify --help" bin/atris.js commands
 rg "serveAtris|showServeHelp|command === 'serve'" bin/atris.js commands/serve.js test/commands.test.js  # Local AI Computer bridge routing + help guard
 rg "ensureNowFile|renderDefaultNow|renderPortfolioNow|countOpenWorkItems|countOpenTodoItems|countJournalCompletedReceipts|now --help" bin/atris.js commands/now.js test/now.test.js test/commands.test.js  # now.md front door: local date, projection-backed open work counts, proof receipts, portfolio signals, non-mutating help
 rg "radarCommand|collectRadar|Operator radar|Agent process top|findTaskWorkspaceRoot|task_reason|task_action|task_load|whats going on|loadBusinessCollaboration|ctop" commands/radar.js bin/atris.js test/radar.test.js test/commands.test.js  # Live Atris OS radar: agent processes joined with nearest workspace task projection, ctop unmapped-session reasons/actions and task-load pileups, mission/loop, worktree, AgentXP, team/member, business collaboration readiness, brain scorecard, Swarlo/delegation, and Codex goal state
+rg "launchpadCommand|collectLaunchpad|chooseNextAction|renderLaunchpad|suggestedNextMoves|taskNeedsAgentReview|taskIsHumanGatedClaimed|atris.launchpad.v1" commands/launchpad.js bin/atris.js test/commands.test.js  # Launchpad command-center card: single next action + 3 suggested moves from local task projection, missions, brain STATUS, and TODO endgame; ranks own-claimed > mission tick > proof review > human-accept queue > open claim > endgame seed > brain move; skips human-gated claimed work; --json (atris.launchpad.v1) and plain card
 rg "releaseAtris" commands/release.js      # Release command
 rg "showSearchHelp|searchJournal|search help flags" bin/atris.js test/commands.test.js # Search command + workspace-free help flags
 rg "showLearnHelp|learnAtris|learn help" commands/learn.js test/commands.test.js # Project learnings command + workspace-free help
@@ -536,6 +537,21 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing" atris/po
 - **Value:** Parallel work visibility + machine-readable output for scripting
 
 **Search:** `rg "statusAtris|showStatusHelp|status and analytics --help" bin/atris.js commands/status.js test/commands.test.js`
+
+### Feature: Launchpad (`atris launchpad`)
+
+**Purpose:** One compact command-center card — the single next action plus 3 suggested moves — synthesized from local task, mission, brain, and proof state
+
+- **Entry point:** `commands/launchpad.js:620` (`launchpadCommand`) routes `--help`/`--json`/plain card
+- **Collector:** `commands/launchpad.js:426` (`collectLaunchpad`) reads the task projection, active missions, brain STATUS next move, and TODO endgame; emits `schema: atris.launchpad.v1`
+- **Ranking:** `commands/launchpad.js:201` (`chooseNextAction`) — own-claimed task > mission needing a tick > proof needing agent review > certified human-accept queue > open claim > endgame seed > brain next move > ask-for-work; `taskIsHumanGatedClaimed` skips claimed work gated on human accept
+- **Suggestions:** `commands/launchpad.js:373` (`suggestedNextMoves`) returns up to 3 plain-language moves
+- **Render:** `commands/launchpad.js:575` (`renderLaunchpad`) draws the ASCII card; `commands/launchpad.js:609` (`showLaunchpadHelp`)
+- **Help:** `bin/atris.js:464` help line; **Routing:** `bin/atris.js:1856-1857` dispatch, `bin/atris.js:922` `knownCommands`
+- **Regression:** `test/commands.test.js:14965` (actor-claimed first), `test/commands.test.js:15039` (clean queue → endgame seed), `test/commands.test.js:15075` (verifier mission when no claimed task); `--help` smoke at `test/commands.test.js:14915`
+- **Value:** Answers "who is doing what, what needs review, what is blocked, what should start next" in one card without cloud auth
+
+**Search:** `rg "launchpadCommand|collectLaunchpad|chooseNextAction|renderLaunchpad|suggestedNextMoves|atris.launchpad.v1" commands/launchpad.js bin/atris.js test/commands.test.js`
 
 ### Feature: Workspace Cleanup (`atris clean`)
 

--- a/atris/TODO.md
+++ b/atris/TODO.md
@@ -11,10 +11,18 @@
 
 ## Backlog
 
-(Empty)
+- **[CLI-762]** Ship npm auto-update for packaged installs (git checkouts stay manual) [update]
+- **[CLI-761]** Ship ax connector turn isolation and Gmail receipt previews [ax]
+- **[CLI-760]** Close runner-agnostic heartbeat gap: verify autopilot/run use shared runner-command flags [runner]
 
 ## In Progress
 
+- **[CLI-763]** Ship atris launchpad command-center card with tests and MAP entry [launchpad]
+  **Claimed by:** Executor at 2026-07-01T06:43:52.146Z
+- **[CLI-744]** Mission XP: Decide and start the next useful mission after: Make mission-run continuation choose and start a concrete follow-up mission instead of marking choose_next_mission work ready on git diff --check [agent-xp]
+  **Claimed by:** mission-lead
+- **[CLI-742]** Mission XP: Decide and start the next useful mission after: Make atris mission run preflight messy operator input through Mission Room before visible-goal ack, so shower and overnight requests become crisp goals, task spines, receipts, and next actions instead of copying raw messy text into the native goal [agent-xp]
+  **Claimed by:** mission-lead
 - **[CLI-731]** Add timeline filter display object to mission timeline JSON output [loop]
   **Claimed by:** auto-improver
 - **[CLI-573]** Mission XP: work overnight and see where we can self improve. goal after goal nonstop 6 hours [agent-xp]
@@ -22,344 +30,12 @@
 
 ## Review
 
-- **[CLI-739]** Add budgeted mission contract judge to mission run [mission]
-- **[CLI-738]** Mission XP: In five minutes, read the existing Atris mission docs and pick the highest-leverage next move for budgeted mission contracts: a user gives an outcome plus time budget, Atris thinks bottleneck-first, uses tasks/goals/team members, and lands in simple language. [agent-xp]
-- **[CLI-737]** Add explicit paused native goal supersede mode [mission]
-- **[CLI-736]** Expose paused-goal fallback sequence [mission]
-- **[CLI-735]** Emit replace-goal action for paused native-only goals [mission]
-- **[CLI-734]** Emit native replace-goal action for paused mission conflicts [mission]
-- **[CLI-733]** Respect paused native goal in direct mission goal bridge [mission]
-- **[CLI-732]** Fix direct mission run visible-goal bridge conflict [mission]
-- **[CLI-730]** Add timeline navigation display object to mission timeline JSON output [loop]
-- **[CLI-729]** Add timeline summary display object to mission timeline JSON output [loop]
-- **[CLI-728]** Add timeline schema display object to mission timeline JSON output [loop]
-- **[CLI-727]** Add timeline empty-state display object to mission timeline JSON output [loop]
-- **[CLI-726]** Add timeline meta display object to mission timeline JSON output [loop]
-- **[CLI-725]** Add timeline artifact display object to mission timeline JSON output [loop]
-- **[CLI-724]** Add timeline prune display object to mission timeline JSON output [loop]
-- **[CLI-723]** Add timeline export display object to mission timeline JSON output [loop]
-- **[CLI-722]** Add timeline status display object to mission timeline JSON output [loop]
-- **[CLI-721]** Add timeline actions display object to mission timeline JSON output [loop]
-- **[CLI-720]** Add timeline proof display object to mission timeline JSON output [loop]
-- **[CLI-719]** Add timeline item display object to mission timeline JSON output [loop]
-- **[CLI-718]** Add history item display object to mission timeline JSON output [loop]
-- **[CLI-717]** Add current landing display object to mission timeline JSON output [loop]
-- **[CLI-716]** Add display object to mission timeline JSON output [loop]
-- **[CLI-715]** Add mission display object to mission timeline JSON output [loop]
-- **[CLI-714]** Add mission labels object to mission timeline JSON output [loop]
-- **[CLI-713]** Add next object to mission timeline JSON output [loop]
-- **[CLI-712]** Add generated object to mission timeline JSON output [loop]
-- **[CLI-711]** Add artifact object to mission timeline JSON output [loop]
-- **[CLI-710]** Add commands object to mission timeline JSON output [loop]
-- **[CLI-709]** Add booleans object to mission timeline JSON output [loop]
-- **[CLI-708]** Add counts object to mission timeline JSON output [loop]
-- **[CLI-707]** Add labels object to mission timeline JSON output [loop]
-- **[CLI-706]** Add currentlandinglabel to mission timeline JSON output [loop]
-- **[CLI-705]** Add historylabel to mission timeline JSON output [loop]
-- **[CLI-704]** Add hashistorywithoutcurrent to mission timeline JSON output [loop]
-- **[CLI-703]** Add historywithoutcurrentcount to mission timeline JSON output [loop]
-- **[CLI-702]** Add historywithoutcurrent to mission timeline JSON output [loop]
-- **[CLI-701]** Avoid duplicating current landing in terminal history list [loop]
-- **[CLI-700]** Show terminal full-history hint only when timeline is truncated [loop]
-- **[CLI-699]** Add History label to mission timeline terminal output [loop]
-- **[CLI-698]** Add current landing summary to mission timeline terminal output [loop]
-- **[CLI-697]** Add timeline count to mission timeline markdown exports [loop]
-- **[CLI-696]** Add compact timeline count to mission timeline terminal output [loop]
-- **[CLI-695]** Add truncation metadata to mission timeline JSON output [loop]
-- **[CLI-694]** Add nextmove to mission timeline JSON output [loop]
-- **[CLI-693]** Add currentlanding to mission timeline JSON output [loop]
-- **[CLI-692]** Add operator commands to mission timeline JSON output [loop]
-- **[CLI-691]** Add full-history export hint to mission timeline terminal output [loop]
-- **[CLI-690]** Add generated timestamp to mission timeline terminal output [loop]
-- **[CLI-689]** Add generatedat to mission timeline JSON output [loop]
-- **[CLI-688]** Add Generated at line to mission timeline markdown exports [loop]
-- **[CLI-687]** Add Full history heading before mission timeline markdown list [loop]
-- **[CLI-686]** Add Current landing section near top of mission timeline markdown exports [loop]
-- **[CLI-685]** Move Operator commands near top of mission timeline markdown exports [loop]
-- **[CLI-684]** Add Operator commands section to mission timeline markdown exports [loop]
-- **[CLI-683]** Add a Prune preview line to mission run landing [loop]
-- **[CLI-682]** Add mission timeline --prune-preview to expose prune summary without --write [loop]
-- **[CLI-681]** Add compact prune summary to mission timeline JSON output [loop]
-- **[CLI-680]** Show mission timeline --write prune summary in terminal output [loop]
-- **[CLI-679]** Add latest prune dry-run summary to mission timeline markdown exports [loop]
-- **[CLI-678]** Run mission prune-runs dry-run and record the compression summary [loop]
-- **[CLI-677]** Add a prune hint to mission timeline markdown exports [loop]
-- **[CLI-676]** Add an Export line to mission run landing for the full markdown timeline command [loop]
-- **[CLI-675]** Add mission timeline --all so markdown exports can include full landing history [loop]
-- **[CLI-674]** Add a Next move section to mission timeline markdown exports [loop]
-- **[CLI-673]** Add mission timeline --write to save the landing list as a markdown report [loop]
-- **[CLI-672]** Add a mission timeline hint to mission run landing after the proof path [loop]
-- **[CLI-671]** Add a mission timeline command that lists saved landing changed and next lines from mission receipts [loop]
-- **[CLI-670]** Save mission run create-next created or continued task details in the summary receipt [loop]
-- **[CLI-669]** Make mission run create-next changed line mention the created or continued task instead of only the heartbeat [loop]
-- **[CLI-668]** Show the active task in mission run create-next landing when duplicate protection skips creation [loop]
-- **[CLI-667]** Add mission run create-next so a heartbeat can materialize the suggested loop task [loop]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-666]** Add command to create and claim the suggested self-improvement task [loop]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-665]** Make mission run landing use evidence-backed loop seed [mission]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-664]** Make self-improvement seed choose a specific target from evidence [loop]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-663]** Write the overnight self-improvement proof timeline [proof]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-662]** Make mission run landing point at the next self-improvement seed [mission]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-661]** Show a next-task seed when loop status has only the active mission [loop]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-660]** Hide Mission XP bookkeeping from loop next moves [loop]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-659]** Suppress vague dogfood tick inbox placeholders from loop next moves [loop]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-658]** Stop completed inbox ideas reappearing in loop next moves [loop]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-657]** Make task accept landing concise [task-review]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-656]** Make review tested line human-facing [task-review]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-655]** Make review saved line approval-ready [task-review]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-654]** Make review queue why-it-matters specific [task-review]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-653]** Recognize clean dry-run proof text [task-review]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-652]** Allow clean dry-run as review verifier [task-review]
-  **Verify:** node bin/atris.js clean --dry-run --json
-- **[CLI-651]** Heal stale MAP run pointer surfaced by clean [maintenance]
-  **Verify:** git diff --check
-- **[CLI-650]** Limit grouped approval queue by default [task-review]
-  **Verify:** node --test test/commands.test.js
-- **[CLI-649]** Run full regression after overnight proof polish [verify]
-  **Verify:** npm test
-- **[CLI-648]** Make no-summary always-on mission landings honest [mission]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-647]** Make mission tick verifier line human-readable [mission]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-646]** Keep always-on mission tick next action running [mission]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-645]** Make mission tick landing summarize the step [mission]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-644]** Make review landing tested text high-level [task-review]
-  **Verify:** node --test test/commands.test.js
-- **[CLI-643]** Stop review landing from listing proof prose as commands [task-review]
-  **Verify:** node --test test/commands.test.js
-- **[CLI-642]** Stop review proof prose becoming fake verifier commands [task-review]
-  **Verify:** node --test test/commands.test.js
-- **[CLI-641]** Guard recruiting shortcut fallback scope [computer]
-  **Verify:** node --test test/computer-create.test.js
-- **[CLI-640]** Fix recruiting shortcut typed workspace resolution [computer]
-  **Verify:** node --test test/computer-create.test.js
-- **[CLI-639]** Align release tests with current publish gate [tests]
-  **Verify:** node --test test/repo-shape.test.js test/publish-release.test.js
-- **[CLI-638]** Fix context-gatherer duplicate import test failure [tests]
-  **Verify:** node --test test/context-gatherer.test.js
-- **[CLI-637]** Refresh ax self-contained script assertion [ax]
-  **Verify:** node --test test/ax.test.js
-- **[CLI-636]** Align review-output regressions with approval console [review]
-  **Verify:** node --test test/review-lane-auto-review.test.js test/task-receipt-evidence.test.js
-- **[CLI-635]** Keep quoted test-name verifier commands in review proof [review]
-  **Verify:** node --test test/commands.test.js
-- **[CLI-634]** Fix mission XP native-goal ack regression [mission]
-  **Verify:** node --test test/mission-xp.test.js
-- **[CLI-633]** Make command XP copy approval-facing [self-improve]
-  **Verify:** git diff --check
-- **[CLI-632]** Make business handoff XP gate approval-facing [self-improve]
-  **Verify:** git diff --check
-- **[CLI-631]** Limit default review approval console [self-improve]
-  **Verify:** git diff --check
-- **[CLI-630]** Replace ready-to-land review labels [self-improve]
-  **Verify:** git diff --check
-- **[CLI-629]** Make review reason line product-facing [self-improve]
-  **Verify:** git diff --check
-- **[CLI-628]** Make review summary human-facing [cli]
-  **Verify:** git diff --check
-- **[CLI-627]** Make review decision line human-facing [cli]
-  **Verify:** git diff --check
-- **[CLI-626]** Make review saved line product-facing [cli]
-  **Verify:** git diff --check
-- **[CLI-625]** Make default landing result completed [cli]
-  **Verify:** git diff --check
-- **[CLI-624]** Summarize prose-only landing proof checks [cli]
-  **Verify:** git diff --check
-- **[CLI-623]** Show omitted landing proof checks [cli]
-  **Verify:** git diff --check
-- **[CLI-622]** Make review landing checked proof-specific [cli]
-  **Verify:** git diff --check
-- **[CLI-621]** Trim prose after proof commands [cli]
-  **Verify:** git diff --check
-- **[CLI-620]** Trim passed-with proof command tails [cli]
-  **Verify:** git diff --check
-- **[CLI-619]** Number multi-command proof lists [cli]
-  **Verify:** git diff --check
-- **[CLI-618]** Document task reviews --all [cli]
-  **Verify:** git diff --check
-- **[CLI-617]** Trim verbose pass-count explanations [cli]
-  **Verify:** git diff --check
-- **[CLI-616]** Trim proof pass-count tails [cli]
-  **Verify:** git diff --check
-- **[CLI-615]** Render proof commands without pipe ambiguity [task]
-  **Verify:** git diff --check
-- **[CLI-614]** Heal stale MAP refs surfaced by clean [clean]
-  **Verify:** git diff --check
-- **[CLI-613]** Respect quoted pipes in proof commands [task]
-  **Verify:** git diff --check
-- **[CLI-612]** Show MAP refs clean would heal [clean]
-  **Verify:** git diff --check
-- **[CLI-611]** Stop caller-session mission run from sleeping after tick [mission-run]
-  **Verify:** git diff --check
-- **[CLI-610]** Ignore quoted product examples in review command extraction [review-chat]
-  **Verify:** git diff --check
-- **[CLI-609]** Clean redundant next wording in mission report text [mission-report]
-  **Verify:** git diff --check
-- **[CLI-608]** Keep mission report timeline titles one-line [mission-report]
-  **Verify:** git diff --check
-- **[CLI-607]** Keep mission report goal labels clean when summaries already name a goal [mission-report]
-  **Verify:** git diff --check
-- **[CLI-606]** Keep review proof commands from swallowing prose [review-chat]
-  **Verify:** git diff --check
-- **[CLI-605]** Keep always-on mission next action running after verifier pass [mission-goal]
-  **Verify:** git diff --check
-- **[CLI-604]** Expose effective mission verifier in JSON [mission-status]
-  **Verify:** git diff --check
-- **[CLI-603]** Give overnight self-improve missions a default verifier [mission-doctor]
-  **Verify:** git diff --check
-- **[CLI-602]** Keep task review JSON receipts concise [task-review]
-  **Verify:** git diff --check
-- **[CLI-601]** Stop mission report duplicate Goal prefixes [mission-report]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-600]** Refresh team member standard feature docs [members]
-  **Verify:** git diff --check
-- **[CLI-599]** Refresh customer skill zone feature docs [skills]
-  **Verify:** git diff --check
-- **[CLI-598]** Refresh CLI UX validation from current help [cli]
-  **Verify:** git diff --check
-- **[CLI-597]** Refresh wiki feature validation docs [wiki]
-  **Verify:** git diff --check
-- **[CLI-596]** Refresh workspace initialization wiki contract [wiki]
-  **Verify:** git diff --check
-- **[CLI-595]** Batch refresh README-backed wiki pages [wiki]
-  **Verify:** git diff --check
-- **[CLI-594]** Refresh horizon type wiki from autopilot [wiki]
-  **Verify:** git diff --check
-- **[CLI-593]** Refresh agent activation contract from CLAUDE adapter [wiki]
-  **Verify:** git diff --check
-- **[CLI-592]** Refresh Atris business wiki command surface [wiki]
-  **Verify:** git diff --check
-- **[CLI-591]** Refresh Atris CLI wiki command surface from README [wiki]
-  **Verify:** git diff --check
-- **[CLI-590]** Repair recursive self-improvement wiki contract [wiki]
-  **Verify:** git diff --check
-- **[CLI-589]** Add source metadata to glass interface wiki page [wiki]
-  **Verify:** git diff --check
-- **[CLI-588]** Stop Atris Labs protocol brief from self-staling [wiki]
-  **Verify:** git diff --check
-- **[CLI-587]** Heal latest MAP ref drift from clean [map]
-  **Verify:** git diff --check
-- **[CLI-586]** Hide empty handoff ticks from mission report timeline [mission-report]
-  **Verify:** git diff --check
-- **[CLI-585]** Make mission run --json machine-readable [mission-run]
-  **Verify:** git diff --check
-- **[CLI-584]** Stop task render resurrecting stale backlog [task-render]
-  **Verify:** git diff --check
-- **[CLI-583]** Heal MAP refs reported by clean [map]
-  **Verify:** git diff --check
-- **[CLI-582]** Make clean --json machine-readable [clean]
-  **Verify:** git diff --check
-- **[CLI-581]** Use task title as review verification objective [task-review]
-  **Verify:** git diff --check
-- **[CLI-580]** Show mission report timeline from run receipts [mission-report]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-579]** Let mission tick write ad hoc verifier receipts [mission]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-578]** Stop repeating certified endgame seed while human accept waits [task-next]
-  **Verify:** node --test test/commands.test.js
-- **[CLI-577]** Audit and close next runner-agnostic heartbeat gap [runner]
-  **Verify:** node --test test/autopilot-runner-model.test.js test/runner-command.test.js
-- **[CLI-576]** Suppress stale compiled endgame from loop next moves [loop]
-  **Verify:** node --test test/moves.test.js test/loop-front.test.js
-- **[CLI-575]** Keep always-on mission tick next action runnable [mission]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-574]** Reconcile drifted brainstorm validate refs [wiki]
-  **Verify:** node --test test/commands.test.js --test-name-pattern=brainstorm
-- **[CLI-572]** Infer overnight settings from mission run objective [mission]
-  **Verify:** node --test test/mission-status.test.js test/pulse.test.js test/loop-front.test.js
-- **[CLI-571]** Support 6-hour overnight heartbeat expiry [pulse]
-  **Verify:** node --test test/pulse.test.js test/loop-front.test.js
-- **[CLI-570]** Mission XP: work overnight and see where we can self improve. goal after goal nonstop 6 hours [agent-xp]
-  **Verify:** node --test test/pulse.test.js
-- **[CLI-569]** Make Mission Room chat-first before mission execution [mission-room]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-568]** Mission XP: Decide and start the next useful mission after: Ship Cash Proof Mission Room [agent-xp]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-567]** Mission XP: Ship Cash Proof Mission Room [agent-xp]
-  **Verify:** node scripts/verify-ship-cash-proof-mission-room.js
-- **[CLI-566]** Mission XP: Make Mission Room name the real business move instead of generic approval-room labels [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-565]** Mission XP: make Mission Room verification print the landing version instead of engineering VERIFIED output [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-564]** Mission XP: dogfood Mission Room so every run produces a concise human timeline of goals, decisions, builds, and proof [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-563]** Mission XP: find a way to constantly prune and compress atris runs so they stay concise [agent-xp]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-562]** Mission XP: build mission completion artifacts as chronological timeline lists [agent-xp]
-  **Verify:** node scripts/verify-mission-artifact-timeline.js
-- **[CLI-561]** Mission XP: think through beautiful human-readable HTML and Markdown mission run receipts with block support for Project Obelisk and Atris runs [agent-xp]
-  **Verify:** node scripts/verify-human-readable-mission-artifact.js
-- **[CLI-560]** Mission XP: make Mission Room preview task-first with editable member routing and landing result [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-559]** Mission XP: add member logs context and proactive next mission suggestions to Mission Room [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-558]** Mission XP: add thinking.md operator memory to Mission Room CLI and dogfood it [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-557]** Mission XP: make Mission Room ask sharp clarifiers and produce an approval packet before starting the goal chain [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-556]** Mission XP: ship the first Chaos -> Mission Room activation slice in atris-cli: messy input becomes a mission card, first proof step, verifier, and shareable receipt path [agent-xp]
-  **Verify:** node scripts/verify-mission-room.js
-- **[CLI-555]** Mission XP: discover the Atris product wedge tonight: test 5 candidate outcomes for mission magic, score relief/proof/shareability, and pick the first product-led growth mission [agent-xp]
-  **Verify:** node scripts/verify-mission-product-wedge.js
-- **[CLI-554]** Mission XP: 30-day runway cash sprint: turn the DoorDash PO and near-term Atris demand into cash fast, starting tomorrow, while the mission loop ships proof-backed product [agent-xp]
-  **Verify:** node scripts/verify-runway-cash-sprint.js
-- **[CLI-553]** Mission XP: Audit and close next runner-agnostic heartbeat gap [agent-xp]
-  **Verify:** node --test test/autopilot-runner-model.test.js test/runner-command.test.js
-- **[CLI-552]** Mission XP: Refresh Atris brain after AI-memory-moat and review-lane mission chain, then stop at human gate [agent-xp]
-  **Verify:** node --test test/commands.test.js --test-name-pattern=brain
-- **[CLI-551]** Mission XP: Decide and start the next useful mission after: Review proof-ready CLI-547 and CLI-548, certify only if evidence holds, and leave human accept untouched [agent-xp]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-550]** Mission XP: Review proof-ready CLI-547 and CLI-548, certify only if evidence holds, and leave human accept untouched [agent-xp]
-  **Verify:** node scripts/verify-review-lane-receipt.js
-- **[CLI-549]** Mission XP: Decide and start the next useful mission after: take all these AI-memory-moat insights, validate we captured them all, and keep setting bounded goals while Keshav lifts [agent-xp]
-  **Verify:** node --test test/commands.test.js --test-name-pattern=review-lane
-- **[CLI-548]** Mission XP: Overnight dogfood: exercise every atris surface, ship bounded proof each tick [agent-xp]
-  **Verify:** test -f atris/runs/dogfood-feature-loop-2026-06-28.jsonl && node --test test/commands.test.js --test-name-pattern=launchpad
-- **[CLI-544]** Mission XP: tiny proof-only mission: prove mission run can start, tick, and complete without product file edits [agent-xp]
-  **Verify:** node --test test/mission-status.test.js
-- **[CLI-530]** Mission XP: Make ax cloud-first a durable team standard [agent-xp]
-  **Verify:** node scripts/verify-ax-cloud-standard.js
-- **[CLI-528]** Mission XP: Fix ax fast auto-routing so prose writing stays cloud and local is only for workspace side effects [agent-xp]
-  **Verify:** node --test test/ax.test.js
-- **[CLI-393]** Clean up any stale wiki pages from session changes [maintenance]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-384]** Document atris run diff in README, CLAUDE.md, wiki, MAP.md [docs]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-381]** Document atris run export in README, CLAUDE.md, wiki, MAP.md [docs]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-378]** Document atris run stats in README, CLAUDE.md, wiki, MAP.md [docs]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-376]** Add glass logging to atris autopilot tick phases [code]
-  **Verify:** node --test test/autopilot-glass-logging.test.js
-- **[CLI-374]** Update MAP.md with searchRunLogs function [maintenance]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-368]** Update MAP.md with pruneRunLogs function [maintenance]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-361]** Add run logs to CLAUDE.md and AGENTS.md documentation [docs]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-360]** Update MAP.md with new run.js glass log functions and subcommand [maintenance]
-  **Verify:** node --test test/run-glass-logs.test.js
-- **[CLI-357]** Add glass interface principle to wiki index and STATUS [wiki]
-  **Verify:** node --test test/run-glass-logs.test.js
+- **[CLI-758]** Make atris go execute one useful bounded slice [autonomy]
+  **Verify:** node --test test/check-command-regression.test.js
 
 ## Blocked
 
+- **[CLI-759]** Mission XP: go go go [agent-xp]
 - **[CLI-501]** Design 24/7 functional team member factory [team-members]
 - **[CLI-500]** Replace generic codex-executor ownership with functional team roles [team-roles]
 - **[CLI-407]** Generate Atris Labs recruiting sync conflict packet [recruiting-sync]
@@ -371,27 +47,26 @@
 - **[CLI-220]** Heal workspace drift: 82 stale MAP.md refs + archive 33 old journals via atris clean [maintenance]
 - **[CLI-216]** Ship launch post: post linkedin-post.md, capture URL in journal, delete the file
 - **[CLI-200]** Auto-improver: Recurring log pattern: Next tick will stop until a human looks at the error. [auto-improver]
-- **[CLI-162]** Refresh control packets after b20be master advance [review]
 
-(6 older blocked tasks archived in `atris task list --status failed` and `atris task events`.)
+(7 older blocked tasks archived in `atris task list --status failed` and `atris task events`.)
 
 ## Completed
 
-- **[CLI-547]** Mission XP: take all these AI-memory-moat insights, validate we captured them all, and keep setting bounded goals while Keshav lifts [agent-xp]
-  **Verify:** node scripts/verify-ai-memory-moat.js
-- **[CLI-546]** Fix dogfood verifier failures after Valhalla changes [dogfood]
-  **Verify:** node --test test/commands.test.js --test-name-pattern=launchpad
-- **[CLI-545]** Mission XP: Watch chat/log/task signals, infer what the operator wants, and run one bounded proof-backed action per tick [agent-xp]
-  **Verify:** node scripts/verify-chat-scan.js
-- **[CLI-543]** Valhalla fix: route atris loop to the loop front door [loop]
-  **Verify:** node --test test/loop-front.test.js
-- **[CLI-542]** Valhalla gate: mission doctor flags slop missions [mission]
-  **Verify:** node scripts/verify-mission-doctor.js
-- **[CLI-541]** Valhalla gate: remote-computer mission parity acceptance test [mission]
-  **Verify:** node scripts/verify-valhalla.js
-- **[CLI-540]** Valhalla gate: ranked next-move source for atris loop [loop]
-  **Verify:** node scripts/verify-valhalla-roadmap.js
-- **[CLI-539]** Valhalla gate: visible review acceptance receipt [task-review]
-  **Verify:** node scripts/verify-valhalla-roadmap.js
+- **[CLI-757]** Mission XP: to ensure mission run works again [agent-xp]
+  **Verify:** node --test test/mission-status.test.js
+- **[CLI-756]** Mission XP: to ensure mission run works [agent-xp]
+  **Verify:** node --test test/mission-status.test.js
+- **[CLI-755]** Mission XP: Messy Input Goal Chain Mission Room with mission-lead: turn "Dogfood Atris mission loop one more time: prove it can turn messy intent into the right next goal, choose only fresh work, or stop..." into one visible goal, task spine, proof receipt, and next action. [agent-xp]
+  **Verify:** git diff --check
+- **[CLI-754]** Mission XP: Decide and start the next useful mission after: Add timeline receipt display object to mission timeline JSON output [agent-xp]
+  **Verify:** git diff --check
+- **[CLI-753]** Mission XP: Add timeline receipt display object to mission timeline JSON output [agent-xp]
+  **Verify:** git diff --check
+- **[CLI-752]** Mission XP: Decide and start the next useful mission after: Add timeline filter display object to mission timeline JSON output [agent-xp]
+  **Verify:** git diff --check
+- **[CLI-751]** Mission XP: Add timeline filter display object to mission timeline JSON output [agent-xp]
+  **Verify:** git diff --check
+- **[CLI-750]** Mission XP: Decide and start the next useful mission after: make continuation missions auto-select a concrete follow-up mission from Atris state instead of returning a <next useful mission> placeholder [agent-xp]
+  **Verify:** git diff --check
 
-(269 older completed tasks archived in `atris task list --status done` and `atris task events`.)
+(464 older completed tasks archived in `atris task list --status done` and `atris task events`.)

--- a/atris/team/launcher/MISSION.md
+++ b/atris/team/launcher/MISSION.md
@@ -1,0 +1,14 @@
+# Mission
+
+<!-- Human-authored purpose file. Keep this durable; runtime state belongs in .atris/state/*.jsonl and now.md. -->
+
+## North Star
+
+Define why this member exists and how it chooses goals.
+
+## How To Choose Goals
+
+- Read MEMBER.md, MISSION.md, current goals, now.md, and recent logs.
+- Choose one useful bounded goal toward the mission.
+- Verify the work, write the receipt, and update the log.
+- Ask the human when vision, taste, risk, or uncertainty matters.

--- a/atris/thinking.md
+++ b/atris/thinking.md
@@ -44,4 +44,7 @@ This file says how Keshav thinks.
 - 2026-06-30T23:23:26.906Z - Messy Input Mission Room: messy shower test: user gives messy input and Atris must turn it into the right mission input, choose the right member, set a visible goal, think bottleneck-first, create tasks...
 - 2026-06-30T23:24:52.169Z - Messy Input Goal Chain Mission Room: messy shower test: user gives messy input and Atris must turn it into the right mission input, choose the right member, set a visible goal, think bottleneck-first, create tasks...
 - 2026-07-01T00:09:01.762Z - Messy Input Goal Chain Mission Room: run for 10 minutes while I shower; make mission run set the goal, understand messy input, choose what to do next, and finish with a specific next goal
+- 2026-07-01T00:45:55.780Z - Messy Input Goal Chain Mission Room: Dogfood Atris mission loop one more time: prove it can turn messy intent into the right next goal, choose only fresh work, or stop cleanly when nothing useful remains
+- 2026-07-01T07:34:38.020Z - Bounded Proof Mission Room: self improve goal after goal: pick one useful bounded mission from current Atris state, run proof, and continue only with real next work
+- 2026-07-01T08:40:15.567Z - Bounded State Message Mission Room: one-message autonomy: improve atris-cli usefully without creating junk state; pick the best next bounded task from live state and prove it
 <!-- ATRIS_MISSION_ROOM_SIGNALS:END -->

--- a/ax
+++ b/ax
@@ -1165,6 +1165,51 @@ function formatApprovalTime(value) {
   return `${months[Number(month) - 1] || month} ${Number(day)}, ${year} at ${hour12}:${minute} ${ampm}`;
 }
 
+function previewText(value, limit = 80) {
+  return String(value || '').replace(/\s+/g, ' ').trim().slice(0, limit);
+}
+
+function previewContact(value) {
+  if (!value) return '';
+  if (typeof value === 'string') return previewText(value, 120);
+  if (typeof value !== 'object') return previewText(value, 120);
+  return previewText(value.email || value.address || value.value || value.name || '', 120);
+}
+
+function previewContacts(value) {
+  const values = Array.isArray(value)
+    ? value
+    : String(value || '').includes(',')
+      ? String(value).split(',')
+      : [value];
+  return values
+    .map(previewContact)
+    .filter(Boolean)
+    .slice(0, 3)
+    .join(', ');
+}
+
+function gmailApprovalDetails(receipt, request, approvalEvent = null) {
+  const payload = request && request.payload && typeof request.payload === 'object' ? request.payload : {};
+  const taskPreview = receipt && receipt.task_preview && typeof receipt.task_preview === 'object' ? receipt.task_preview : {};
+  const slots = taskPreview.slots && typeof taskPreview.slots === 'object' ? taskPreview.slots : {};
+  const preview = approvalEvent && approvalEvent.preview && typeof approvalEvent.preview === 'object' ? approvalEvent.preview : {};
+  return {
+    to: previewContacts(payload.to || payload.recipient || payload.recipients || payload.email || slots.to || slots.recipient || preview.to),
+    subject: previewText(payload.subject || payload.title || slots.subject || preview.subject, 80),
+  };
+}
+
+function isGmailApproval(request, approvalEvent = null, accept = {}) {
+  const connector = canonicalConnectorId((request && request.connector) || (approvalEvent && approvalEvent.tool));
+  const action = String(
+    (request && (request.executor_action_type || request.action_type || request.action))
+    || accept.task
+    || ''
+  ).toLowerCase().replace(/_/g, ' ');
+  return connector === 'gmail' && /\b(send|reply|compose)\b/.test(action);
+}
+
 function formatApprovalReceipt(receipt) {
   if (!receipt || typeof receipt !== 'object') return null;
   const events = Array.isArray(receipt.tool_events) ? receipt.tool_events : [];
@@ -1180,6 +1225,15 @@ function formatApprovalReceipt(receipt) {
     const when = formatApprovalTime(start);
     const title = taskPreviewTitle(receipt) || accept.title || (approvalEvent.preview && approvalEvent.preview.summary) || 'calendar event';
     return `Approval needed before creation: calendar event "${String(title).slice(0, 80)}"${when ? ` ${when}` : ''}`;
+  }
+
+  if (isGmailApproval(request, approvalEvent, accept)) {
+    const details = gmailApprovalDetails(receipt, request, approvalEvent);
+    const parts = [
+      details.to ? `to ${details.to}` : '',
+      details.subject ? `subject "${details.subject}"` : '',
+    ].filter(Boolean);
+    return `Approval needed before sending Gmail${parts.length ? `: ${parts.join(' ')}` : ''} (body hidden until approved)`;
   }
 
   const connector = String(request.connector || approvalEvent.tool || 'connector').replace(/_/g, ' ');
@@ -1210,6 +1264,16 @@ function formatTaskPreviewPlan(receipt) {
   if (!taskPreview) return null;
   const task = String(taskPreview.task || '').trim();
   const slots = taskPreview.slots && typeof taskPreview.slots === 'object' ? taskPreview.slots : {};
+  const approvalEvent = taskPreviewApprovalEvent(receipt);
+  const request = approvalEvent && approvalEvent.approval_request;
+  if (isGmailApproval(request, approvalEvent, receipt.task_accept_receipt || {}) || task === 'gmail.send_message') {
+    const details = gmailApprovalDetails(receipt, request || { payload: slots }, approvalEvent);
+    return [
+      'send Gmail',
+      details.to ? `to ${details.to}` : '',
+      details.subject ? `subject "${details.subject}"` : '',
+    ].filter(Boolean).join(' ');
+  }
   if (task === 'calendar.create_event') {
     const title = taskPreviewTitle(receipt);
     const start = slots.start || (receipt.task_accept_receipt && receipt.task_accept_receipt.start);
@@ -1712,12 +1776,30 @@ function buildMessage(message, history = []) {
   return String(message || '').trim();
 }
 
+function createTurnId() {
+  return `axt_${Date.now().toString(36)}_${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function connectorTurnPolicy(message, options = {}) {
+  if (!connectorWriteIntent(message)) return null;
+  const policy = {
+    schema: 'ax.connector_turn.v1',
+    scope: 'current_turn_only',
+    policy: 'preview_then_explicit_approval',
+    writes_require_approval: true,
+  };
+  if (options.turnId) policy.turn_id = String(options.turnId);
+  if (options.conversationId) policy.conversation_id = String(options.conversationId);
+  return policy;
+}
+
 function buildPayload(message, options = {}) {
   const mode = normalizeMode(options.mode);
   const route = options.business ? 'local' : resolveRoute(message, options);
   const local = route !== 'cloud';
   const verifyCommand = String(options.verify || '').trim();
   const previousMessages = structuredHistory(options.history || []);
+  const turnId = String(options.turnId || '').trim();
   const payload = {
     message: buildMessage(message, options.history || []),
     model: modelForMode(mode),
@@ -1729,6 +1811,14 @@ function buildPayload(message, options = {}) {
   }
   if (options.conversationId) {
     payload.conversation_id = String(options.conversationId);
+  }
+  if (turnId) {
+    payload.turn_id = turnId;
+  }
+  const connectorPolicy = !local ? connectorTurnPolicy(message, { ...options, turnId }) : null;
+  if (connectorPolicy) {
+    payload.connector_turn = connectorPolicy;
+    payload.external_action_policy = 'preview_then_explicit_approval';
   }
   if (options.business) {
     // Business cloud workspace: the model loop stays on the backend and every
@@ -1882,6 +1972,7 @@ async function postTurn(message, options = {}) {
   const local = route !== 'cloud';
   const endpointRoute = options.business ? 'cloud' : route;
   const token = authToken();
+  const turnId = options.turnId || createTurnId();
   const shouldSendConnectionContext = options.connectionContext
     || route === 'cloud'
     || mentionsConnector(message)
@@ -1890,7 +1981,7 @@ async function postTurn(message, options = {}) {
     ? await buildConnectionContext({ token, localWorkspace: local })
     : null);
   const connectionUserId = !local && isLoopbackBackend({ route: endpointRoute }) ? authUserId() : '';
-  const payload = buildPayload(message, { ...options, route, connectionContext, connectionUserId });
+  const payload = buildPayload(message, { ...options, route, connectionContext, connectionUserId, turnId });
   const postData = JSON.stringify(payload);
   const output = options.output || process.stdout;
   // Relayed business turns wait on EC2 terminal calls (up to 60s each) with no
@@ -2269,7 +2360,8 @@ async function chat(options = {}) {
     const turnRoute = options.business ? 'cloud' : resolveRoute(trimmed, { route });
     if (!(await ensureRuntimeReady(turnRoute))) return false;
     const turnFunction = options.turnFunction || turnFunctionForMode(mode);
-    const result = await turnFunction(trimmed, { mode, cwd, history, output, route, business: options.business, verify: options.verify, conversationId });
+    const turnId = options.turnId || createTurnId();
+    const result = await turnFunction(trimmed, { mode, cwd, history, output, route, business: options.business, verify: options.verify, conversationId, turnId });
     if (result.output && !result.output.endsWith('\n')) output.write('\n');
     const approvalExecution = normalizeMode(mode) === 'code-fast'
       ? null

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -919,7 +919,7 @@ if (command === '2' && ['fast', 'pro'].includes(String(firstCommandArg || '').to
 }
 
 // Check if this is a known command or natural language input
-const knownCommands = ['init', 'log', 'now', 'radar', 'ctop', 'launchpad', 'status', 'analytics', 'visualize', 'brain', 'brainstorm', 'autopilot', 'run', 'plan', 'do', 'review', 'release',
+const knownCommands = ['init', 'log', 'now', 'radar', 'ctop', 'launchpad', 'status', 'analytics', 'visualize', 'brain', 'brainstorm', 'autopilot', 'run', '_start', 'plan', 'do', 'review', 'release',
                        'activate', '_activate', 'agent', 'chat', 'fast', 'ax', 'console', 'serve', 'login', 'logout', 'whoami', 'switch', 'use', 'accounts', '_resolve', '_profile-email', '_switch-session', 'shell-init', 'update', 'upgrade', 'version', 'help', 'next', 'atris',
                        'clean', 'verify', 'search', 'skill', 'member', 'codex-goal', 'app', 'apps', 'learn', 'lesson', 'plugin', 'experiments', 'receipt', 'proof', 'openclaw', 'pull', 'push', 'live', 'align', 'terminal', 'computer', 'diff', 'business', 'sync', 'youtube',
                        'ingest', 'query', 'lint', 'loop', 'pulse', 'task', 'mission', 'probe', 'worktree', 'aeo', 'slop', 'strings', 'security-review', 'secure', 'deck', 'site', 'theme', 'card', 'reel', 'improve', 'xp', 'play', 'gm', 'x', 'recap', 'signup', 'clarity', 'moves',
@@ -946,7 +946,15 @@ if (command === '--version' || command === '-v' || process.argv.includes('--vers
 // If no command OR command is not recognized, treat as natural language
 // Voice-friendly aliases — natural language → command mapping
 // Solves speech-to-text issues (inspired by gstack v0.14.6 voice-triggers)
+const START_MISSION_OBJECTIVE = 'self improve goal after goal: pick one useful bounded mission from current Atris state, run proof, and continue only with real next work';
+
 const voiceTriggers = {
+  'start': '_start',
+  'start now': '_start',
+  'go': '_start',
+  'keep going': '_start',
+  'keepgoing': '_start',
+  'keep-going': '_start',
   'review my code': 'code-review',
   'check my code': 'code-review',
   'run a review': 'code-review',
@@ -971,7 +979,12 @@ const voiceTriggers = {
 if (!command || !knownCommands.includes(command)) {
   // Check voice triggers before falling through to natural language
   const fullInput = process.argv.slice(2).join(' ').toLowerCase().trim();
-  const triggered = voiceTriggers[fullInput];
+  const fullInputWithoutFlags = process.argv.slice(2)
+    .filter((arg, index, args) => !String(arg).startsWith('-') && !isOptionValue(args, index, RUNNER_FLAG_NAMES))
+    .join(' ')
+    .toLowerCase()
+    .trim();
+  const triggered = voiceTriggers[fullInput] || voiceTriggers[fullInputWithoutFlags];
   if (triggered) {
     command = triggered;
     // Re-check — if it's now a known command, fall through to dispatch
@@ -1402,6 +1415,40 @@ if (command === 'init') {
     .then(() => process.exit(0))
     .catch((error) => {
       console.error(`✗ Error: ${error.message || error}`);
+      process.exit(1);
+    });
+} else if (command === '_start') {
+  const args = process.argv.slice(3);
+  if (args.includes('--help') || args.includes('-h') || args[0] === 'help') {
+    console.log('');
+    console.log('Usage: atris start [options]');
+    console.log('');
+    console.log('Starts the durable mission loop for one useful self-improvement mission.');
+    console.log('');
+    console.log('Options:');
+    console.log('  --json       Print the mission route without starting it.');
+    console.log('  --owner X    Override mission owner.');
+    console.log('  --cadence X  Override mission cadence.');
+    console.log('');
+    process.exit(0);
+  }
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify({
+      ok: true,
+      action: 'start_mission_run',
+      route: `atris mission run "${START_MISSION_OBJECTIVE}"`,
+      reason: 'casual_launch',
+      objective: START_MISSION_OBJECTIVE,
+      expected_loop: 'mission_run',
+    }, null, 2));
+    process.exit(0);
+  }
+
+  Promise.resolve(require('../commands/mission').missionCommand(['run', START_MISSION_OBJECTIVE, ...args]))
+    .then(() => process.exit(process.exitCode || 0))
+    .catch((error) => {
+      console.error(`✗ Start failed: ${error.message || error}`);
       process.exit(1);
     });
 } else if (command === 'task') {

--- a/commands/mission.js
+++ b/commands/mission.js
@@ -197,6 +197,8 @@ const MISSION_RUN_BOOLEAN_FLAGS = [
   '--stop-when-done',
   '--room-preflight',
   '--no-room-preflight',
+  '--room-auto-run',
+  '--no-room-auto-run',
   '--allow-native-goal-supersede',
   '--supersede-paused-native-goal',
   '--always-on',
@@ -727,13 +729,16 @@ function missionSelfImprovementSeedAction(mission, root = process.cwd()) {
   }
 }
 
-function missionHumanNextAction(mission, root = process.cwd()) {
+function missionHumanNextAction(mission, root = process.cwd(), options = {}) {
   if (!mission) return 'Pick the next customer-facing move.';
+  if (mission.goal_chain?.pause_ready) return 'Mission feels good; review proof, then complete, revise, or choose the next goal.';
   if (mission.status === 'ready' && /^queue AgentXP review:/i.test(mission.next_action || '')) {
     return 'Ready for human review; accept in Atris if the proof looks right.';
   }
   if (mission.status === 'ready' && mission.always_on) {
-    return missionSelfImprovementSeedAction(mission, root) || 'Run the next proof step.';
+    return options.allowSelfImprovementSeed
+      ? (missionSelfImprovementSeedAction(mission, root) || 'Run the next proof step.')
+      : 'Run the next proof step.';
   }
   if (mission.status === 'ready') return 'Review the proof, then complete the mission.';
   if (mission.status === 'complete') return 'Pick the next customer-facing move.';
@@ -775,6 +780,22 @@ function missionVerifierCheckedText(verifierResult, mission) {
   return `Verifier failed: ${command}.`;
 }
 
+function missionVerifierHighLevelTestText(verifierResult, mission) {
+  if (!verifierResult) return 'No automated verifier ran for this receipt; judge it from the receipt, changed files, and next action.';
+  const command = verifierResult.command || mission.verifier || 'configured verifier';
+  const outcome = verifierResult.passed ? 'passed' : 'failed';
+  if (/^git\s+diff\s+--check\b/i.test(command)) {
+    return `Diff cleanliness check ${outcome}: no whitespace or patch-format issues in the changed files.`;
+  }
+  if (/\bnode\s+--test\b/i.test(command) && /\btest\/mission-status\.test\.js\b/i.test(command)) {
+    return `Mission behavior checks ${outcome}: mission start, tick, completion, timeline landing, goal-chain, next-mission, and human-accept boundaries were exercised.`;
+  }
+  if (/\bnode\s+--test\b/i.test(command)) {
+    return `Automated behavior checks ${outcome}: the touched code path was exercised by Node tests.`;
+  }
+  return `Verifier command ${outcome}: ${command}.`;
+}
+
 function missionFallbackChangedText(mission, status, tickIndex, { ranTicks = null, effectiveMaxTicks = null } = {}) {
   if (mission?.always_on && (status === 'ready' || status === 'running')) {
     return 'Recorded a proof heartbeat for this always-on mission.';
@@ -805,6 +826,79 @@ function missionTickResultLines(mission, tickIndex, receiptPath, verifierResult 
   return lines;
 }
 
+function missionReceiptSummaryText(result) {
+  const tick = result?.tick || {};
+  return tick.summary
+    || tick.atris2?.receipt_text
+    || tick.claude?.receipt_text
+    || result?.summary
+    || result?.reason
+    || '';
+}
+
+function missionReceiptTickIndex(mission, result) {
+  const value = Number(result?.tick?.tick_index || mission?.last_tick_index || 0);
+  return Number.isFinite(value) && value > 0 ? value : 1;
+}
+
+function missionReceiptStatus(mission, result) {
+  const tickStatus = String(result?.tick?.status || '').trim();
+  if (tickStatus === 'blocked') return 'blocked';
+  if (result?.verifier_result?.passed === false) return 'blocked';
+  if (result?.verifier_result?.passed === true) return 'proof_ready';
+  return String(mission?.status || 'running');
+}
+
+function missionReceiptNextText(mission, result) {
+  if (result?.next) return String(result.next);
+  if (result?.landing?.next) return String(result.landing.next);
+  if (result?.verifier_result?.passed === true) {
+    return mission?.always_on ? 'Run the next proof step.' : 'Review the proof, then complete the mission.';
+  }
+  if (result?.verifier_result) return 'Fix the verifier failure or revise the mission.';
+  return missionHumanNextAction(mission);
+}
+
+function missionReceiptLanding(mission, result, receiptPath = '') {
+  const verifierResult = result?.verifier_result || null;
+  const status = missionReceiptStatus(mission, result);
+  const summary = missionReceiptSummaryText(result);
+  const changed = missionLandingStepSummary(summary)
+    || missionFallbackChangedText(mission, status, missionReceiptTickIndex(mission, result));
+  const checked = missionVerifierCheckedText(verifierResult, mission);
+  const tested = missionVerifierHighLevelTestText(verifierResult, mission);
+  return {
+    schema: 'atris.result_landing.v1',
+    status,
+    changed,
+    checked,
+    tested,
+    proof: receiptPath ? `Receipt saved at ${receiptPath}.` : 'Receipt saved in mission run history.',
+    next: missionReceiptNextText(mission, result),
+    timeline_visible: !missionLandingChangedIsGenericTick(mission, changed),
+  };
+}
+
+function missionLandingChangedIsGenericTick(mission, changed) {
+  const text = String(changed || '').trim();
+  const objective = String(mission?.objective || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (!objective) return false;
+  return new RegExp(`^${objective} recorded tick \\d+\\.$`).test(text);
+}
+
+function normalizeMissionReceiptResult(mission, result, receiptPath = '') {
+  const object = result && typeof result === 'object' && !Array.isArray(result)
+    ? { ...result }
+    : { value: result };
+  if (!object.landing) {
+    object.landing = missionReceiptLanding(mission, object, receiptPath);
+  }
+  if (object.verifier_result && !('passed' in object)) {
+    object.passed = !!object.verifier_result.passed;
+  }
+  return object;
+}
+
 function missionRunStartNextLine(mission, nextCommand, warnings = []) {
   if (warnings.length) return 'Add a verifier before completion, then run the first proof tick.';
   if (isCodexGoalMission(mission) && !codexNativeGoalAck(mission)) {
@@ -823,6 +917,7 @@ function missionRunTakeoffLines(mission, { warnings = [], nextCommand = '' } = {
     `  Goal: ${mission.objective}`,
     `  Done when: ${mission.stop_condition || 'the mission has proof or a human decision'}.`,
     ...(missionBudgetLine(mission) ? [`  Budget: ${missionBudgetLine(mission)}`] : []),
+    ...missionGoalChainLines(mission),
     '  Proof: Mission state saved in .atris/state/missions.jsonl.',
     `  Check: ${checked}`,
     `  Next: ${missionRunStartNextLine(mission, nextCommand, warnings)}`,
@@ -837,7 +932,41 @@ function missionRunPreflightSignals(text) {
 function shouldMissionRunRoomPreflight(objective, args = []) {
   if (hasFlag(args, '--no-room-preflight')) return false;
   if (hasFlag(args, '--room-preflight')) return true;
-  return missionRunPreflightSignals(objective);
+  return missionRunPreflightSignals(objective) || missionRunTrustedRoomSignals(objective);
+}
+
+function missionRunTrustedRoomSignals(text) {
+  const lower = String(text || '').toLowerCase().replace(/\s+/g, ' ');
+  return /\b(one[-\s]?message|autonomy|autonomous|self[-\s]?improve|improve\s+(atris|this|it)|keep\s+going|work\s+on\s+this|next\s+useful|goes?\s+off|no\s+junk|junk\s+state)\b/i.test(lower);
+}
+
+function shouldMissionRunTrustedRoom(rawObjective, args = []) {
+  if (hasFlag(args, '--no-room-auto-run')) return false;
+  if (hasFlag(args, '--room-auto-run')) return true;
+  return missionRunTrustedRoomSignals(rawObjective);
+}
+
+function missionRunConcreteTitle(value) {
+  const title = String(value || '').replace(/\s+/g, ' ').trim();
+  if (!title) return '';
+  if (/^(go|go go|go go go|keep going|do it|start|run|continue)$/i.test(title)) return '';
+  if (title.length < 8) return '';
+  return title;
+}
+
+function selectMissionRunUsefulTarget(rawObjective, root = process.cwd()) {
+  try {
+    const moves = require('../lib/next-moves');
+    const rawTitle = missionRunConcreteTitle(rawObjective);
+    return moves.nextMoves(root, 8)
+      .filter((move) => missionRunConcreteTitle(move?.title))
+      .filter((move) => !rawTitle || String(move.title).trim() !== rawTitle)
+      .find((move) => move.source === 'task')
+      || moves.nextMoves(root, 8).find((move) => missionRunConcreteTitle(move?.title))
+      || null;
+  } catch {
+    return null;
+  }
 }
 
 function missionRunPreflightSentence(text, max = 140) {
@@ -852,15 +981,26 @@ function missionRunPreflightObjective(rawObjective, room, owner) {
   return `${name} with ${owner}: turn "${missionRunPreflightSentence(task)}" into one visible goal, task spine, proof receipt, and next action.`;
 }
 
+function missionRunTrustedObjective(rawObjective, room, target) {
+  const targetTitle = missionRunConcreteTitle(target?.title);
+  if (targetTitle) return targetTitle;
+  if (missionRunTrustedRoomSignals(rawObjective)) {
+    return 'Improve Atris one-message autonomy without creating junk mission state';
+  }
+  return missionRunPreflightObjective(rawObjective, room, room?.owner || 'mission-lead');
+}
+
 function buildMissionRunRoomPreflight(rawObjective, args = [], options = {}) {
   if (!shouldMissionRunRoomPreflight(rawObjective, args)) return null;
   const root = options.root || process.cwd();
   const owner = options.owner || readFlag(args, '--owner', process.env.ATRIS_AGENT_ID || 'mission-lead');
+  const trustedRun = options.allowTrustedRun !== false && shouldMissionRunTrustedRoom(rawObjective, args);
+  const selectedTarget = trustedRun ? selectMissionRunUsefulTarget(rawObjective, root) : null;
   const ownerResolution = resolveFunctionalOwner({
     requestedOwner: owner,
-    title: rawObjective,
+    title: selectedTarget?.title || rawObjective,
     tag: readFlag(args, '--lane', 'workspace'),
-    goal: rawObjective,
+    goal: selectedTarget?.title || rawObjective,
     root,
     fallbackOwners: ['mission-lead', 'task-planner', 'architect', 'validator'],
   });
@@ -868,9 +1008,14 @@ function buildMissionRunRoomPreflight(rawObjective, args = [], options = {}) {
     root,
     owner: ownerResolution.owner,
     ownerResolution,
+    trustedRun,
+    selectedTarget,
+    verifier: trustedRun ? DEFAULT_LONG_RUN_VERIFIER : '',
   });
   const written = writeMissionRoomReceipt(room, { root });
-  const shapedObjective = missionRunPreflightObjective(rawObjective, written.room, ownerResolution.owner);
+  const shapedObjective = trustedRun
+    ? missionRunTrustedObjective(rawObjective, written.room, selectedTarget)
+    : missionRunPreflightObjective(rawObjective, written.room, ownerResolution.owner);
   return {
     schema: 'atris.mission_run_preflight.v1',
     source: 'mission_room',
@@ -881,8 +1026,17 @@ function buildMissionRunRoomPreflight(rawObjective, args = [], options = {}) {
     room_receipt_path: written.relativePath,
     owner: ownerResolution.owner,
     owner_resolution: ownerResolution.reason,
-    task_spine_required: true,
-    next_action: 'attach task spine, then run one proof tick',
+    trusted_run: trustedRun,
+    selected_target: selectedTarget ? {
+      title: selectedTarget.title,
+      source: selectedTarget.source,
+      ref: selectedTarget.ref || null,
+      why: selectedTarget.why || '',
+    } : null,
+    task_spine_required: !selectedTarget,
+    next_action: selectedTarget
+      ? 'run one proof tick for the selected existing task'
+      : 'attach task spine, then run one proof tick',
   };
 }
 
@@ -914,7 +1068,7 @@ function missionRunCreatedNextLine(createdNext, continuationGoal, mission) {
   }
   return continuationGoal?.mission
     ? `Next mission: ${continuationGoal.mission.objective}.`
-    : missionHumanNextAction(mission);
+    : missionHumanNextAction(mission, process.cwd(), { allowSelfImprovementSeed: true });
 }
 
 function missionRunTimelineCommand(mission) {
@@ -943,6 +1097,126 @@ function missionBudgetLine(mission) {
 
 function missionSpendsFullBudget(mission) {
   return mission?.budget_contract?.policy === 'spend_full_budget';
+}
+
+function missionGoalChainIntent(text) {
+  const lower = String(text || '').toLowerCase().replace(/\s+/g, ' ');
+  return /\b(3\s*(?:or|-)?\s*4|three\s+or\s+four|multiple|child|subgoals?|goal\s+after\s+goal|keeps?\s+goaling|mission\s+feeling\s+good|feels?\s+good|validated\s+and\s+i\s+can\s+understand)\b/.test(lower);
+}
+
+function missionGoalChainTargetCount(text) {
+  const lower = String(text || '').toLowerCase();
+  if (/\b3\s*(?:or|-)?\s*4\b|\bthree\s+or\s+four\b/.test(lower)) return 4;
+  const explicit = lower.match(/\b([3-4])\s+(?:goals?|child\s+goals?|subgoals?)\b/);
+  if (explicit) return Number(explicit[1]);
+  return 4;
+}
+
+function buildMissionGoalChain(objective, options = {}) {
+  const targetCount = Math.max(3, Math.min(4, Number(options.targetCount || missionGoalChainTargetCount(objective)) || 4));
+  const baseGoals = [
+    {
+      title: 'Find the novel mission',
+      done_when: 'A concrete mission is named with why it matters now.',
+      validation: 'Plain-English reason plus the source signal that made it worth doing.',
+    },
+    {
+      title: 'Split it into child goals',
+      done_when: 'The mission has a 3-4 step path with a clear first move.',
+      validation: 'Each child goal says what proof would make it done.',
+    },
+    {
+      title: 'Run the smallest proof',
+      done_when: 'One real artifact, code change, status output, or receipt exists.',
+      validation: 'A verifier, receipt, or inspectable output proves the work happened.',
+    },
+    {
+      title: 'Explain the pause or next goal',
+      done_when: 'The result says what changed, how it was checked, and whether to accept, revise, or continue.',
+      validation: 'The operator can understand the mission state without reading logs.',
+    },
+  ].slice(0, targetCount).map((goal, index) => ({
+    order: index + 1,
+    status: 'pending',
+    ...goal,
+  }));
+
+  return {
+    schema: 'atris.mission_goal_chain.v1',
+    mode: 'validated_child_goals',
+    status: 'planned',
+    target_count: targetCount,
+    done_count: 0,
+    current_goal_order: 1,
+    plain_language: 'One mission can be reached by several small goals, each with proof.',
+    pause_rule: 'Pause when the chain has proof strong enough to understand, accept, revise, or choose the next mission.',
+    validation_rule: 'Every child goal must leave a receipt, verifier result, artifact, or explicit stop reason.',
+    goals: baseGoals,
+  };
+}
+
+function missionGoalChainCounts(goalChain) {
+  const goals = Array.isArray(goalChain?.goals) ? goalChain.goals : [];
+  const done = goals.filter((goal) => goal?.status === 'done').length;
+  return { done, total: goals.length };
+}
+
+function missionGoalChainPendingGoal(goalChain) {
+  const goals = Array.isArray(goalChain?.goals) ? goalChain.goals : [];
+  return goals.find((goal) => goal?.status !== 'done' && goal?.status !== 'blocked') || null;
+}
+
+function missionGoalChainNextAction(goalChain) {
+  const goal = missionGoalChainPendingGoal(goalChain);
+  if (!goal) return 'continue child-goal chain';
+  return `continue child goal ${goal.order}: ${goal.title}`;
+}
+
+function advanceMissionGoalChain(goalChain, summary, verifierResult = null) {
+  if (!goalChain || !Array.isArray(goalChain.goals) || !goalChain.goals.length) return goalChain || null;
+  const cleanSummary = String(summary || '').replace(/\s+/g, ' ').trim();
+  if (!cleanSummary && !verifierResult) return goalChain;
+
+  const goals = goalChain.goals.map((goal) => ({ ...goal }));
+  const nextIndex = goals.findIndex((goal) => goal.status !== 'done');
+  if (nextIndex === -1) return goalChain;
+
+  const validationResult = verifierResult
+    ? (verifierResult.passed ? 'Verifier passed.' : 'Verifier failed; this goal needs repair.')
+    : 'Summary receipt recorded.';
+  goals[nextIndex] = {
+    ...goals[nextIndex],
+    status: verifierResult && !verifierResult.passed ? 'blocked' : 'done',
+    completed_at: stampIso(),
+    result: cleanSummary.slice(0, 240) || validationResult,
+    validation_result: validationResult,
+  };
+
+  const counts = missionGoalChainCounts({ goals });
+  const blocked = goals.some((goal) => goal.status === 'blocked');
+  const nextPending = goals.find((goal) => goal.status !== 'done' && goal.status !== 'blocked');
+  return {
+    ...goalChain,
+    goals,
+    done_count: counts.done,
+    current_goal_order: nextPending ? nextPending.order : null,
+    status: blocked ? 'blocked' : counts.done >= counts.total ? 'validated' : 'running',
+    pause_ready: !blocked && counts.done >= counts.total,
+  };
+}
+
+function missionGoalChainLines(mission) {
+  const chain = mission?.goal_chain;
+  if (!chain || !Array.isArray(chain.goals) || !chain.goals.length) return [];
+  const counts = missionGoalChainCounts(chain);
+  const lines = [
+    `  goal chain: ${counts.done}/${counts.total} done; ${chain.pause_rule}`,
+  ];
+  for (const goal of chain.goals) {
+    const mark = goal.status === 'done' ? '[x]' : goal.status === 'blocked' ? '[!]' : '[ ]';
+    lines.push(`    ${mark} ${goal.order}. ${goal.title} -> ${goal.validation}`);
+  }
+  return lines;
 }
 
 function missionRunSummaryLines(mission, ranTicks, effectiveMaxTicks, finalReceipt, pauseReason = null, continuationGoal = null, ticks = [], createdNext = null) {
@@ -1362,10 +1636,10 @@ function handledContinuationTargetKeys(root, moves) {
   }
   try {
     for (const row of listMissions(root)) {
-      if (TERMINAL_STATUSES.has(String(row?.status || '').toLowerCase())) add(row.objective);
+      add(row.objective);
     }
   } catch {
-    // If state is unreadable, fall back to the remaining explicit filters.
+    // If mission state is unreadable, fall back to the remaining explicit filters.
   }
   return keys;
 }
@@ -1384,14 +1658,28 @@ function chooseNextMissionTarget(mission, root = process.cwd()) {
         return !(mission?.id && move.ref === mission.id && title === currentObjective);
       })
       .filter((move) => !currentObjective || String(move.title || '').trim() !== currentObjective)
-      .filter((move) => !parentObjective || String(move.title || '').trim() !== parentObjective);
+      .filter((move) => !parentObjective || String(move.title || '').trim() !== parentObjective)
+      .map((move) => ({
+        ...move,
+        value_preview: missionValuePreview(move, mission, root),
+      }))
+      .sort((a, b) => {
+        const aScore = Number(a.value_preview?.score?.total || 0);
+        const bScore = Number(b.value_preview?.score?.total || 0);
+        if (aScore !== bScore) return bScore - aScore;
+        return Number(b.weight || 0) - Number(a.weight || 0);
+      });
     if (candidates[0]) return candidates[0];
     const target = moves.latestSuggestedTarget(root);
     if (isConcreteContinuationTarget(target) && !handledTargets.has(continuationTargetKey(target))) {
-      return {
+      const fallback = {
         title: target,
         why: 'latest proof timeline suggested this follow-up mission',
         source: 'mission_report',
+      };
+      return {
+        ...fallback,
+        value_preview: missionValuePreview(fallback, mission, root),
       };
     }
   } catch {
@@ -1400,12 +1688,353 @@ function chooseNextMissionTarget(mission, root = process.cwd()) {
   return null;
 }
 
-function chooseNextMissionCommand(mission, root = process.cwd()) {
+function normalizeMissionOwner(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function missionMemberTasteProfile(owner) {
+  const key = normalizeMissionOwner(owner);
+  if (/\b(security|sync-inspector|proof-inspector|validator)\b/.test(key)) {
+    return {
+      id: 'security_guard',
+      name: 'Security / trust',
+      bias: 'Prefer work that prevents unsafe behavior, privacy mistakes, or quiet trust breaks.',
+    };
+  }
+  if (/\b(researcher|architect|improver|auto-improver|problem-solver|objective-generator)\b/.test(key)) {
+    return {
+      id: 'technical_homerun',
+      name: 'Technical homerun',
+      bias: 'Prefer technical leaps, but require a usability or proof gate before spending serious tokens.',
+    };
+  }
+  return {
+    id: 'usability_operator',
+    name: 'Usability / demo',
+    bias: 'Prefer work that makes the product easier, faster, clearer, or more demo-ready.',
+  };
+}
+
+function missionValueSignals(title) {
+  const text = String(title || '').toLowerCase();
+  const signals = [];
+  const add = (id, label, pattern) => {
+    if (pattern.test(text)) signals.push({ id, label });
+  };
+  add('usability', 'simplifies use', /\b(simple|simplify|preview|clear|plain|feynman|demo|onboarding|ux|workflow|usable|understand)\b/);
+  add('speed', 'speeds the process', /\b(speed|fast|faster|latency|token|waste|friction|shortcut|automation|auto)\b/);
+  add('users_revenue', 'can help users or revenue', /\b(user|users|customer|revenue|payment|checkout|pricing|conversion|retention|demo)\b/);
+  add('trust', 'protects trust', /\b(security|safe|safety|trust|permission|approval|auth|privacy|gmail|email|connector|leak|isolation)\b/);
+  add('technical', 'technical advancement', /\b(agent|ax|connector|isolation|research|benchmark|model|compiler|runtime|architecture|rl|experiment)\b/);
+  add('freshness', 'keeps workflow current', /\b(up[- ]?to[- ]?date|fresh|sync|stale|current|latest)\b/);
+  return signals;
+}
+
+function missionTasteSnippet(value, max = 180) {
+  const text = String(value || '')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/[`*_#>]+/g, '')
+    .replace(/^[-\d.()[\]\s]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!text) return '';
+  return text.length > max ? `${text.slice(0, max - 3).trim()}...` : text;
+}
+
+function missionTasteSnippets(text, limit = 4) {
+  const tastePattern = /\b(plain|jargon|feynman|understand|simple|clarify|clarity|proof|receipt|verify|verified|checked|tested|accept|approval|runway|revenue|cash|user|customer|demo|technical|homerun|security|trust|privacy|logs|working memory|recent|speed|token|waste|simplify)\b/i;
+  const snippets = [];
+  for (const line of String(text || '').split(/\r?\n/)) {
+    const snippet = missionTasteSnippet(line);
+    if (!snippet || !tastePattern.test(snippet)) continue;
+    snippets.push(snippet);
+  }
+  return snippets.slice(-limit);
+}
+
+function readTextFile(root, relativePath) {
+  const file = path.join(root, ...relativePath.split('/'));
+  try {
+    return { path: relativePath, present: true, text: fs.readFileSync(file, 'utf8') };
+  } catch {
+    return { path: relativePath, present: false, text: '' };
+  }
+}
+
+function recentMarkdownFiles(dir, limit = 2) {
+  const files = [];
+  try {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      const stat = fs.statSync(full);
+      if (stat.isDirectory()) {
+        for (const child of recentMarkdownFiles(full, limit * 4)) files.push(child);
+      } else if (/\.md$/i.test(entry)) {
+        files.push(full);
+      }
+    }
+  } catch {
+    return [];
+  }
+  return files
+    .sort((a, b) => {
+      const aBase = path.basename(a);
+      const bBase = path.basename(b);
+      if (aBase !== bBase) return aBase.localeCompare(bBase);
+      return a.localeCompare(b);
+    })
+    .slice(-limit);
+}
+
+function readRecentTasteLogs(root, owner, limit = 3) {
+  const logFiles = [
+    ...recentMarkdownFiles(path.join(root, 'atris', 'logs'), 2),
+    ...recentMarkdownFiles(path.join(root, 'atris', 'team', owner || '', 'logs'), 2),
+  ];
+  const seen = new Set();
+  return logFiles
+    .filter((file) => {
+      const key = path.resolve(file);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(-limit)
+    .map((file) => {
+      let text = '';
+      try { text = fs.readFileSync(file, 'utf8'); } catch { text = ''; }
+      return {
+        path: path.relative(root, file),
+        snippets: missionTasteSnippets(text, 3),
+      };
+    })
+    .filter((entry) => entry.snippets.length);
+}
+
+function readTasteReviewHistory(root, limit = 4) {
+  const file = path.join(root, '.atris', 'state', 'tasks.projection.json');
+  let projection = null;
+  try { projection = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { projection = null; }
+  const tasks = Array.isArray(projection?.tasks) ? projection.tasks : [];
+  const accepted = [];
+  const revised = [];
+  const sorted = tasks
+    .filter(Boolean)
+    .sort((a, b) => Number(b.updated_at || 0) - Number(a.updated_at || 0));
+  for (const task of sorted) {
+    const title = missionTasteSnippet(task.title, 120);
+    for (const event of Array.isArray(task.events) ? task.events : []) {
+      const type = String(event?.event_type || '');
+      const payload = event?.payload || {};
+      if ((type === 'accepted' || (type === 'reviewed' && Number(payload.reward || 0) > 0)) && accepted.length < limit) {
+        accepted.push(missionTasteSnippet(`${title}: ${payload.proof || payload.note || 'accepted'}`));
+      }
+      if (type === 'revision_requested' && revised.length < limit) {
+        revised.push(missionTasteSnippet(`${title}: ${payload.note || 'revision requested'}`));
+      }
+    }
+  }
+  return { accepted, revised };
+}
+
+function missionTasteMemorySignals(text) {
+  const definitions = [
+    ['plain_language', 'Keshav asks for plain English', /\b(plain|jargon|feynman|understand|simple|clarify|clarity)\b/i],
+    ['proof_gate', 'Keshav wants proof before accept', /\b(proof|receipt|verify|verified|checked|tested|accept|approval)\b/i],
+    ['runway_revenue', 'runway pushes user or revenue work', /\b(runway|revenue|cash|user|users|customer|demo|adoption|retention)\b/i],
+    ['technical_ambition', 'technical advancement still matters', /\b(technical|homerun|research|runtime|architecture|model|benchmark|agent)\b/i],
+    ['trust_boundary', 'trust and approval boundaries matter', /\b(security|safe|safety|trust|privacy|approval|permission|gmail|email|connector)\b/i],
+    ['working_memory', 'recent logs are working memory', /\b(logs?|working memory|recent|today|now)\b/i],
+    ['speed_token', 'avoid wasted time and tokens', /\b(speed|fast|faster|token|waste|friction|simplify)\b/i],
+  ];
+  return definitions
+    .filter(([, , pattern]) => pattern.test(text))
+    .map(([id, label]) => ({ id, label }));
+}
+
+function readMissionTasteMemory(root = process.cwd(), owner = '') {
+  const safeOwner = normalizeMissionOwner(owner || process.env.ATRIS_AGENT_ID || 'mission-lead') || 'mission-lead';
+  const thinking = readTextFile(root, 'atris/thinking.md');
+  const memberMission = readTextFile(root, `atris/team/${safeOwner}/MISSION.md`);
+  const recentLogs = readRecentTasteLogs(root, safeOwner);
+  const taskHistory = readTasteReviewHistory(root);
+  const thinkingSnippets = missionTasteSnippets(thinking.text, 5);
+  const memberMissionSnippets = missionTasteSnippets(memberMission.text, 5);
+  const allText = [
+    ...thinkingSnippets,
+    ...memberMissionSnippets,
+    ...recentLogs.flatMap((entry) => entry.snippets),
+    ...taskHistory.accepted,
+    ...taskHistory.revised,
+  ].join('\n');
+  const signals = missionTasteMemorySignals(allText);
+  return {
+    schema: 'atris.mission_taste_memory.v1',
+    owner: safeOwner,
+    sources: {
+      thinking_md: {
+        path: thinking.path,
+        present: thinking.present,
+        snippets: thinkingSnippets,
+      },
+      member_mission: {
+        path: memberMission.path,
+        present: memberMission.present,
+        snippets: memberMissionSnippets,
+      },
+      recent_logs: recentLogs,
+      task_history: taskHistory,
+    },
+    signals,
+  };
+}
+
+function missionTasteMemoryBoost(signals, tasteMemory, profile) {
+  const candidateIds = new Set((signals || []).map((signal) => signal.id));
+  const memoryIds = new Set((tasteMemory?.signals || []).map((signal) => signal.id));
+  const hasCandidate = (id) => candidateIds.has(id) ? 1 : 0;
+  const hasMemory = (id) => memoryIds.has(id);
+  let boost = 0;
+  if (hasMemory('plain_language')) boost += hasCandidate('usability') * 2;
+  if (hasMemory('proof_gate')) boost += (hasCandidate('trust') || hasCandidate('usability') || hasCandidate('technical')) ? 1 : 0;
+  if (hasMemory('runway_revenue')) boost += hasCandidate('users_revenue') * 3;
+  if (hasMemory('technical_ambition')) boost += profile.id === 'technical_homerun' ? hasCandidate('technical') * 2 : hasCandidate('technical');
+  if (hasMemory('trust_boundary')) boost += hasCandidate('trust') * 2;
+  if (hasMemory('working_memory')) boost += (hasCandidate('freshness') || hasCandidate('speed')) ? 1 : 0;
+  if (hasMemory('speed_token')) boost += hasCandidate('speed') * 2;
+  return boost;
+}
+
+function missionValueScore(signals, profile, tasteMemory = null) {
+  const ids = new Set((signals || []).map((signal) => signal.id));
+  const has = (id) => ids.has(id) ? 1 : 0;
+  const base = has('usability') + has('speed') + has('users_revenue') + has('trust') + has('freshness');
+  let profileBoost = 0;
+  if (profile.id === 'technical_homerun') profileBoost = (has('technical') * 2) + has('trust') + has('speed');
+  else if (profile.id === 'security_guard') profileBoost = (has('trust') * 3) + has('freshness');
+  else profileBoost = (has('usability') * 2) + has('speed') + has('users_revenue');
+  const memoryBoost = missionTasteMemoryBoost(signals, tasteMemory, profile);
+  return {
+    total: base + profileBoost + memoryBoost,
+    signals: Array.from(ids),
+    memory_boost: memoryBoost,
+  };
+}
+
+function missionPlainTaskPreview(title) {
+  const text = String(title || '').replace(/\s+/g, ' ').trim();
+  if (!text) return 'Do one concrete useful thing.';
+  if (/ax\b/i.test(text) && /gmail/i.test(text) && /turn isolation/i.test(text)) {
+    return 'Make ax safer with Gmail: keep each chat request separate, and show a clear preview or receipt before Gmail actions.';
+  }
+  const cleaned = text
+    .replace(/^mission xp:\s*/i, '')
+    .replace(/^ship\s+/i, '')
+    .replace(/\bturn isolation\b/ig, 'separate chat requests')
+    .replace(/\breceipt previews?\b/ig, 'clear before/after receipts')
+    .replace(/\bconnector\b/ig, 'connected-app path');
+  return `${cleaned.charAt(0).toUpperCase()}${cleaned.slice(1)}`.replace(/[.!?:;,]+$/g, '') + '.';
+}
+
+function missionTasteMemoryReason(tasteMemory, signals) {
+  const candidateIds = new Set((signals || []).map((signal) => signal.id));
+  const memoryIds = new Set((tasteMemory?.signals || []).map((signal) => signal.id));
+  if (memoryIds.has('runway_revenue') && candidateIds.has('users_revenue')) return 'Keshav has been steering toward user/revenue proof because runway is tight.';
+  if (memoryIds.has('plain_language') && candidateIds.has('usability')) return 'Keshav keeps asking for plain-English, understandable work.';
+  if (memoryIds.has('proof_gate') && (candidateIds.has('trust') || candidateIds.has('technical'))) return 'Keshav wants proof and receipts before serious work is accepted.';
+  if (memoryIds.has('working_memory')) return 'Recent logs are being used as working memory for what matters now.';
+  if (memoryIds.has('technical_ambition') && candidateIds.has('technical')) return 'The member memory still values technical advancement when it has proof.';
+  return '';
+}
+
+function missionPreviewWhyNow(move, profile, signals, tasteMemory = null) {
+  const ids = new Set((signals || []).map((signal) => signal.id));
+  let base = '';
+  if (profile.id === 'technical_homerun') {
+    base = ids.has('technical')
+      ? 'This is a technical bet; run it only because it can make the product stronger without making the user think harder.'
+      : 'This is not a technical homerun on its face, so it needs clear usability proof before it should win.';
+  } else if (profile.id === 'security_guard') {
+    base = ids.has('trust')
+      ? 'This matters because trust failures are expensive and should be blocked before users feel them.'
+      : 'This is not mainly security work, so it should only run if the current trust queue is quiet.';
+  } else if (ids.has('users_revenue')) {
+    base = 'This matters now because it can help demos, users, retention, or revenue.';
+  } else if (ids.has('usability') || ids.has('speed')) {
+    base = 'This matters now because it can make the product easier or faster to use.';
+  } else {
+    base = move?.why || 'This needs a clear reason before it should spend serious tokens.';
+  }
+  const memoryReason = missionTasteMemoryReason(tasteMemory, signals);
+  return memoryReason ? `${base} Taste memory says: ${memoryReason}` : base;
+}
+
+function missionPreviewRisk(signals) {
+  const ids = new Set((signals || []).map((signal) => signal.id));
+  if (ids.has('technical') && !ids.has('usability')) return 'Risk: it becomes clever infrastructure that does not make the product easier.';
+  if (ids.has('trust')) return 'Risk: changing connected-tool behavior can hide or create approval/privacy mistakes.';
+  return 'Risk: it adds complexity without a visible product win.';
+}
+
+function missionPreviewValidation(signals) {
+  const ids = new Set((signals || []).map((signal) => signal.id));
+  if (ids.has('trust')) return 'Validate with a before/after receipt and a test proving unsafe state does not carry across turns.';
+  if (ids.has('users_revenue')) return 'Validate with a customer-visible proof: demo path, signup/payment path, or retention signal.';
+  if (ids.has('technical')) return 'Validate with a small benchmark, regression test, or artifact that proves the technical bet helped.';
+  return 'Validate with a simple before/after check that a human can understand.';
+}
+
+function missionValuePreview(move, mission, root = process.cwd()) {
+  const profile = missionMemberTasteProfile(mission?.owner);
+  const signals = missionValueSignals(move?.title);
+  const tasteMemory = readMissionTasteMemory(root, mission?.owner);
+  const score = missionValueScore(signals, profile, tasteMemory);
+  return {
+    schema: 'atris.mission_value_preview.v1',
+    member: mission?.owner || null,
+    profile,
+    candidate: {
+      title: move?.title || '',
+      source: move?.source || null,
+      ref: move?.ref || null,
+    },
+    feynman: {
+      what: missionPlainTaskPreview(move?.title),
+      why_now: missionPreviewWhyNow(move, profile, signals, tasteMemory),
+      risk: missionPreviewRisk(signals),
+      validation: missionPreviewValidation(signals),
+      taste: missionTasteMemoryReason(tasteMemory, signals) || 'No live taste memory matched this candidate yet.',
+    },
+    value_signals: signals,
+    taste_memory: tasteMemory,
+    score,
+  };
+}
+
+function chooseNextMissionPlan(mission, root = process.cwd()) {
   const owner = mission?.owner || process.env.ATRIS_AGENT_ID || 'mission-lead';
   const target = chooseNextMissionTarget(mission, root);
-  if (target?.title) return `atris mission run ${shellQuote(target.title)} --owner ${owner}`;
+  if (target?.title) {
+    return {
+      target,
+      command: `atris mission run ${shellQuote(target.title)} --owner ${owner}`,
+      preview: target.value_preview || missionValuePreview(target, mission, root),
+    };
+  }
   const missionId = mission?.id || '<mission-id>';
-  return `atris mission stop ${missionId} --reason ${shellQuote('no concrete follow-up mission found in Atris state')} --json`;
+  return {
+    target: null,
+    command: `atris mission stop ${missionId} --reason ${shellQuote('no concrete follow-up mission found in Atris state')} --json`,
+    preview: null,
+  };
+}
+
+function chooseNextMissionCommand(mission, root = process.cwd()) {
+  return chooseNextMissionPlan(mission, root).command;
+}
+
+function chooseNextMissionPreview(mission, root = process.cwd()) {
+  return chooseNextMissionPlan(mission, root).preview;
 }
 
 function effectiveMissionVerifier(mission) {
@@ -1495,14 +2124,33 @@ function completeActiveContinuationForStartedMission(nextMission, root = process
   };
 }
 
+function missionCanSeedContinuation(parent) {
+  if (!parent) return false;
+  if (parent.status === 'complete') return true;
+  return GOAL_LOOP_STATUSES.has(String(parent.status || '')) && missionTaskHumanAcceptWaiting(parent);
+}
+
 function seedMissionRunContinuation(parent, root = process.cwd(), proof = '') {
-  if (!parent || parent.status !== 'complete') return null;
+  if (!missionCanSeedContinuation(parent)) return null;
   if (parent.continue_on_complete !== true) return null;
-  if (parent.continuation_seeded_mission_id) return {
-    inserted: false,
-    reason: 'already_seeded',
-    mission_id: parent.continuation_seeded_mission_id,
-  };
+  if (parent.continuation_seeded_mission_id) {
+    const seeded = resolveMission(parent.continuation_seeded_mission_id, root);
+    if (seeded && TERMINAL_STATUSES.has(String(seeded.status || '')) && seeded.continued_by_mission_id) {
+      return {
+        inserted: false,
+        reason: 'already_continued',
+        mission_id: parent.continuation_seeded_mission_id,
+        mission: null,
+        continued_by_mission_id: seeded.continued_by_mission_id,
+      };
+    }
+    return {
+      inserted: false,
+      reason: 'already_seeded',
+      mission_id: parent.continuation_seeded_mission_id,
+      mission: seeded || null,
+    };
+  }
 
   const existing = findActiveContinuationMission(parent, root);
   if (existing) return { inserted: false, reason: 'active_continuation_exists', mission: existing };
@@ -1534,7 +2182,9 @@ function seedMissionRunContinuation(parent, root = process.cwd(), proof = '') {
     parent_proof: proof || parent.receipt_path || null,
     next_action: '',
   };
-  nextMission.next_action = `decide next mission, then run: ${chooseNextMissionCommand(nextMission, root)}`;
+  const nextPlan = chooseNextMissionPlan(nextMission, root);
+  nextMission.next_action = `decide next mission, then run: ${nextPlan.command}`;
+  nextMission.next_action_preview = nextPlan.preview;
 
   ensureMemberMissionFile(nextMission.owner, root, nextMission.objective);
   const { mission: saved } = saveMission(nextMission, root, 'mission_continuation_started', {
@@ -1563,6 +2213,19 @@ function seedMissionRunContinuation(parent, root = process.cwd(), proof = '') {
       dirty_hash: worktreeBaseline.dirty_hash,
     } : null,
   };
+}
+
+function seedNextMoveContinuationGoal(root = process.cwd()) {
+  const candidates = listMissions(root)
+    .filter((mission) => runnerUsesCallerSession(mission.runner))
+    .filter((mission) => mission.continue_on_complete === true)
+    .filter((mission) => missionCanSeedContinuation(mission));
+  candidates.sort((a, b) => missionSortTime(b) - missionSortTime(a));
+  for (const parent of candidates) {
+    const seeded = seedMissionRunContinuation(parent, root, parent.receipt_path || 'agent-certified task waiting for human accept');
+    if (seeded?.mission && missionSelectableForCodexGoal(seeded.mission)) return { ...seeded, parent: seeded.parent || parent };
+  }
+  return null;
 }
 
 function startMission(args) {
@@ -1630,12 +2293,16 @@ function startMissionFromRunObjective(objective, args) {
   const missionRunPreflight = buildMissionRunRoomPreflight(rawObjective, args, {
     root: process.cwd(),
     owner: preflightOwner,
+    allowTrustedRun: !inferredLoop.wantsLongRun,
   });
   const missionObjective = missionRunPreflight?.shaped_objective || rawObjective;
   const verifier = readFlag(
     args,
     '--verify',
-    inferRunObjectiveVerifier(missionObjective) || inferRunObjectiveVerifier(rawObjective) || (inferredLoop.wantsLongRun ? DEFAULT_LONG_RUN_VERIFIER : ''),
+    inferRunObjectiveVerifier(missionObjective)
+      || inferRunObjectiveVerifier(rawObjective)
+      || (missionRunPreflight?.trusted_run ? DEFAULT_LONG_RUN_VERIFIER : '')
+      || (inferredLoop.wantsLongRun ? DEFAULT_LONG_RUN_VERIFIER : ''),
   );
   const stopCondition = readFlag(
     args,
@@ -1664,6 +2331,9 @@ function startMissionFromRunObjective(objective, args) {
   if (hasFlag(args, '--xp-task') || hasFlag(args, '--agent-xp') || missionRunPreflight?.task_spine_required) startArgs.push('--xp-task');
 
   const mission = markMissionRunContinuation(missionFromArgs(startArgs));
+  if (missionGoalChainIntent(rawObjective) || missionGoalChainIntent(missionObjective)) {
+    mission.goal_chain = buildMissionGoalChain(missionObjective || rawObjective);
+  }
   if (missionRunPreflight) {
     mission.mission_run_preflight = missionRunPreflight;
     mission.raw_objective = rawObjective;
@@ -1794,7 +2464,9 @@ function attachMissionTask(args) {
     if (nextMission.status === 'ready' && nextMission.receipt_path) {
       nextMission.next_action = missionXpReadyAction(nextMission, nextMission.receipt_path) || nextMission.next_action;
     } else if (missionChoosesNextMission(nextMission)) {
-      nextMission.next_action = `decide next mission, then run: ${chooseNextMissionCommand(nextMission)}`;
+      const nextPlan = chooseNextMissionPlan(nextMission);
+      nextMission.next_action = `decide next mission, then run: ${nextPlan.command}`;
+      nextMission.next_action_preview = nextPlan.preview;
     } else if (!nextMission.verifier && !nextMission.always_on) {
       nextMission.next_action = `work task then run: atris task current-step --goal-id ${nextMission.id} --as ${nextMission.owner} --proof "<proof>" --json`;
     }
@@ -1865,13 +2537,15 @@ function statusMission(args) {
         `  id: ${mission.id}`,
         `  owner: ${mission.owner}`,
         ...(mission.executed_by ? [`  executed_by: ${mission.executed_by}`] : []),
-        `  state: ${mission.status}`,
-        ...missionHeartbeatLines(mission),
-        ...(mission.worktree_root ? [`  worktree: ${mission.worktree_root}`] : []),
-        `  next: ${mission.next_action || 'tick or verify'}`,
-        ...(mission.task_spine?.task_ref ? [`  task: ${mission.task_spine.task_ref}`] : []),
-        ...(mission.task_spine?.current_step_command ? [`  task next: ${mission.task_spine.current_step_command}`] : []),
-        ...(!mission.task_spine?.has_task && mission.task_spine?.ensure_task_command ? [`  task setup: ${mission.task_spine.ensure_task_command}`] : []),
+	        `  state: ${mission.status}`,
+	        ...missionHeartbeatLines(mission),
+	        ...(mission.worktree_root ? [`  worktree: ${mission.worktree_root}`] : []),
+	        `  next: ${mission.next_action || 'tick or verify'}`,
+	        ...(mission.next_action_preview?.feynman?.what ? [`  preview: ${mission.next_action_preview.feynman.what}`] : []),
+	        ...missionGoalChainLines(mission),
+	        ...(mission.task_spine?.task_ref ? [`  task: ${mission.task_spine.task_ref}`] : []),
+	        ...(mission.task_spine?.current_step_command ? [`  task next: ${mission.task_spine.current_step_command}`] : []),
+	        ...(!mission.task_spine?.has_task && mission.task_spine?.ensure_task_command ? [`  task setup: ${mission.task_spine.ensure_task_command}`] : []),
         ...(mission.receipt_path ? [`  proof: ${mission.receipt_path}`] : []),
         ...(completionGateLabel(mission.completion_gate) ? [`  gate: ${completionGateLabel(mission.completion_gate)}`] : []),
       ])
@@ -2043,6 +2717,7 @@ function missionLandingTimeline(mission, root = process.cwd(), limit = 12) {
     }
     if (!receipt || receipt.mission_id !== mission.id) continue;
     const landing = receipt.result && receipt.result.landing;
+    if (landing && landing.timeline_visible === false) continue;
     const changed = String(landing && landing.changed || '').trim();
     const next = String(landing && landing.next || '').trim();
     if (!changed && !next) continue;
@@ -2856,11 +3531,8 @@ function writeReceipt(mission, result, root = process.cwd()) {
   fs.mkdirSync(paths.runsDir, { recursive: true });
   const safeTime = stampIso().replace(/[:.]/g, '-');
   const receiptPath = path.join(paths.runsDir, `mission-${mission.id}-${safeTime}.json`);
-  // Back-compat: legacy consumers read receipt.result.passed (verifier-only shape).
-  // New shape nests verifier under result.verifier_result, so mirror .passed at top.
-  const finalResult = (result && typeof result === 'object' && result.verifier_result && !('passed' in result))
-    ? { ...result, passed: !!result.verifier_result.passed }
-    : result;
+  const relativeReceiptPath = path.relative(root, receiptPath);
+  const finalResult = normalizeMissionReceiptResult(mission, result, relativeReceiptPath);
   fs.writeFileSync(receiptPath, JSON.stringify({
     schema: 'atris.mission_receipt.v1',
     mission_id: mission.id,
@@ -2870,7 +3542,7 @@ function writeReceipt(mission, result, root = process.cwd()) {
     verifier: mission.verifier || null,
     result: finalResult,
   }, null, 2) + '\n', 'utf8');
-  return path.relative(root, receiptPath);
+  return relativeReceiptPath;
 }
 
 function shellQuote(value) {
@@ -3181,6 +3853,23 @@ function missionHasHumanAsks(mission) {
     && mission.human_asks.some((ask) => String(ask || '').trim());
 }
 
+function missionTaskHumanAcceptWaiting(mission) {
+  const taskId = missionTaskSpine(mission)?.task_id;
+  if (!taskId) return false;
+  try {
+    const taskDb = require('../lib/task-db');
+    const db = taskDb.open();
+    const task = taskDb.getTask(db, taskId);
+    if (!task) return false;
+    const metadata = task.metadata || {};
+    return task.status === 'review'
+      && metadata.approval_status === 'pending'
+      && metadata.agent_certified === true;
+  } catch {
+    return false;
+  }
+}
+
 function missionIsRunnable(mission) {
   return mission
     && GOAL_LOOP_STATUSES.has(String(mission.status || ''))
@@ -3194,6 +3883,7 @@ function missionSortTime(mission) {
 function selectDueMission(root = process.cwd(), now = new Date()) {
   const candidates = listMissions(root)
     .filter((mission) => missionSelectableForLoop(mission, now))
+    .filter((mission) => !missionTaskHumanAcceptWaiting(mission))
     .filter((mission) => effectiveMissionVerifier(mission) || callerSessionMissionReadyForDue(mission))
     .filter((mission) => mission.always_on || !missionVerifierPassed(mission))
     .filter((mission) => missionDueAt(mission, now));
@@ -3219,6 +3909,7 @@ function callerSessionMissionReadyForDue(mission) {
 
 function missionSelectableForCodexGoal(mission, now = new Date()) {
   if (!missionIsRunnable(mission)) return false;
+  if (missionTaskHumanAcceptWaiting(mission)) return false;
   if (mission.always_on && missionVerifierPassed(mission) && !missionDueAt(mission, now)) {
     return parseCadenceSeconds(mission.cadence) > 0;
   }
@@ -3422,6 +4113,23 @@ function readDirectRunCodexGoalRequest(root = process.cwd(), now = new Date()) {
   if (!mission || !isCodexGoalMission(mission)) return null;
   if (!missionSelectableForCodexGoal(mission, now)) return null;
   return { request, mission };
+}
+
+function clearDirectRunCodexGoalRequestForMission(missionId, root = process.cwd()) {
+  const file = statePaths(root).codexGoalRequestJson;
+  let request = null;
+  try {
+    request = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return false;
+  }
+  if (String(request?.mission_id || '') !== String(missionId || '')) return false;
+  try {
+    fs.rmSync(file, { force: true });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function activeCodexVisibleGoalOwner(root = process.cwd(), excludeId = '', now = new Date(), runtimeGoalState = null) {
@@ -3712,9 +4420,19 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
   if (directRequest && activeGoalOwner) {
     return codexGoalActiveConflictPayload(directRequest.mission, activeGoalOwner, directRequest.request, heartbeatMode, runtimeGoalState);
   }
-  const selected = directRequest
+  let selected = directRequest
     ? { mission: directRequest.mission, reason: 'direct_run', direct_goal_request: directRequest.request }
     : selectCodexGoalMission(root, options);
+  if (!selected && !directRequest) {
+    const continuation = seedNextMoveContinuationGoal(root);
+    if (continuation?.mission) {
+      selected = {
+        mission: continuation.mission,
+        reason: continuation.inserted ? 'next_move_continuation_seeded' : 'next_move_continuation_active',
+        seeded_continuation_goal: continuation,
+      };
+    }
+  }
   if (!selected) {
     const heartbeat = heartbeatMode ? codexGoalHeartbeat(null, null) : undefined;
     return {
@@ -3725,7 +4443,7 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
     };
   }
 
-  const { mission, reason, direct_goal_request: directGoalRequest } = selected;
+  const { mission, reason, direct_goal_request: directGoalRequest, seeded_continuation_goal: seededContinuationGoal } = selected;
   const taskSpine = missionTaskSpine(mission);
   const missionView = missionStatusView(mission);
   const objective = codexGoalObjective(mission);
@@ -3762,6 +4480,8 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
     native_goal_ack_command: codexGoalAckCommand(mission, objective),
     native_goal_ack: ack,
     direct_goal_request: directGoalRequest || null,
+    seeded_continuation_goal: seededContinuationGoal || null,
+    next_action_preview: mission.next_action_preview || (missionChoosesNextMission(mission) ? chooseNextMissionPreview(mission, root) : null),
     runtime_goal_state: runtimeGoalState,
   };
   const heartbeat = heartbeatMode ? codexGoalHeartbeat(goal, mission) : undefined;
@@ -4912,25 +5632,34 @@ function tickMission(args) {
       worktree: tickWorktree,
     });
 
-    let status = 'running';
-    let nextAction = (verifierCommand || effectiveVerifier)
-      ? `run verifier: ${verifierCommand || effectiveVerifier}`
-      : (mission.always_on && missionTaskSpine(mission)?.has_task
-        ? nextCandidateTickAction(mission)
-        : 'attach task, verifier, or proof');
-    if (verifierResult?.passed) {
-      const xpReadyAction = missionXpReadyAction(mission, receiptPath);
-      status = (completeOnPass && !mission.always_on && !xpReadyAction) ? 'complete' : 'ready';
-      nextAction = mission.always_on ? nextCandidateTickAction(mission) :
-        (xpReadyAction || (completeOnPass ? 'mission complete' : `review proof then run: atris mission complete ${mission.id} --proof "${receiptPath}"`));
-    } else if (verifierResult) {
-      status = 'blocked';
-      nextAction = 'fix verifier failure or revise mission';
-    }
-    const clearsPauseState = !['paused', 'stopped'].includes(status);
-    const nextMission = {
-      ...mission,
-      status,
+	    let status = 'running';
+	    let nextAction = (verifierCommand || effectiveVerifier)
+	      ? `run verifier: ${verifierCommand || effectiveVerifier}`
+	      : (mission.always_on && missionTaskSpine(mission)?.has_task
+	        ? nextCandidateTickAction(mission)
+	        : 'attach task, verifier, or proof');
+	    const nextGoalChain = advanceMissionGoalChain(mission.goal_chain, summary, verifierResult);
+	    if (verifierResult?.passed && nextGoalChain && !nextGoalChain.pause_ready) {
+	      status = 'running';
+	      nextAction = missionGoalChainNextAction(nextGoalChain);
+	    } else if (verifierResult?.passed) {
+	      const xpReadyAction = missionXpReadyAction(mission, receiptPath);
+	      status = (completeOnPass && !mission.always_on && !xpReadyAction) ? 'complete' : 'ready';
+	      nextAction = mission.always_on ? nextCandidateTickAction(mission) :
+	        (xpReadyAction || (completeOnPass ? 'mission complete' : `review proof then run: atris mission complete ${mission.id} --proof "${receiptPath}"`));
+	    } else if (verifierResult) {
+	      status = 'blocked';
+	      nextAction = 'fix verifier failure or revise mission';
+	    } else if (nextGoalChain?.pause_ready) {
+	      status = 'ready';
+	      nextAction = `mission feels good; review proof then run: atris mission complete ${mission.id} --proof "${receiptPath}"`;
+	    } else if (nextGoalChain) {
+	      nextAction = missionGoalChainNextAction(nextGoalChain);
+	    }
+	    const clearsPauseState = !['paused', 'stopped'].includes(status);
+	    const nextMission = {
+	      ...mission,
+	      status,
       paused_at: clearsPauseState ? null : mission.paused_at || null,
       stop_reason: clearsPauseState ? null : mission.stop_reason || null,
       resumed_at: clearsPauseState && mission.status === 'paused' ? tickRecord.finished_at : mission.resumed_at || null,
@@ -4939,11 +5668,12 @@ function tickMission(args) {
       last_tick_status: tickRecord.status,
       last_tick_reason: tickRecord.reason,
       last_tick_index: tickIdx,
-      last_tick_layer: tickRecord.layer,
-      last_tick_layer_source: tickRecord.layer_source,
-      verifier_result: verifierResult || mission.verifier_result || null,
-      next_action: nextAction,
-    };
+	      last_tick_layer: tickRecord.layer,
+	      last_tick_layer_source: tickRecord.layer_source,
+	      verifier_result: verifierResult || mission.verifier_result || null,
+	      ...(nextGoalChain ? { goal_chain: nextGoalChain } : {}),
+	      next_action: nextAction,
+	    };
     const { mission: saved } = saveMission(nextMission, cwd, 'mission_tick', {
       tick_index: tickIdx, verify, verifier_result: verifierResult, receipt_path: receiptPath, layer: tickRecord.layer,
     });
@@ -4999,7 +5729,6 @@ function receiptShowsPass(receipt) {
 // verifier passed. Mirrors the task plane's proof-only accept guard so the
 // final transition consumes the receipts instead of trusting free text.
 function missionCompletionGate(mission, proof, root = process.cwd()) {
-  if (!effectiveMissionVerifier(mission)) return { ok: true, source: 'no_verifier' };
   const receipt = readReceiptProof(proof, root);
   if (receipt) {
     if (receipt.mission_id !== mission.id) {
@@ -5010,6 +5739,7 @@ function missionCompletionGate(mission, proof, root = process.cwd()) {
       : { ok: false, source: 'receipt', reason: 'proof receipt does not show a passing verifier' };
   }
   if (mission.verifier_result?.passed === true) return { ok: true, source: 'mission_state' };
+  if (!effectiveMissionVerifier(mission)) return { ok: true, source: 'no_verifier' };
   return { ok: false, source: 'mission_state', reason: 'verifier has not passed for this mission and proof is not a passing receipt' };
 }
 
@@ -5126,9 +5856,10 @@ function stopMission(args) {
     next_action: status === 'paused' ? `resume with: atris mission tick ${mission.id}` : 'mission stopped',
   };
   const { mission: saved } = saveMission(next, process.cwd(), pause ? 'mission_paused' : 'mission_stopped', { reason, receipt_path: receiptPath });
+  const directGoalRequestCleared = pause ? false : clearDirectRunCodexGoalRequestForMission(saved.id, process.cwd());
   const logPath = appendMemberLog(saved.owner, pause ? 'Mission paused' : 'Mission stopped', { mission: saved.objective, reason });
   printJsonOrText(
-    { ok: true, action: pause ? 'mission_paused' : 'mission_stopped', mission: saved, receipt_path: receiptPath, log_path: logPath },
+    { ok: true, action: pause ? 'mission_paused' : 'mission_stopped', mission: saved, receipt_path: receiptPath, log_path: logPath, direct_goal_request_cleared: directGoalRequestCleared },
     [
       `${pause ? 'Paused' : 'Stopped'} mission: ${saved.objective}`,
       `Reason: ${reason}`,
@@ -5369,7 +6100,7 @@ atris mission - durable goal + loop + owner + proof state
   atris mission watch [id] [--interval <s>] [--idle-every <s>]   Live heartbeat: prints a line per tick as it lands
   atris mission layers [--mission <id-substr>] [--since <date>] [--json]   Per-layer growth curve across tick receipts
                        (rolls up sibling git-worktree missions; --local scopes to this checkout)
-  atris mission room "<messy input>" [--owner <member>] [--json]   Create a Mission Room card and shareable receipt from messy intent
+  atris mission room "<messy input>" [--owner <member>] [--room-auto-run] [--json]   Create a Mission Room card and shareable receipt from messy intent
   atris mission prune-runs [--apply] [--days <n>] [--keep-newest <n>] [--json]   Compress old run receipts into a manifest and prune unreferenced clutter
   atris mission goal [--runtime codex|atris] [--heartbeat] [--native-goal-status active|paused] [--native-goal-objective "..."] [--allow-native-goal-supersede] [--json]
   atris mission goal ack <id> --runtime codex --status active --objective "<objective>" --json
@@ -5379,10 +6110,12 @@ atris mission - durable goal + loop + owner + proof state
   atris mission run ["objective"|<member> ["objective"]|id|--due] [--owner <member>] [--max-ticks 4] [--max-wall 3600] [--cadence "15m"]
                                 [--native-goal-status active|paused] [--native-goal-objective "..."] [--allow-native-goal-supersede]
                                 [--spend-full-budget|--use-whole-budget|--stop-when-done] [--room-preflight|--no-room-preflight]
+                                [--room-auto-run|--no-room-auto-run]
                                 [--no-claude] [--no-verify] [--complete-on-pass] [--no-drain] [--create-next] [--json]
                        (bare/member-only run prompts; one-word fuzzy intent starts a new visible-goal mission; --due runs the saved queue)
                        (plain time like "20 minutes" means finish early if solved; say "use the whole time" to spend the full budget)
                        (messy, shower, and overnight requests preflight through Mission Room before the visible goal is written)
+                       (--room-auto-run makes trusted self-improvement asks preview through Mission Room, select real work, then start one bounded goal)
                        (mission-run completions seed the next visible goal: decide and start the next useful mission)
   atris mission complete <id> --proof "..."
   atris mission stop <id> [--pause] [--reason "..."]
@@ -5575,9 +6308,9 @@ function layersMission(args) {
 function roomMission(args) {
   const asJson = wantsJson(args);
   const explicitOwner = readFlag(args, '--owner', '');
-  const input = stripKnownFlags(args, ['--owner'], ['--json']).join(' ').trim();
+  const input = stripKnownFlags(args, ['--owner'], ['--json', '--room-auto-run', '--no-room-auto-run']).join(' ').trim();
   if (!input) {
-    exitMissionError('Usage: atris mission room "<messy input>" [--owner <member>] [--json]', 1, asJson);
+    exitMissionError('Usage: atris mission room "<messy input>" [--owner <member>] [--room-auto-run] [--json]', 1, asJson);
   }
   const requestedOwner = explicitOwner || process.env.ATRIS_AGENT_ID || '';
   const ownerResolution = resolveFunctionalOwner({
@@ -5591,7 +6324,13 @@ function roomMission(args) {
 
   let room;
   try {
-    room = buildMissionRoom(input, { owner, root: process.cwd(), ownerResolution });
+    room = buildMissionRoom(input, {
+      owner,
+      root: process.cwd(),
+      ownerResolution,
+      trustedRun: hasFlag(args, '--room-auto-run') && !hasFlag(args, '--no-room-auto-run'),
+      verifier: DEFAULT_LONG_RUN_VERIFIER,
+    });
   } catch (error) {
     exitMissionError(error.message || String(error), 1, asJson);
   }

--- a/lib/mission-room.js
+++ b/lib/mission-room.js
@@ -332,11 +332,15 @@ function buildClarifyingQuestions() {
   ];
 }
 
-function buildApprovalPacket(name, summary, owner) {
-  const approvedCommand = `atris mission start "${name}" --owner ${owner} --runner codex_goal --lane code --verify "<cmd>" --xp-task`;
+function buildApprovalPacket(name, summary, owner, options = {}) {
+  const verifier = options.verifier || '<cmd>';
+  const approvedCommand = `atris mission start "${name}" --owner ${owner} --runner codex_goal --lane code --verify "${verifier}" --xp-task`;
+  const trustedRun = options.trustedRun === true;
   return {
-    status: 'awaiting_operator_approval',
-    approve_question: `Approve ${name} as the mission?`,
+    status: trustedRun ? 'trusted_auto_run' : 'awaiting_operator_approval',
+    approve_question: trustedRun
+      ? `Run ${name} after this preview?`
+      : `Approve ${name} as the mission?`,
     operator_role: 'Approve taste, judgment, priority, and final accept; Atris owns bounded execution and proof receipts.',
     proposed_mission: name,
     proposed_outcome: `A proof-backed mission that resolves: ${summary}`,
@@ -350,7 +354,21 @@ function buildApprovalPacket(name, summary, owner) {
   };
 }
 
-function buildGoalChain(name) {
+function buildGoalChain(name, options = {}) {
+  if (options.trustedRun === true) {
+    return {
+      mode: 'trusted_run',
+      loop: 'clarify -> plan preview -> set one goal -> prove -> receipt -> next goal or stop',
+      first_goal: `Run ${name} until one inspectable proof receipt exists.`,
+      next_goal_policy: 'Set exactly one next goal only after proof; stop when no concrete useful move is available.',
+      stop_conditions: [
+        'the useful-work selector finds no concrete bounded move',
+        'verifier fails and cannot be repaired inside the current goal',
+        'the next step requires taste, priority, budget, or customer judgment',
+        'the mission reaches an inspectable delivery receipt',
+      ],
+    };
+  }
   return {
     mode: 'approval_gated',
     loop: 'clarify -> approve packet -> set one goal -> prove -> receipt -> approve/revise/next goal',
@@ -507,18 +525,21 @@ function contextPaths(context) {
   return Array.from(new Set(paths));
 }
 
-function buildProactiveNextMission(name, owner, context, approvalPacket) {
+function buildProactiveNextMission(name, owner, context, approvalPacket, options = {}) {
   const hasMember = context?.member_context?.member_exists;
   const proposedMember = context?.proposed_member || owner;
+  const trustedRun = options.trustedRun === true;
   return {
-    status: 'suggested_after_operator_approval',
+    status: trustedRun ? 'ready_to_run_after_preview' : 'suggested_after_operator_approval',
     objective: hasMember
       ? `Run ${name} with ${owner} until the first proof receipt is ready.`
       : `Select or create ${proposedMember}, then run ${name} until the first proof receipt is ready.`,
     why_now: 'This is the most direct next mission from the messy input, selected member, logs, and thinking.md.',
     selected_member: owner,
     context_paths: contextPaths(context),
-    approval_question: `Start this as the next mission after you approve ${name}?`,
+    approval_question: trustedRun
+      ? `Start this as the next mission after the preview?`
+      : `Start this as the next mission after you approve ${name}?`,
     start_command: approvalPacket.approved_next_command,
     member_setup_command: hasMember ? null : `atris member create ${proposedMember}`,
     stop_rule: 'Stop at one proof receipt, one approval question, or one real blocker.',
@@ -609,7 +630,21 @@ function buildTimelinePreview(name, summary, owner, goalChain) {
   };
 }
 
-function buildPendingResultLanding(name, owner, timelinePreview) {
+function buildPendingResultLanding(name, owner, timelinePreview, options = {}) {
+  if (options.trustedRun === true) {
+    return {
+      schema: 'atris.mission_room_result.v1',
+      status: 'ready_to_run',
+      landing: {
+        status: 'ready_to_run',
+        changed: `Room ready: ${name} has a preview and can start one bounded goal with ${owner}.`,
+        checked: 'Plan preview, member route, timeline, and trusted run policy are prepared; mission state is created only after useful work is selected.',
+        proof: null,
+        decision: 'Start one bounded goal, produce proof, then continue only if the next move is concrete.',
+        timeline_preview: timelinePreview?.items || [],
+      },
+    };
+  }
   return {
     schema: 'atris.mission_room_result.v1',
     status: 'pending_goal_run',
@@ -624,11 +659,12 @@ function buildPendingResultLanding(name, owner, timelinePreview) {
   };
 }
 
-function buildChatZone(name, owner, taskPlanPreview, timelinePreview, approvalPacket) {
+function buildChatZone(name, owner, taskPlanPreview, timelinePreview, approvalPacket, options = {}) {
+  const trustedRun = options.trustedRun === true;
   return {
     schema: 'atris.mission_room_chat_zone.v1',
-    status: 'clarifying',
-    current_step: 'shape_the_mission_before_execution',
+    status: trustedRun ? 'ready_to_run' : 'clarifying',
+    current_step: trustedRun ? 'preview_then_execute_one_goal' : 'shape_the_mission_before_execution',
     member: owner,
     plan_preview: {
       mission: name,
@@ -642,7 +678,9 @@ function buildChatZone(name, owner, taskPlanPreview, timelinePreview, approvalPa
       decision_options: approvalPacket?.decision_options || ['approve', 'revise', 'stop'],
       approve_question: approvalPacket?.approve_question || `Approve ${name} as the mission?`,
     },
-    execution_policy: 'Do not start a mission goal until the operator approves this room.',
+    execution_policy: trustedRun
+      ? 'Trusted run: after the preview, start exactly one bounded goal and stop at proof or a real blocker.'
+      : 'Do not start a mission goal until the operator approves this room.',
     result_landing_policy: 'Use result.landing only after a bounded goal runs and proof exists.',
   };
 }
@@ -660,9 +698,13 @@ function buildMissionRoom(input, options = {}) {
   const summary = sentenceExcerpt(normalized);
   const hash = crypto.createHash('sha1').update(normalized).digest('hex').slice(0, 12);
   const slug = slugify(name);
+  const trustedRun = options.trustedRun === true;
   const clarifyingQuestions = buildClarifyingQuestions();
-  const approvalPacket = buildApprovalPacket(name, summary, owner);
-  const goalChain = buildGoalChain(name);
+  const approvalPacket = buildApprovalPacket(name, summary, owner, {
+    trustedRun,
+    verifier: options.verifier,
+  });
+  const goalChain = buildGoalChain(name, { trustedRun });
   const timelinePreview = buildTimelinePreview(name, summary, owner, goalChain);
   const firstProofStep = 'Create the smallest artifact or change that proves this mission advanced, then attach a verifier, receipt path, screenshot, or human accept gate.';
   const context = collectMissionRoomContext(normalized, {
@@ -672,9 +714,9 @@ function buildMissionRoom(input, options = {}) {
   });
   const memberRoute = buildMemberRoute(name, owner, context, approvalPacket);
   const taskPlanPreview = buildTaskPlanPreview(name, summary, owner, context, goalChain, firstProofStep, memberRoute);
-  const proactiveNextMission = buildProactiveNextMission(name, owner, context, approvalPacket);
-  const result = buildPendingResultLanding(name, owner, timelinePreview);
-  const chatZone = buildChatZone(name, owner, taskPlanPreview, timelinePreview, approvalPacket);
+  const proactiveNextMission = buildProactiveNextMission(name, owner, context, approvalPacket, { trustedRun });
+  const result = buildPendingResultLanding(name, owner, timelinePreview, { trustedRun });
+  const chatZone = buildChatZone(name, owner, taskPlanPreview, timelinePreview, approvalPacket, { trustedRun });
 
   return {
     schema: 'atris.mission_room.v1',
@@ -703,10 +745,16 @@ function buildMissionRoom(input, options = {}) {
     timeline_preview: timelinePreview,
     proactive_next_mission: proactiveNextMission,
     result,
+    execution_mode: trustedRun ? 'trusted_run' : 'approval_gated',
+    trusted_execution: trustedRun ? {
+      status: 'ready_to_run',
+      selected_target: options.selectedTarget || null,
+      policy: 'preview first, start one bounded goal, write proof, then continue only if the next move is concrete',
+    } : null,
     first_proof_step: firstProofStep,
     verifier: 'Receipt must include mission name, truth snapshot, target outcome, stop-doing list, first proof step, and share line.',
     share_line: `This mission moved from chaos to proof: ${name}. Inspect the receipt or claim the next step.`,
-    next_command: `After approval: ${approvalPacket.approved_next_command}`,
+    next_command: `${trustedRun ? 'After preview' : 'After approval'}: ${approvalPacket.approved_next_command}`,
     receipt_slug: slug,
   };
 }
@@ -764,9 +812,10 @@ function writeMissionRoomReceipt(room, options = {}) {
 function missionRoomLines(room, receiptPath) {
   const timelineItems = (room.timeline_preview?.items || [])
     .map((item) => `    ${item.order}. ${item.title}: ${item.did} Meaning: ${item.meant}`);
+  const trustedRun = room.execution_mode === 'trusted_run';
   return [
     'Mission Room',
-    `  Chat zone: ${room.chat_zone?.status || 'clarifying'} (no goal runs until approve)`,
+    `  Chat zone: ${room.chat_zone?.status || 'clarifying'} (${trustedRun ? 'preview then run one bounded goal' : 'no goal runs until approve'})`,
     `  Task plan preview: ${room.task_plan_preview?.task || room.truth_snapshot}`,
     `  Mission: ${room.name}`,
     `  Member route: ${room.member_route?.suggested_member || room.owner} (editable; ${room.member_route?.why || room.member_context?.status || 'suggested'})`,
@@ -780,11 +829,11 @@ function missionRoomLines(room, receiptPath) {
     ...(timelineItems.length ? timelineItems : ['    1. Goal set: pending. Meaning: prove one visible step before the next goal.']),
     `  Thinking: ${room.thinking_memory?.path || 'atris/thinking.md'}`,
     `  Proactive suggestion: ${room.proactive_next_mission?.objective || room.goal_chain.first_goal}`,
-    `  Result landing: ${room.result?.landing?.status || 'pending_goal_run'} -> stays pending until a goal runs and proof exists`,
+    `  Result landing: ${room.result?.landing?.status || 'pending_goal_run'} -> ${trustedRun ? 'ready to start one bounded goal' : 'stays pending until a goal runs and proof exists'}`,
     `  Verifier: ${room.verifier}`,
     `  Share: ${room.share_line}`,
     `  Receipt: ${receiptPath}`,
-    `  After approve: ${room.approval_packet.approved_next_command}`,
+    `  ${trustedRun ? 'After preview' : 'After approve'}: ${room.approval_packet.approved_next_command}`,
   ];
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "scripts": {
     "test": "node --test",
+    "lint:decks": "node scripts/lint-all-decks.js",
     "publish:release": "node scripts/publish-atris-release.js",
     "prepare": "cp scripts/pre-commit .git/hooks/pre-commit 2>/dev/null && chmod +x .git/hooks/pre-commit || true"
   },

--- a/test/ax.test.js
+++ b/test/ax.test.js
@@ -343,6 +343,37 @@ test('ax routes connector reads to authenticated cloud context', () => {
   assert.equal(payload.connection_context.schema, 'atris.connection_capabilities.v1');
 });
 
+test('ax marks connector writes as isolated preview turns', () => {
+  const payload = ax.buildPayload('send gmail to ada@example.com about receipts', {
+    mode: 'fast',
+    route: 'cloud',
+    conversationId: 'ax-thread-1',
+    turnId: 'turn-123',
+    connectionContext: {
+      schema: 'atris.connection_capabilities.v1',
+      connections: [{
+        id: 'gmail',
+        connected: true,
+        authority: { list_messages: 'read_only', send_message: 'approval_required' },
+      }],
+    },
+  });
+
+  assert.equal(payload.max_turns, 1);
+  assert.equal(payload.turn_id, 'turn-123');
+  assert.equal(payload.conversation_id, 'ax-thread-1');
+  assert.equal(payload.external_action_policy, 'preview_then_explicit_approval');
+  assert.deepEqual(payload.connector_turn, {
+    schema: 'ax.connector_turn.v1',
+    scope: 'current_turn_only',
+    policy: 'preview_then_explicit_approval',
+    writes_require_approval: true,
+    turn_id: 'turn-123',
+    conversation_id: 'ax-thread-1',
+  });
+  assert.equal(payload.allow_external_actions, undefined);
+});
+
 test('ax sends chat history as structured previous messages, not a prompt wrapper', () => {
   const history = [
     { role: 'user', content: 'hi' },
@@ -654,6 +685,45 @@ test('ax renders approval preview rows from Atris2 receipts', () => {
   assert.match(rendered, /check\s+approval required/);
   assert.match(rendered, /wait\s+Approval needed before creation: calendar event "markoo" Jun 28, 2026 at 2:00 PM/);
   assert.equal(state.output, 'Accepted: markoo today at 2:00 PM.\nCalendar approval still needed before I create it.');
+});
+
+test('ax renders Gmail approval previews without leaking the body', () => {
+  const receipt = {
+    task_preview: {
+      task: 'gmail.send_message',
+      owner_member: 'comms',
+      status: 'approval_required',
+      missing: [],
+      slots: {
+        to: 'ada@example.com',
+        subject: 'Receipt review',
+      },
+    },
+    tool_events: [{
+      tool: 'gmail',
+      approval_request: {
+        connector: 'gmail',
+        action: 'send_message',
+        executor_action_type: 'gmail_send',
+        status: 'approval_required',
+        payload: {
+          to: ['ada@example.com'],
+          subject: 'Receipt review',
+          body: 'secret receipt body',
+        },
+      },
+    }],
+  };
+
+  const rendered = [
+    ...ax.formatTaskPreviewRows(receipt, { color: false }),
+    ax.formatApprovalReceipt(receipt),
+  ].join('\n');
+
+  assert.match(rendered, /owner\s+comms/);
+  assert.match(rendered, /plan\s+send Gmail to ada@example.com subject "Receipt review"/);
+  assert.match(rendered, /Approval needed before sending Gmail: to ada@example.com subject "Receipt review" \(body hidden until approved\)/);
+  assert.doesNotMatch(rendered, /secret receipt body/);
 });
 
 test('ax does not execute approval previews before explicit acceptance', async () => {
@@ -997,6 +1067,52 @@ test('ax stored approval preview includes exact approve command without payload 
     assert.match(listed, /wait\s+Approval needed before creation: calendar event "markoo" Jun 28, 2026 at 2:00 PM/);
     assert.match(listed, new RegExp(`approve\\s+ax --approve ${record.id}`));
     assert.doesNotMatch(listed, /secret payload text/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ax stored Gmail approval preview hides email body', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-gmail-approval-'));
+  const storePath = path.join(dir, 'approvals.json');
+  const receipt = {
+    task_preview: {
+      task: 'gmail.send_message',
+      owner_member: 'comms',
+      status: 'approval_required',
+      missing: [],
+      slots: {
+        to: 'ada@example.com',
+        subject: 'Receipt review',
+      },
+    },
+    tool_events: [{
+      tool: 'gmail',
+      approval_request: {
+        connector: 'gmail',
+        action: 'send_message',
+        executor_action_type: 'gmail_send',
+        status: 'approval_required',
+        payload: {
+          to: 'ada@example.com',
+          subject: 'Receipt review',
+          body: 'secret receipt body',
+        },
+      },
+    }],
+  };
+
+  try {
+    const request = ax.approvalRequestFromReceipt(receipt);
+    const record = ax.persistPendingApproval(receipt, request, { storePath, cwd: dir, mode: 'fast' });
+    const listed = ax.formatStoredApprovals(ax.readApprovalStore({ storePath }), { color: false });
+
+    assert.equal(record.id, request.approval_request_id);
+    assert.match(listed, /owner\s+comms/);
+    assert.match(listed, /plan\s+send Gmail to ada@example.com subject "Receipt review"/);
+    assert.match(listed, /wait\s+Approval needed before sending Gmail: to ada@example.com subject "Receipt review" \(body hidden until approved\)/);
+    assert.match(listed, new RegExp(`approve\\s+ax --approve ${record.id}`));
+    assert.doesNotMatch(listed, /secret receipt body/);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -17293,6 +17293,32 @@ test('feedback rejects unknown subcommands before submit fallback', () => {
 // unknown command warning
 // ============================================
 
+test('casual launch words route to the durable mission loop', () => {
+  const dir = makeTempDir();
+  try {
+    for (const args of [
+      ['start', '--json'],
+      ['go', '--json'],
+      ['keep', 'going', '--json'],
+    ]) {
+      const res = runCli(args, { cwd: dir });
+      assert.equal(res.status, 0, `${args.join(' ')} failed: ${res.stderr}`);
+      assert.equal(res.stderr, '');
+      const payload = JSON.parse(res.stdout);
+      assert.equal(payload.ok, true);
+      assert.equal(payload.action, 'start_mission_run');
+      assert.match(payload.route, /^atris mission run /);
+      assert.match(payload.objective, /self improve goal after goal/);
+      assert.equal(payload.expected_loop, 'mission_run');
+      assert.doesNotMatch(res.stdout, /Unknown command/i);
+      assert.doesNotMatch(res.stdout, /COPY\/PASTE PROMPT/i);
+      assert.doesNotMatch(res.stdout, /atris run --once/i);
+    }
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('unknown single-word command shows warning', () => {
   const dir = makeTempDir();
   try {

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -690,6 +690,45 @@ test('mission complete emits a human-readable landing receipt', () => {
   }
 });
 
+test('mission complete credits ad hoc passing receipt before no-verifier fallback', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const started = runCli([
+      'mission',
+      'start',
+      'ad hoc verifier completion receipt',
+      '--owner',
+      'mission-lead',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(started.status, 0, started.stderr || started.stdout);
+    const mission = JSON.parse(started.stdout).mission;
+
+    const tick = runCli([
+      'mission',
+      'tick',
+      mission.id,
+      '--verify',
+      'node -e "process.exit(0)"',
+      '--summary',
+      'Proved with an ad hoc verifier.',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(tick.status, 0, tick.stderr || tick.stdout);
+    const receiptPath = JSON.parse(tick.stdout).receipt_path;
+
+    const completed = runCli(['mission', 'complete', mission.id, '--proof', receiptPath, '--json'], { cwd: dir });
+    assert.equal(completed.status, 0, completed.stderr || completed.stdout);
+    const payload = JSON.parse(completed.stdout);
+    assert.equal(payload.mission.completion_gate.source, 'receipt');
+    assert.match(payload.landing.checked, /passing verifier receipt/);
+    assert.doesNotMatch(payload.landing.checked, /No verifier was configured/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('mission run objective starts with product takeoff instead of runner plumbing', () => {
   const dir = makeTempDir();
   try {
@@ -799,6 +838,89 @@ test('mission tick landing uses step summary when provided', () => {
     assert.match(ticked.stdout, /Changed: Made review landing proof high-level\./);
     assert.doesNotMatch(ticked.stdout, /Changed: overnight self improve loop is ready for review\./);
     assert.match(ticked.stdout, /How I checked: Verifier passed: node -e "process\.exit\(0\)"/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission tick receipt stores result.landing with high-level verifier meaning', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'smoke.test.js'), [
+      "const test = require('node:test');",
+      "const assert = require('node:assert/strict');",
+      "test('smoke behavior', () => assert.equal(1 + 1, 2));",
+      '',
+    ].join('\n'), 'utf8');
+    const started = runCli([
+      'mission',
+      'start',
+      'standard landing receipt mission',
+      '--owner',
+      'mission-lead',
+      '--verify',
+      'node --test smoke.test.js',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(started.status, 0, started.stderr || started.stdout);
+    const mission = JSON.parse(started.stdout).mission;
+
+    const ticked = runCli([
+      'mission',
+      'tick',
+      mission.id,
+      '--verify',
+      '--summary',
+      'Standardized mission proof receipts.',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(ticked.status, 0, ticked.stderr || ticked.stdout);
+    const payload = JSON.parse(ticked.stdout);
+    const receipt = JSON.parse(fs.readFileSync(path.join(dir, payload.receipt_path), 'utf8'));
+
+    assert.equal(receipt.result.landing.schema, 'atris.result_landing.v1');
+    assert.equal(receipt.result.landing.changed, 'Standardized mission proof receipts.');
+    assert.equal(receipt.result.landing.checked, 'I ran the behavior checks.');
+    assert.match(receipt.result.landing.tested, /Automated behavior checks passed/);
+    assert.match(receipt.result.landing.proof, /Receipt saved at atris\/runs\/mission-/);
+    assert.match(receipt.result.landing.next, /Review the proof, then complete the mission/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission timeline reads standard result.landing from tick receipts', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const started = runCli([
+      'mission',
+      'start',
+      'timeline standard landing receipt',
+      '--owner',
+      'mission-lead',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(started.status, 0, started.stderr || started.stdout);
+    const mission = JSON.parse(started.stdout).mission;
+
+    const ticked = runCli([
+      'mission',
+      'tick',
+      mission.id,
+      '--summary',
+      'Saved a human-readable landing receipt.',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(ticked.status, 0, ticked.stderr || ticked.stdout);
+
+    const timeline = runCli(['mission', 'timeline', mission.id, '--json'], { cwd: dir });
+    assert.equal(timeline.status, 0, timeline.stderr || timeline.stdout);
+    const payload = JSON.parse(timeline.stdout);
+    assert.equal(payload.current_landing.changed, 'Saved a human-readable landing receipt.');
+    assert.match(payload.current_landing.next, /Keep running the mission/);
+    assert.equal(payload.current_landing.receipt_path, JSON.parse(ticked.stdout).receipt_path);
   } finally {
     cleanupTempDir(dir);
   }
@@ -1031,6 +1153,7 @@ test('mission timeline lists saved landing changed and next lines', () => {
     assert.match(timeline.stdout, /Showing 1 item\./);
     assert.match(timeline.stdout, /Current landing:\n  Changed: Created and claimed next task: \S+ Add receipt timeline proof\./);
     assert.doesNotMatch(timeline.stdout, /History:/);
+    assert.doesNotMatch(timeline.stdout, /landing timeline codex loop recorded tick 1\./);
     assert.doesNotMatch(timeline.stdout, /  1\. Created and claimed next task/);
     assert.match(timeline.stdout, /Created and claimed next task: \S+ Add receipt timeline proof\./);
     assert.match(timeline.stdout, /Next: Created next task: \S+ Add receipt timeline proof\./);
@@ -2410,6 +2533,74 @@ test('mission room text output leads with chat zone before execution', () => {
   }
 });
 
+test('mission room trusted mode previews then permits one bounded run', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const memberDir = path.join(dir, 'atris', 'team', 'mission-lead');
+    fs.mkdirSync(path.join(memberDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(memberDir, 'MEMBER.md'), '# Mission Lead\n\nOwns Mission Room loops.\n', 'utf8');
+    fs.writeFileSync(path.join(memberDir, 'MISSION.md'), '# Mission\n\nTurn messy intent into proof-backed missions.\n', 'utf8');
+    fs.writeFileSync(path.join(memberDir, 'now.md'), '# Now\n\nMission Room context slice.\n', 'utf8');
+
+    const input = 'one-message autonomy: improve atris-cli usefully without creating junk state';
+    const res = runCli(['mission', 'room', input, '--owner', 'mission-lead', '--room-auto-run', '--json'], { cwd: dir });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.room.execution_mode, 'trusted_run');
+    assert.equal(payload.room.goal_chain.mode, 'trusted_run');
+    assert.equal(payload.room.chat_zone.status, 'ready_to_run');
+    assert.match(payload.room.chat_zone.execution_policy, /Trusted run/);
+    assert.equal(payload.room.result.landing.status, 'ready_to_run');
+    assert.match(payload.room.next_command, /^After preview:/);
+    assert.match(payload.room.approval_packet.approved_next_command, /--verify "git diff --check"/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run trusted room selects real task before creating mission state', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.atris', 'state'), { recursive: true });
+    const memberDir = path.join(dir, 'atris', 'team', 'mission-lead');
+    fs.mkdirSync(path.join(memberDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(memberDir, 'MEMBER.md'), '# Mission Lead\n\nOwns Mission Room loops.\n', 'utf8');
+    fs.writeFileSync(path.join(memberDir, 'MISSION.md'), '# Mission\n\nTurn messy intent into proof-backed missions.\n', 'utf8');
+    fs.writeFileSync(path.join(memberDir, 'now.md'), '# Now\n\nMission Room context slice.\n', 'utf8');
+    fs.writeFileSync(path.join(dir, '.atris', 'state', 'tasks.projection.json'), JSON.stringify({
+      tasks: [
+        {
+          id: 'task-1',
+          display_id: 'CLI-758',
+          title: 'Make atris go execute one useful bounded slice',
+          status: 'open',
+          tag: 'autonomy',
+          workspace_root: dir,
+        },
+      ],
+    }, null, 2), 'utf8');
+
+    const input = 'one-message autonomy: improve atris-cli usefully without creating junk state';
+    const res = runCli(['mission', 'run', input, '--owner', 'mission-lead', '--json'], { cwd: dir });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.action, 'mission_run_started');
+    assert.equal(payload.mission.objective, 'Make atris go execute one useful bounded slice');
+    assert.equal(payload.mission.verifier, 'git diff --check');
+    assert.equal(payload.mission.xp_task, undefined);
+    assert.equal(payload.mission.mission_run_preflight.trusted_run, true);
+    assert.equal(payload.mission.mission_run_preflight.selected_target.ref, 'CLI-758');
+    assert.notEqual(payload.mission.objective, input);
+    assert.doesNotMatch(payload.mission.objective, /go go go/i);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('mission room names next-mission decisions instead of recycling prior mission words', () => {
   const dir = makeTempDir();
   try {
@@ -2713,6 +2904,71 @@ test('mission run supports explicit whole-budget mode without manager jargon', (
     assert.equal(payload.budget_contract.plain_language, 'Use the whole time.');
     assert.match(payload.mission.stop_condition, /run for 20 minutes; use the whole time unless blocked or unsafe/);
     assert.match(payload.budget_contract.stop_rule, /keep picking the next useful move until time is up/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run can plan and advance a validated child-goal chain', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const run = runCli([
+      'mission',
+      'run',
+      'show me 3 or 4 goals done towards a novel mission that is validated and understandable',
+      '--owner',
+      'auto-improver',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const payload = JSON.parse(run.stdout);
+    const mission = payload.mission;
+
+    assert.equal(mission.goal_chain.schema, 'atris.mission_goal_chain.v1');
+    assert.equal(mission.goal_chain.target_count, 4);
+    assert.equal(mission.goal_chain.done_count, 0);
+    assert.equal(mission.goal_chain.goals.length, 4);
+    assert.match(mission.goal_chain.pause_rule, /Pause when the chain has proof/);
+
+    const statusBefore = runCli(['mission', 'status', mission.id], { cwd: dir });
+    assert.equal(statusBefore.status, 0, statusBefore.stderr || statusBefore.stdout);
+    assert.match(statusBefore.stdout, /goal chain: 0\/4 done/);
+
+    ackNativeCodexGoal(dir, mission);
+    let latest = mission;
+    for (let index = 1; index <= 4; index += 1) {
+      const tickArgs = [
+        'mission',
+        'tick',
+        mission.id,
+        '--summary',
+        `goal ${index}: proof recorded for child goal ${index}`,
+        '--json',
+      ];
+      if (index === 3) tickArgs.splice(6, 0, '--verify', 'node -e "process.exit(0)"');
+      const tick = runCli(tickArgs, { cwd: dir });
+      assert.equal(tick.status, 0, tick.stderr || tick.stdout);
+      const tickPayload = JSON.parse(tick.stdout);
+      latest = tickPayload.mission;
+      assert.equal(latest.goal_chain.done_count, index);
+      assert.equal(latest.goal_chain.goals[index - 1].status, 'done');
+      if (index === 3) {
+        assert.equal(tickPayload.verifier_result.passed, true);
+        assert.equal(latest.status, 'running');
+        assert.match(latest.next_action, /continue child goal 4/);
+      }
+    }
+
+    assert.equal(latest.status, 'ready');
+    assert.equal(latest.goal_chain.status, 'validated');
+    assert.equal(latest.goal_chain.pause_ready, true);
+    assert.match(latest.next_action, /mission feels good/);
+
+    const status = runCli(['mission', 'status', mission.id], { cwd: dir });
+    assert.equal(status.status, 0, status.stderr || status.stdout);
+    assert.match(status.stdout, /goal chain: 4\/4 done/);
+    assert.match(status.stdout, /\[x\] 4\. Explain the pause or next goal/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -3038,6 +3294,181 @@ test('continuation mission chooses next mission instead of passing on inherited 
   }
 });
 
+test('continuation mission includes member value preview before starting next mission', { skip: !hasNodeSqlite() && 'node:sqlite unavailable' }, () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'ROADMAP.md'), [
+      '# Roadmap',
+      '',
+      '## Open loop items',
+      '',
+      '- [ ] Ship ax connector turn isolation and Gmail receipt previews',
+      '',
+    ].join('\n'), 'utf8');
+    appendMissionState(dir, {
+      id: 'mission-choice-preview',
+      slug: 'mission-choice-preview',
+      owner: 'researcher',
+      objective: 'Decide and start the next useful mission after: run awake loop with member taste',
+      status: 'planning',
+      runner: 'codex_goal',
+      verifier: '',
+      started_from: 'mission_run_continuation',
+      continuation_policy: 'choose_next_mission',
+      parent_mission_id: 'mission-parent',
+      parent_objective: 'run awake loop with member taste',
+      native_goal_ack: {
+        runtime: 'codex',
+        status: 'active',
+        objective: 'Decide and start the next useful mission after: run awake loop with member taste',
+      },
+      created_at: '2026-06-30T12:00:00.000Z',
+      updated_at: '2026-06-30T12:00:00.000Z',
+    });
+
+    const attached = runCli(['mission', 'attach-task', 'mission-choice-preview', '--json'], { cwd: dir });
+    assert.equal(attached.status, 0, attached.stderr || attached.stdout);
+    const attachedPayload = JSON.parse(attached.stdout);
+    assert.match(attachedPayload.mission.next_action, /atris mission run 'Ship ax connector turn isolation and Gmail receipt previews' --owner researcher/);
+    assert.equal(attachedPayload.mission.next_action_preview.schema, 'atris.mission_value_preview.v1');
+    assert.equal(attachedPayload.mission.next_action_preview.profile.id, 'technical_homerun');
+    assert.equal(
+      attachedPayload.mission.next_action_preview.feynman.what,
+      'Make ax safer with Gmail: keep each chat request separate, and show a clear preview or receipt before Gmail actions.',
+    );
+    assert.match(attachedPayload.mission.next_action_preview.feynman.why_now, /technical bet/);
+    assert.match(attachedPayload.mission.next_action_preview.feynman.validation, /before\/after receipt/);
+
+    const ack = ackNativeCodexGoal(dir, attachedPayload.mission);
+    assert.equal(ack.codex_goal_state.goal.next_action_preview.feynman.what, attachedPayload.mission.next_action_preview.feynman.what);
+
+    const status = runCli(['mission', 'status', 'mission-choice-preview'], { cwd: dir });
+    assert.equal(status.status, 0, status.stderr || status.stdout);
+    assert.match(status.stdout, /preview: Make ax safer with Gmail/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('continuation mission uses taste memory and recent logs when scoring next mission', { skip: !hasNodeSqlite() && 'node:sqlite unavailable' }, () => {
+  const dir = makeTempDir();
+  const previousDb = process.env.ATRIS_TASKS_DB;
+  let taskDb = null;
+  try {
+    const taskDbPath = path.join(dir, '.atris', 'tasks.db');
+    process.env.ATRIS_TASKS_DB = taskDbPath;
+    taskDb = require('../lib/task-db');
+    taskDb.close();
+
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'atris', 'team', 'auto-improver', 'logs'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'atris', 'logs', '2026'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'ROADMAP.md'), [
+      '# Roadmap',
+      '',
+      '## Open loop items',
+      '',
+      '- [ ] Build compiler benchmark harness',
+      '- [ ] Ship onboarding proof preview for customer demo',
+      '',
+    ].join('\n'), 'utf8');
+    fs.writeFileSync(path.join(dir, 'atris', 'thinking.md'), [
+      '# thinking.md',
+      '',
+      '- 30 days of runway means prefer user/revenue proof over clever work.',
+      '- Everything should be plain English and easy to understand.',
+      '- Proof and receipts matter before accept.',
+      '',
+    ].join('\n'), 'utf8');
+    fs.writeFileSync(path.join(dir, 'atris', 'team', 'auto-improver', 'MISSION.md'), [
+      '# Auto-Improver Mission',
+      '',
+      '- Prevent repeated token waste.',
+      '- Keep technical work only when it creates visible proof.',
+      '',
+    ].join('\n'), 'utf8');
+    fs.writeFileSync(path.join(dir, 'atris', 'logs', '2026', '2026-07-01.md'), [
+      '# 2026-07-01',
+      '',
+      '- Recent logs are working memory: focus on demo-ready proof and users.',
+      '',
+    ].join('\n'), 'utf8');
+    fs.writeFileSync(path.join(dir, 'atris', 'team', 'auto-improver', 'logs', '2026-07-01.md'), [
+      '# 2026-07-01',
+      '',
+      '- Working memory: do not waste tokens; simplify the next preview.',
+      '',
+    ].join('\n'), 'utf8');
+    const db = taskDb.open();
+    const acceptedTask = taskDb.addTask(db, {
+      title: 'Accepted demo proof path',
+      status: 'done',
+      tag: 'taste',
+      workspaceRoot: taskDb.workspaceRoot(dir),
+    });
+    taskDb.reviewTask(db, {
+      id: acceptedTask.id,
+      actor: 'keshav',
+      reward: 1,
+      proof: 'Plain customer demo proof was accepted.',
+    });
+    const revisedTask = taskDb.addTask(db, {
+      title: 'Rejected jargon plan',
+      status: 'review',
+      claimedBy: 'auto-improver',
+      tag: 'taste',
+      workspaceRoot: taskDb.workspaceRoot(dir),
+    });
+    taskDb.reviseTask(db, {
+      id: revisedTask.id,
+      actor: 'keshav',
+      note: 'Too much jargon; explain in simple terms first.',
+    });
+    appendMissionState(dir, {
+      id: 'mission-choice-memory',
+      slug: 'mission-choice-memory',
+      owner: 'auto-improver',
+      objective: 'Decide and start the next useful mission after: use taste memory',
+      status: 'planning',
+      runner: 'codex_goal',
+      verifier: '',
+      started_from: 'mission_run_continuation',
+      continuation_policy: 'choose_next_mission',
+      parent_mission_id: 'mission-parent',
+      parent_objective: 'use taste memory',
+      native_goal_ack: {
+        runtime: 'codex',
+        status: 'active',
+        objective: 'Decide and start the next useful mission after: use taste memory',
+      },
+      created_at: '2026-06-30T12:00:00.000Z',
+      updated_at: '2026-06-30T12:00:00.000Z',
+    });
+
+    const attached = runCli(['mission', 'attach-task', 'mission-choice-memory', '--json'], { cwd: dir, env: { ATRIS_TASKS_DB: taskDbPath } });
+    assert.equal(attached.status, 0, attached.stderr || attached.stdout);
+    const payload = JSON.parse(attached.stdout);
+    assert.match(payload.mission.next_action, /atris mission run 'Ship onboarding proof preview for customer demo' --owner auto-improver/);
+    const preview = payload.mission.next_action_preview;
+    assert.equal(preview.taste_memory.schema, 'atris.mission_taste_memory.v1');
+    assert.equal(preview.taste_memory.sources.thinking_md.present, true);
+    assert.equal(preview.taste_memory.sources.member_mission.present, true);
+    assert.equal(preview.taste_memory.sources.recent_logs.length, 2);
+    assert.equal(preview.taste_memory.sources.task_history.accepted.length, 1);
+    assert.equal(preview.taste_memory.sources.task_history.revised.length, 1);
+    assert(preview.score.memory_boost > 0);
+    assert(preview.taste_memory.signals.some((signal) => signal.id === 'working_memory'));
+    assert.match(preview.feynman.why_now, /Taste memory says:/);
+    assert.match(preview.feynman.taste, /runway|plain-English|proof|working memory/i);
+  } finally {
+    if (taskDb) taskDb.close();
+    if (previousDb === undefined) delete process.env.ATRIS_TASKS_DB;
+    else process.env.ATRIS_TASKS_DB = previousDb;
+    cleanupTempDir(dir);
+  }
+});
+
 test('continuation mission stops instead of returning placeholder when no concrete next mission exists', () => {
   const dir = makeTempDir();
   try {
@@ -3126,6 +3557,56 @@ test('continuation mission skips report target that was already handled', () => 
     const ack = ackNativeCodexGoal(dir, attachedPayload.mission);
     assert.match(ack.codex_goal_state.goal.next_command, /atris mission stop mission-choice-handled-report --reason 'no concrete follow-up mission found in Atris state' --json/);
     assert.doesNotMatch(ack.codex_goal_state.goal.next_command, /Repeat done thing/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('continuation mission skips report target that already exists as ready work', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris', 'reports'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'atris', 'reports', '2099-01-02-proof.md'), [
+      '# Proof',
+      '',
+      'Suggested target: repeat active thing.',
+      '',
+    ].join('\n'), 'utf8');
+    appendMissionState(dir, {
+      id: 'mission-repeat-active-thing',
+      slug: 'mission-repeat-active-thing',
+      objective: 'Repeat active thing',
+      status: 'ready',
+      runner: 'codex_goal',
+      verifier: '',
+      created_at: '2026-06-30T11:00:00.000Z',
+      updated_at: '2026-06-30T11:05:00.000Z',
+    });
+    appendMissionState(dir, {
+      id: 'mission-choice-active-report',
+      slug: 'mission-choice-active-report',
+      objective: 'Decide and start the next useful mission after: finish active report',
+      status: 'planning',
+      runner: 'codex_goal',
+      verifier: '',
+      started_from: 'mission_run_continuation',
+      continuation_policy: 'choose_next_mission',
+      parent_mission_id: 'mission-parent-active-report',
+      parent_objective: 'finish active report',
+      native_goal_ack: {
+        runtime: 'codex',
+        status: 'active',
+        objective: 'Decide and start the next useful mission after: finish active report',
+      },
+      created_at: '2026-06-30T12:00:00.000Z',
+      updated_at: '2026-06-30T12:00:00.000Z',
+    });
+
+    const attached = runCli(['mission', 'attach-task', 'mission-choice-active-report', '--json'], { cwd: dir });
+    assert.equal(attached.status, 0, attached.stderr || attached.stdout);
+    const attachedPayload = JSON.parse(attached.stdout);
+    assert.match(attachedPayload.mission.next_action, /atris mission stop mission-choice-active-report --reason 'no concrete follow-up mission found in Atris state' --json/);
+    assert.doesNotMatch(attachedPayload.mission.next_action, /Repeat active thing/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -3770,6 +4251,260 @@ test('mission goal skips human-gated ready missions', () => {
     assert.equal(payload.action, 'codex_goal_candidate');
     assert.equal(payload.goal.mission_id, 'older-codex-work');
   } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission goal skips agent-certified mission tasks waiting for human accept', { skip: !hasNodeSqlite() && 'node:sqlite unavailable' }, () => {
+  const dir = makeTempDir();
+  const previousDb = process.env.ATRIS_TASKS_DB;
+  let taskDb = null;
+  try {
+    const taskDbPath = path.join(dir, '.atris', 'tasks.db');
+    process.env.ATRIS_TASKS_DB = taskDbPath;
+    taskDb = require('../lib/task-db');
+    taskDb.close();
+
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const db = taskDb.open();
+    const task = taskDb.addTask(db, {
+      title: 'Mission XP: certified waiting task',
+      status: 'review',
+      claimedBy: 'auto-improver',
+      tag: 'agent-xp',
+      workspaceRoot: taskDb.workspaceRoot(dir),
+      metadata: {
+        approval_status: 'pending',
+        agent_review_pass_count: 2,
+        agent_certified: true,
+        goal_id: 'human-waiting-codex',
+      },
+    });
+
+    appendMissionState(dir, {
+      id: 'older-codex-work',
+      slug: 'older-codex-work',
+      objective: 'older executable codex mission',
+      status: 'running',
+      runner: 'codex_goal',
+      verifier: 'true',
+      created_at: '2026-05-01T00:00:00.000Z',
+      updated_at: '2026-05-01T00:00:00.000Z',
+    });
+    appendMissionState(dir, {
+      id: 'human-waiting-codex',
+      slug: 'human-waiting-codex',
+      objective: 'certified mission waiting for human accept',
+      status: 'ready',
+      runner: 'codex_goal',
+      verifier: 'true',
+      always_on: true,
+      task_id: task.id,
+      current_task_id: task.id,
+      task_ids: [task.id],
+      xp_task: {
+        task_id: task.id,
+        ref: 'CLI-999',
+      },
+      created_at: '2026-05-02T00:00:00.000Z',
+      updated_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const selected = selectCodexGoalMission(dir);
+    assert.equal(selected.mission.id, 'older-codex-work');
+    const due = selectDueMission(dir);
+    assert.equal(due.id, 'older-codex-work');
+
+    const goal = runCli(['mission', 'goal', '--json'], { cwd: dir, env: { ATRIS_TASKS_DB: taskDbPath } });
+    assert.equal(goal.status, 0, goal.stderr || goal.stdout);
+    const payload = JSON.parse(goal.stdout);
+    assert.equal(payload.action, 'codex_goal_candidate');
+    assert.equal(payload.goal.mission_id, 'older-codex-work');
+  } finally {
+    if (taskDb) taskDb.close();
+    if (previousDb === undefined) delete process.env.ATRIS_TASKS_DB;
+    else process.env.ATRIS_TASKS_DB = previousDb;
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission goal seeds next-move continuation after certified mission waits for human accept', { skip: !hasNodeSqlite() && 'node:sqlite unavailable' }, () => {
+  const dir = makeTempDir();
+  const previousDb = process.env.ATRIS_TASKS_DB;
+  let taskDb = null;
+  try {
+    const taskDbPath = path.join(dir, '.atris', 'tasks.db');
+    process.env.ATRIS_TASKS_DB = taskDbPath;
+    taskDb = require('../lib/task-db');
+    taskDb.close();
+
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const db = taskDb.open();
+    const task = taskDb.addTask(db, {
+      title: 'Mission XP: certified waiting task',
+      status: 'review',
+      claimedBy: 'auto-improver',
+      tag: 'agent-xp',
+      workspaceRoot: taskDb.workspaceRoot(dir),
+      metadata: {
+        approval_status: 'pending',
+        agent_review_pass_count: 2,
+        agent_certified: true,
+        goal_id: 'human-waiting-codex',
+      },
+    });
+
+    appendMissionState(dir, {
+      id: 'human-waiting-codex',
+      slug: 'human-waiting-codex',
+      objective: 'certified mission waiting for human accept',
+      status: 'ready',
+      runner: 'codex_goal',
+      verifier: 'true',
+      always_on: true,
+      continue_on_complete: true,
+      receipt_path: 'atris/runs/proof.json',
+      task_id: task.id,
+      current_task_id: task.id,
+      task_ids: [task.id],
+      xp_task: {
+        task_id: task.id,
+        ref: 'CLI-999',
+      },
+      created_at: '2026-05-02T00:00:00.000Z',
+      updated_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const goal = runCli(['mission', 'goal', '--json'], { cwd: dir, env: { ATRIS_TASKS_DB: taskDbPath } });
+    assert.equal(goal.status, 0, goal.stderr || goal.stdout);
+    const payload = JSON.parse(goal.stdout);
+    assert.equal(payload.action, 'codex_goal_candidate');
+    assert.equal(payload.goal.reason, 'next_move_continuation_seeded');
+    assert.equal(
+      payload.goal.objective,
+      'Decide and start the next useful mission after: certified mission waiting for human accept',
+    );
+    assert.equal(payload.goal.seeded_continuation_goal.inserted, true);
+    assert.equal(payload.goal.seeded_continuation_goal.parent.id, 'human-waiting-codex');
+    assert.equal(payload.goal.mission_id, payload.goal.seeded_continuation_goal.mission.id);
+    assert.equal(payload.goal.seeded_continuation_goal.mission.started_from, 'mission_run_continuation');
+    assert.equal(payload.goal.seeded_continuation_goal.mission.continuation_policy, 'choose_next_mission');
+
+    const secondGoal = runCli(['mission', 'goal', '--json'], { cwd: dir, env: { ATRIS_TASKS_DB: taskDbPath } });
+    assert.equal(secondGoal.status, 0, secondGoal.stderr || secondGoal.stdout);
+    const secondPayload = JSON.parse(secondGoal.stdout);
+    assert.equal(secondPayload.goal.mission_id, payload.goal.mission_id);
+  } finally {
+    if (taskDb) taskDb.close();
+    if (previousDb === undefined) delete process.env.ATRIS_TASKS_DB;
+    else process.env.ATRIS_TASKS_DB = previousDb;
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission goal ignores completed handoff continuations when seeding the next mission', { skip: !hasNodeSqlite() && 'node:sqlite unavailable' }, () => {
+  const dir = makeTempDir();
+  const previousDb = process.env.ATRIS_TASKS_DB;
+  let taskDb = null;
+  try {
+    const taskDbPath = path.join(dir, '.atris', 'tasks.db');
+    process.env.ATRIS_TASKS_DB = taskDbPath;
+    taskDb = require('../lib/task-db');
+    taskDb.close();
+
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const db = taskDb.open();
+    const staleTask = taskDb.addTask(db, {
+      title: 'Mission XP: stale parent waiting',
+      status: 'review',
+      claimedBy: 'auto-improver',
+      tag: 'agent-xp',
+      workspaceRoot: taskDb.workspaceRoot(dir),
+      metadata: {
+        approval_status: 'pending',
+        agent_review_pass_count: 2,
+        agent_certified: true,
+        goal_id: 'stale-parent',
+      },
+    });
+    const currentTask = taskDb.addTask(db, {
+      title: 'Mission XP: current planning waiting',
+      status: 'review',
+      claimedBy: 'auto-improver',
+      tag: 'agent-xp',
+      workspaceRoot: taskDb.workspaceRoot(dir),
+      metadata: {
+        approval_status: 'pending',
+        agent_review_pass_count: 2,
+        agent_certified: true,
+        goal_id: 'current-planning',
+      },
+    });
+
+    appendMissionState(dir, {
+      id: 'current-planning',
+      slug: 'current-planning',
+      objective: 'current certified planning mission',
+      status: 'planning',
+      runner: 'codex_goal',
+      continue_on_complete: true,
+      task_id: currentTask.id,
+      current_task_id: currentTask.id,
+      task_ids: [currentTask.id],
+      xp_task: {
+        task_id: currentTask.id,
+        ref: 'CLI-1000',
+      },
+      created_at: '2026-05-02T00:00:00.000Z',
+      updated_at: '2026-05-02T00:00:00.000Z',
+    });
+    appendMissionState(dir, {
+      id: 'stale-parent',
+      slug: 'stale-parent',
+      objective: 'stale parent mission',
+      status: 'ready',
+      runner: 'codex_goal',
+      continue_on_complete: true,
+      continuation_seeded_mission_id: 'stale-continuation',
+      task_id: staleTask.id,
+      current_task_id: staleTask.id,
+      task_ids: [staleTask.id],
+      xp_task: {
+        task_id: staleTask.id,
+        ref: 'CLI-999',
+      },
+      created_at: '2026-05-03T00:00:00.000Z',
+      updated_at: '2026-05-03T00:00:00.000Z',
+    });
+    appendMissionState(dir, {
+      id: 'stale-continuation',
+      slug: 'stale-continuation',
+      objective: 'Decide and start the next useful mission after: stale parent mission',
+      status: 'complete',
+      runner: 'codex_goal',
+      started_from: 'mission_run_continuation',
+      continuation_policy: 'choose_next_mission',
+      parent_mission_id: 'stale-parent',
+      continued_by_mission_id: 'already-started',
+      created_at: '2026-05-03T00:01:00.000Z',
+      updated_at: '2026-05-03T00:01:00.000Z',
+    });
+
+    const goal = runCli(['mission', 'goal', '--json'], { cwd: dir, env: { ATRIS_TASKS_DB: taskDbPath } });
+    assert.equal(goal.status, 0, goal.stderr || goal.stdout);
+    const payload = JSON.parse(goal.stdout);
+    assert.equal(payload.action, 'codex_goal_candidate');
+    assert.equal(payload.goal.reason, 'next_move_continuation_seeded');
+    assert.equal(payload.goal.seeded_continuation_goal.parent.id, 'current-planning');
+    assert.notEqual(payload.goal.mission_id, 'stale-continuation');
+    assert.equal(
+      payload.goal.objective,
+      'Decide and start the next useful mission after: current certified planning mission',
+    );
+  } finally {
+    if (taskDb) taskDb.close();
+    if (previousDb === undefined) delete process.env.ATRIS_TASKS_DB;
+    else process.env.ATRIS_TASKS_DB = previousDb;
     cleanupTempDir(dir);
   }
 });


### PR DESCRIPTION
## What changed

This makes mission proof receipts understandable by default.

Every mission receipt now gets a human landing with:

- `changed`: what actually changed
- `checked`: how it was checked
- `tested`: what the verifier meant in plain English
- `proof`: where the receipt lives
- `next`: what decision comes next

Actual live landing from this run:

```text
Changed: Standardized result.landing receipts for mission.
How I checked: I ran the behavior checks.
What I tested: Mission behavior checks passed: mission start, tick, completion, timeline landing, goal-chain, next-mission, and human-accept boundaries were exercised.
Proof: Receipt saved at atris/runs/mission-mission-2026-07-01-make-this-the-standard-for-e-51a237bd-2026-07-01T10-08-44-652Z.json.
Next: Review the proof, then complete the mission.
```

Also included in this push:

- mission child-goal chains for 3-4 goal missions
- continuation selection that skips already-running or completed targets
- trusted Mission Room auto-run path for bounded self-improvement requests
- `atris start` / casual launch routing into the durable mission loop
- ax connector write isolation and Gmail approval previews that hide message bodies

## Why

The old proof could say `90/90` or `result.landing` and still fail the human test.

This PR makes the receipt itself explain why the work is believable without requiring the operator to read logs or test output.

## Validation

- `node -c ax`
- `node -c bin/atris.js`
- `node -c commands/mission.js`
- `node --test test/ax.test.js test/commands.test.js test/mission-status.test.js` passed `509/509`
- `git diff --check`

## Review note

This branch includes the pre-existing local commit `8a52188b Add launchpad command-center MAP entry (CLI-763)` because the checkout was already ahead of `origin/master` before this commit.