### PR TITLE
[codex] surface provider seed wedge in benchmark compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ What to inspect:
 - `atris experiments replay endstate` runs the full public dry-run rehearsal
 - the benchmark contract lives at `atris/features/endstate/contract.md`
 - the verification log lives at `atris/features/endstate/validate.md`
+- receipts can include `provider_seed`; if a seeded provider row is wedged,
+  compare reports the run as inconclusive instead of a normal score decision
 
 The stack wins Level 1 only if it beats the baseline on total score and does
 not lose the reviewed completion category.

--- a/atris/features/endstate/artifact-schema.json
+++ b/atris/features/endstate/artifact-schema.json
@@ -71,6 +71,15 @@
           "items": { "type": "string" }
         }
       }
+    },
+    "provider_seed": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string", "enum": ["ok", "wedged", "inconclusive", "missing", "skipped"] },
+        "provider": { "type": "string" },
+        "row_id": { "type": "string" },
+        "reason": { "type": "string" }
+      }
     }
   }
 }

--- a/atris/features/endstate/contract.md
+++ b/atris/features/endstate/contract.md
@@ -55,6 +55,7 @@ Each run must emit:
 - wiki delta or `not_applicable`
 - elapsed time
 - intervention count
+- optional `provider_seed` health when the run depends on a seeded provider row
 
 Schema source of truth: `atris/features/endstate/artifact-schema.json`
 
@@ -86,5 +87,7 @@ The stack wins Level 1 if it beats the baseline on total score and does not lose
 
 - The benchmark harness can validate both packs, emit dry-run receipts, compare
   the latest artifacts, and replay that full public rehearsal in one command.
+- Comparisons report wedged provider seed rows as inconclusive re-cert state, so
+  provider infrastructure failures do not masquerade as a stack-vs-baseline loss.
 - The remaining gap is not tooling. It is evidence: a real head-to-head result
   on pinned snapshots that clears the Level 1 rule.

--- a/commands/experiments.js
+++ b/commands/experiments.js
@@ -16,6 +16,7 @@ const {
   scoreEndstateArtifact,
   summarizeReview,
   writeArtifact,
+  providerSeedDiagnostic,
 } = require('../lib/endstate');
 
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -463,7 +464,9 @@ function formatCompareLine(label, entry) {
   const score = getArtifactScore(artifact);
   const review = artifact.review?.status || 'unknown';
   const interventions = artifact.interventions?.count || 0;
-  return `  ${label}: ${score}/100 | review: ${review} | interventions: ${interventions} | artifact: ${path.relative(process.cwd(), entry.filePath)}`;
+  const providerSeed = providerSeedDiagnostic(artifact);
+  const seedStatus = providerSeed ? ` | provider seed: ${providerSeed.status}` : '';
+  return `  ${label}: ${score}/100 | review: ${review} | interventions: ${interventions}${seedStatus} | artifact: ${path.relative(process.cwd(), entry.filePath)}`;
 }
 
 function experimentsCompare(target = 'endstate') {
@@ -486,7 +489,9 @@ function experimentsCompare(target = 'endstate') {
     console.log(formatCompareLine('baseline', baselineEntry));
     console.log(formatCompareLine('stack', stackEntry));
     console.log('');
-    if (comparison.winner === 'stack') {
+    if (comparison.inconclusive) {
+      console.log('Decision: inconclusive.');
+    } else if (comparison.winner === 'stack') {
       console.log('Decision: stack wins.');
     } else {
       console.log('Decision: no winner yet.');

--- a/lib/endstate.js
+++ b/lib/endstate.js
@@ -139,6 +139,43 @@ function getReviewRank(artifact) {
   return 0;
 }
 
+function compactReason(text, fallback = 'provider seed row wedged') {
+  const clean = String(text || '').trim().replace(/\s+/g, ' ');
+  if (!clean) return fallback;
+  return clean.length > 180 ? `${clean.slice(0, 177)}...` : clean;
+}
+
+function providerSeedDiagnostic(artifact) {
+  const seed = artifact?.provider_seed || artifact?.providerSeed || null;
+  const explicitStatus = String(seed?.status || artifact?.provider_seed_status || '').trim().toLowerCase();
+  const explicitReason = seed?.reason || artifact?.provider_seed_reason || '';
+  const text = [
+    explicitStatus,
+    explicitReason,
+    artifact?.review?.summary,
+    artifact?.notes,
+    ...(Array.isArray(artifact?.tests) ? artifact.tests.map((test) => `${test.command || ''} ${test.status || ''}`) : []),
+  ].filter(Boolean).join(' ');
+
+  const hasSeedProvider = /\b(provider[_ -]?seed|seed[_ -]?provider|seeded provider|provider row|seed row)\b/i.test(text)
+    || (/\bprovider\b/i.test(text) && /\bseed(?:ed|s|ing)?\b/i.test(text));
+  const isWedged = /\b(wedged|inconclusive|blocked|stale|timeout|timed out|hung|missing|unavailable|failed)\b/i.test(text);
+
+  if (!hasSeedProvider || !isWedged) return null;
+
+  const status = /inconclusive/i.test(explicitStatus || text) ? 'inconclusive' : 'wedged';
+  const provider = seed?.provider || artifact?.provider || null;
+  const rowId = seed?.row_id || seed?.rowId || artifact?.provider_seed_row_id || null;
+  const reason = compactReason(explicitReason || artifact?.review?.summary || artifact?.notes);
+
+  return {
+    status,
+    provider,
+    row_id: rowId,
+    reason,
+  };
+}
+
 function readLatestArtifact(packDir) {
   const artifactsDir = path.join(packDir, 'artifacts');
   if (!fs.existsSync(artifactsDir)) {
@@ -165,6 +202,28 @@ function compareEndstateArtifacts(baselineEntry, stackEntry) {
   const stackScore = getArtifactScore(stackEntry.artifact);
   const baselineReview = getReviewRank(baselineEntry.artifact);
   const stackReview = getReviewRank(stackEntry.artifact);
+  const providerSeedDiagnostics = {
+    baseline: providerSeedDiagnostic(baselineEntry.artifact),
+    stack: providerSeedDiagnostic(stackEntry.artifact),
+  };
+  const providerSeedBlocked = Object.entries(providerSeedDiagnostics)
+    .filter(([, diagnostic]) => diagnostic)
+    .map(([track, diagnostic]) => ({ track, ...diagnostic }));
+
+  if (providerSeedBlocked.length > 0) {
+    const details = providerSeedBlocked
+      .map((item) => `${item.track}${item.provider ? `/${item.provider}` : ''}: ${item.reason}`)
+      .join('; ');
+    return {
+      winner: 'none',
+      leader: 'inconclusive',
+      reason: `Inconclusive provider seed re-cert: ${details}. Fix or reseed the provider row, then rerun the benchmark comparison.`,
+      baselineScore,
+      stackScore,
+      inconclusive: true,
+      providerSeedDiagnostics,
+    };
+  }
 
   const stackWins = stackScore > baselineScore && stackReview >= baselineReview;
   const leader = stackScore === baselineScore
@@ -188,6 +247,8 @@ function compareEndstateArtifacts(baselineEntry, stackEntry) {
     reason,
     baselineScore,
     stackScore,
+    inconclusive: false,
+    providerSeedDiagnostics,
   };
 }
 
@@ -251,6 +312,7 @@ module.exports = {
   getArtifactScore,
   getGitHead,
   inferTestResults,
+  providerSeedDiagnostic,
   readLatestArtifact,
   readTextIfExists,
   scoreEndstateArtifact,

--- a/test/experiments.test.js
+++ b/test/experiments.test.js
@@ -85,6 +85,35 @@ function prepareEndstateWorkspace(dir) {
   }
 }
 
+function writeEndstateArtifact(dir, slug, artifact) {
+  const artifactsDir = path.join(dir, 'atris', 'experiments', slug, 'artifacts');
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(artifactsDir, `${artifact.run_id}.json`),
+    JSON.stringify(artifact, null, 2),
+    'utf8'
+  );
+}
+
+function endstateArtifact(overrides = {}) {
+  const track = overrides.track || 'baseline';
+  return {
+    run_id: overrides.run_id || `2099-01-01T00-00-00-000Z-${track}`,
+    track,
+    repo_commits: { atris_cli: 'cli-sha', atrisos_backend: 'backend-sha' },
+    task_brief: 'prove the benchmark comparison path',
+    prompt_context: 'benchmark prompt context',
+    changed_files: [],
+    tests: [{ command: 'node --test test/experiments.test.js', status: 'pass' }],
+    review: { status: 'draft', summary: 'draft benchmark receipt' },
+    wiki: { status: 'not_applicable', before: '', after: '' },
+    elapsed_seconds: 0,
+    interventions: { count: 0, events: [] },
+    score: 35,
+    ...overrides,
+  };
+}
+
 test('init creates experiments framework assets', () => {
   const dir = makeTempDir();
   try {
@@ -336,6 +365,39 @@ test('experiments compare endstate summarizes the latest receipts', { skip: !pyt
     assert.match(compare.stdout, /stack: 35\/100 \| review: draft \| interventions: 0/);
     assert.match(compare.stdout, /Decision: no winner yet\./);
     assert.match(compare.stdout, /Scores are tied at 35\/100/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('experiments compare endstate reports provider seed wedge as inconclusive', () => {
+  const dir = makeTempDir();
+  try {
+    prepareEndstateWorkspace(dir);
+    writeEndstateArtifact(dir, 'endstate-baseline', endstateArtifact({
+      run_id: '2099-01-01T00-00-00-000Z-baseline',
+      track: 'baseline',
+    }));
+    writeEndstateArtifact(dir, 'endstate-stack', endstateArtifact({
+      run_id: '2099-01-01T00-00-00-000Z-stack',
+      track: 'stack',
+      review: {
+        status: 'fail',
+        summary: 'provider row seed-42 wedged during re-cert',
+      },
+      provider_seed: {
+        status: 'wedged',
+        provider: 'fireworks',
+        row_id: 'seed-42',
+        reason: 'provider row seed-42 wedged during re-cert',
+      },
+    }));
+
+    const compare = runCli(['experiments', 'compare', 'endstate'], { cwd: dir });
+    assert.equal(compare.status, 0, compare.stderr);
+    assert.match(compare.stdout, /stack: 35\/100 \| review: fail \| interventions: 0 \| provider seed: wedged/);
+    assert.match(compare.stdout, /Decision: inconclusive\./);
+    assert.match(compare.stdout, /stack\/fireworks: provider row seed-42 wedged during re-cert/);
   } finally {
     cleanupTempDir(dir);
   }


### PR DESCRIPTION
## Summary
- add optional provider_seed health to Endstate benchmark artifacts
- make benchmark comparison report wedged provider seed rows as inconclusive re-cert state
- document the field and cover the stack/fireworks seed-42 wedge regression

## Validation
- node --test test/experiments.test.js
- git diff --check origin/master...HEAD
- node bin/atris.js experiments compare endstate
- node bin/atris.js experiments replay endstate