### PR TITLE
mission runner tells a sleeping backend apart from a real failure and retries instead of p (CLI-845, built by codex)

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -5561,6 +5561,22 @@ function consecutiveSameReasonErrors(ticks) {
   return { reason: last.reason, count };
 }
 
+function isTransientAtris2BackendError(error) {
+  const text = String(error || '');
+  if (!text) return false;
+  return /\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|EPIPE)\b/i.test(text)
+    || /\b(?:socket hang up|request timeout|no response headers|stream stalled)\b/i.test(text)
+    || /\bHTTP\s+(?:502|503|504|522|523|524)\b/i.test(text);
+}
+
+function atris2TurnErrorReason(error) {
+  return isTransientAtris2BackendError(error) ? 'atris2-backend-unavailable' : 'atris2-error';
+}
+
+function missionRunKeepsRetryingError(reason) {
+  return reason === 'atris2-backend-unavailable';
+}
+
 function isWithinActiveHours(activeHours, now = new Date()) {
   if (!activeHours || !activeHours.start || !activeHours.end) return true;
   const tz = activeHours.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
@@ -6089,12 +6105,13 @@ async function runMission(args) {
           unsupported: turn.unsupported,
           duration_ms: turn.duration_ms,
           error: turn.error,
+          backend_unavailable: isTransientAtris2BackendError(turn.error) || undefined,
           receipt_text: String(turn.text || '').slice(0, 4000),
         };
         if (controller.signal.aborted) { pauseReason = 'aborted-during-atris2'; break; }
         if (turn.error === 'not-logged-in') { pauseReason = 'auth-required'; break; }
         if (!turn.ok || !String(turn.text || '').trim()) {
-          result = { ...result, status: 'errored', reason: 'atris2-error' };
+          result = { ...result, status: 'errored', reason: atris2TurnErrorReason(turn.error) };
         } else {
           result = { ...result, status: 'ran', reason: 'tick-ok', ran: true };
         }
@@ -6315,7 +6332,9 @@ async function runMission(args) {
       // is the same trap one step less deterministic: keep retrying and the loop burns every
       // tick + cron firing on it. Halt at two-in-a-row and surface the reason for a human.
       const errStreak = consecutiveSameReasonErrors(ticks);
-      if (errStreak.count >= 2) { pauseReason = `repeated-error:${errStreak.reason}`; break; }
+      // Sleeping Atris2 backends are different: leave the mission running so the
+      // next tick or heartbeat can catch the backend after it wakes.
+      if (errStreak.count >= 2 && !missionRunKeepsRetryingError(errStreak.reason)) { pauseReason = `repeated-error:${errStreak.reason}`; break; }
 
       // Sleep until next tick
       let sleepMs = 0;
@@ -6338,7 +6357,7 @@ async function runMission(args) {
 
     if (!pauseReason && ticks.length >= effectiveMaxTicks) {
       const lastTick = ticks[ticks.length - 1];
-      if (lastTick && lastTick.status !== 'ran') pauseReason = 'max-ticks-reached';
+      if (lastTick && lastTick.status !== 'ran' && !missionRunKeepsRetryingError(lastTick.reason)) pauseReason = 'max-ticks-reached';
     }
 
     if (pauseReason && !['complete', 'ready', 'max-wall-reached'].includes(pauseReason)) {

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const http = require('node:http');
 const os = require('node:os');
 const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
@@ -194,6 +195,64 @@ console.log(JSON.stringify({
     assert.match(payload.ticks[0].claude.receipt_text, /## Receipt/);
     assert.match(payload.ticks[0].claude.receipt_text, /Next tick: monitor payout surfaces only/);
   } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run keeps sleeping Atris2 backend missions running for retry', async () => {
+  const dir = makeTempDir();
+  let server = null;
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    server = http.createServer((req, res) => {
+      if (req.url === '/api/atris2/turn') {
+        res.writeHead(503, { 'Content-Type': 'text/plain' });
+        res.end('backend warming');
+        return;
+      }
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+    });
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address();
+
+    appendMissionState(dir, {
+      id: 'sleeping-atris2-backend',
+      slug: 'sleeping-atris2-backend',
+      objective: 'sleeping atris2 backend mission',
+      status: 'running',
+      runner: 'atris2',
+      verifier: 'true',
+      created_at: '2026-05-02T00:00:00.000Z',
+      updated_at: '2026-05-02T00:00:00.000Z',
+    });
+
+    const run = await runCliAsync(['mission', 'run', 'sleeping-atris2-backend', '--max-ticks', '1', '--json'], {
+      cwd: dir,
+      env: {
+        ATRIS_TOKEN: 'fake-token',
+        ATRIS_API_URL: `http://127.0.0.1:${port}/api`,
+      },
+    });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.pause_reason, null);
+    assert.equal(payload.mission.status, 'running');
+    assert.equal(payload.ticks.length, 1);
+    assert.equal(payload.ticks[0].status, 'errored');
+    assert.equal(payload.ticks[0].reason, 'atris2-backend-unavailable');
+    assert.equal(payload.ticks[0].atris2.backend_unavailable, true);
+
+    const status = runCli(['mission', 'status', '--status', 'running', '--json'], { cwd: dir });
+    assert.equal(status.status, 0, status.stderr || status.stdout);
+    const stored = JSON.parse(status.stdout).missions.find((mission) => mission.id === 'sleeping-atris2-backend');
+    assert.equal(stored.status, 'running');
+    assert.equal(stored.stop_reason, null);
+  } finally {
+    if (server?.listening) await new Promise((resolve) => server.close(resolve));
     cleanupTempDir(dir);
   }
 });


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-fleet-cli-845-20260703-112531
Target: atris/feed-command