### PR TITLE
feat(mission): one-door dispatch — auto-ack, preflight flags, runner profiles

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -309,10 +309,13 @@ const MISSION_RUN_BOOLEAN_FLAGS = [
   '--spend-full-budget',
   '--use-whole-budget',
   '--stop-when-done',
+  '--preflight',
+  '--no-preflight',
   '--room-preflight',
   '--no-room-preflight',
   '--room-auto-run',
   '--no-room-auto-run',
+  '--manual-ack',
   '--allow-native-goal-supersede',
   '--supersede-paused-native-goal',
   '--take-goal-slot',
@@ -1192,9 +1195,11 @@ function missionRunPreflightSignals(text) {
 }
 
 function shouldMissionRunRoomPreflight(objective, args = []) {
+  if (hasFlag(args, '--no-preflight')) return false;
   if (hasFlag(args, '--no-room-preflight')) return false;
+  if (hasFlag(args, '--preflight')) return true;
   if (hasFlag(args, '--room-preflight')) return true;
-  return missionRunPreflightSignals(objective) || missionRunTrustedRoomSignals(objective);
+  return true;
 }
 
 function missionRunTrustedRoomSignals(text) {
@@ -1256,6 +1261,8 @@ function buildMissionRunRoomPreflight(rawObjective, args = [], options = {}) {
   if (!shouldMissionRunRoomPreflight(rawObjective, args)) return null;
   const root = options.root || process.cwd();
   const owner = options.owner || readFlag(args, '--owner', process.env.ATRIS_AGENT_ID || 'mission-lead');
+  const explicitPreflight = hasFlag(args, '--preflight') || hasFlag(args, '--room-preflight');
+  const signalPreflight = missionRunPreflightSignals(rawObjective) || missionRunTrustedRoomSignals(rawObjective);
   const trustedRun = options.allowTrustedRun !== false && shouldMissionRunTrustedRoom(rawObjective, args);
   const selectedTarget = trustedRun ? selectMissionRunUsefulTarget(rawObjective, root) : null;
   const ownerResolution = resolveFunctionalOwner({
@@ -1278,6 +1285,7 @@ function buildMissionRunRoomPreflight(rawObjective, args = [], options = {}) {
   const shapedObjective = trustedRun
     ? missionRunTrustedObjective(rawObjective, written.room, selectedTarget)
     : missionRunPreflightObjective(rawObjective, written.room, ownerResolution.owner);
+  const taskSpineRequired = !selectedTarget && (explicitPreflight || signalPreflight);
   return {
     schema: 'atris.mission_run_preflight.v1',
     source: 'mission_room',
@@ -1296,10 +1304,10 @@ function buildMissionRunRoomPreflight(rawObjective, args = [], options = {}) {
       ref: selectedTarget.ref || null,
       why: selectedTarget.why || '',
     } : null,
-    task_spine_required: !selectedTarget,
+    task_spine_required: taskSpineRequired,
     next_action: selectedTarget
       ? 'run one proof tick for the selected existing task'
-      : 'attach task spine, then run one proof tick',
+      : (taskSpineRequired ? 'attach task spine, then run one proof tick' : 'run one proof tick'),
   };
 }
 
@@ -1719,7 +1727,7 @@ function missionFromArgs(args) {
     '--native-goal-objective',
     '--visible-goal-status',
     '--visible-goal-objective',
-  ], ['--json', '--always-on', '--xp-task', '--agent-xp', '--worktree', '--duplicate', '--spend-full-budget', '--use-whole-budget', '--stop-when-done', '--allow-native-goal-supersede', '--supersede-paused-native-goal', '--take-goal-slot'])
+  ], ['--json', '--always-on', '--xp-task', '--agent-xp', '--worktree', '--duplicate', '--spend-full-budget', '--use-whole-budget', '--stop-when-done', '--preflight', '--no-preflight', '--room-preflight', '--no-room-preflight', '--manual-ack', '--allow-native-goal-supersede', '--supersede-paused-native-goal', '--take-goal-slot'])
     .filter((part) => String(part || '').trim() !== '...');
   const objective = objectiveParts.join(' ').trim();
   if (!objective) {
@@ -3096,6 +3104,7 @@ function startMissionFromRunObjective(objective, args) {
   const nativeGoalOptions = {
     ...(nativeGoalStatus ? { nativeGoalStatus } : {}),
     ...(nativeGoalObjective ? { nativeGoalObjective } : {}),
+    ...(hasFlag(args, '--manual-ack') ? { manualAck: true } : {}),
     ...(hasFlag(args, '--allow-native-goal-supersede') || hasFlag(args, '--supersede-paused-native-goal') ? { allowNativeGoalSupersede: true } : {}),
   };
   const goalSlotHandoff = hasFlag(args, '--take-goal-slot') && isCodexGoalMission(saved)
@@ -3105,6 +3114,7 @@ function startMissionFromRunObjective(objective, args) {
   const codexGoalState = runnerUsesCallerSession(saved.runner)
     ? refreshCodexGoalController(process.cwd(), { missionId: saved.id, ...nativeGoalOptions })
     : null;
+  const outputMission = resolveMission(saved.id, process.cwd()) || saved;
   const nativeGoal = codexGoalState?.native_goal_action
     || (codexGoalState?.goal?.requires_native_goal_start ? codexGoalState.goal.native_goal_action : null);
   const nextCommand = codexGoalState?.next_command || codexGoalState?.goal?.next_command || atrisGoalState.goal?.next_command || `atris mission tick ${saved.id} --summary "<what changed>"`;
@@ -3112,7 +3122,7 @@ function startMissionFromRunObjective(objective, args) {
     {
       ok: true,
       action: 'mission_run_started',
-      mission: saved,
+      mission: outputMission,
       budget_contract: saved.budget_contract || null,
       warnings,
       state_path: statePaths().missionsJsonl,
@@ -3134,7 +3144,7 @@ function startMissionFromRunObjective(objective, args) {
       native_goal_ack_command: codexGoalState?.goal?.native_goal_ack_command || codexGoalState?.active_goal_conflict?.commands?.ack_new_mission || null,
       next_command: nextCommand,
     },
-    missionRunTakeoffLines(saved, { warnings, nextCommand }),
+    missionRunTakeoffLines(outputMission, { warnings, nextCommand }),
     asJson,
   );
 }
@@ -4937,8 +4947,53 @@ function codexRuntimeStateBlocksMissionSlot(runtimeGoalState, mission) {
   return runtimeGoalState.objective === codexGoalObjective(mission);
 }
 
+function codexRuntimeStateCanAutoAckMission(runtimeGoalState, mission) {
+  if (!runtimeGoalState || !mission) return false;
+  if (runtimeGoalState.status !== 'active') return false;
+  if (!runtimeGoalState.objective) return false;
+  return codexRuntimeStateBlocksMissionSlot(runtimeGoalState, mission);
+}
+
 function codexGoalAckCommand(mission, objective = codexGoalObjective(mission)) {
   return `atris mission goal ack ${mission.id} --runtime codex --status active --objective ${shellQuote(objective)} --json`;
+}
+
+function recordCodexNativeGoalAck(mission, root = process.cwd(), options = {}) {
+  const canonicalObjective = codexGoalObjective(mission);
+  const reportedObjective = String(options.reportedObjective || canonicalObjective).trim();
+  const ack = {
+    runtime: 'codex',
+    status: 'active',
+    mission_id: mission.id,
+    objective: canonicalObjective,
+    ...(reportedObjective && reportedObjective !== canonicalObjective ? { reported_objective: reportedObjective } : {}),
+    acknowledged_at: stampIso(),
+  };
+  const nextMission = {
+    ...mission,
+    native_goal_ack: ack,
+    next_action: codexGoalNextCommand({ ...mission, native_goal_ack: ack }),
+  };
+  const supersededNativeGoalAcks = supersedeOtherCodexNativeGoalAcks(root, nextMission, ack);
+  const { mission: saved } = saveMission(
+    nextMission,
+    root,
+    options.eventName || 'mission_native_goal_ack',
+    { ack, ...(options.eventDetail || {}) },
+  );
+  return { saved, ack, supersededNativeGoalAcks };
+}
+
+function maybeAutoAckCodexNativeGoal(mission, root = process.cwd(), options = {}) {
+  if (options.manualAck === true) return null;
+  if (!isCodexGoalMission(mission) || codexNativeGoalAck(mission)) return null;
+  const runtimeGoalState = codexRuntimeGoalStateFromOptions(options);
+  if (!codexRuntimeStateCanAutoAckMission(runtimeGoalState, mission)) return null;
+  return recordCodexNativeGoalAck(mission, root, {
+    reportedObjective: runtimeGoalState.objective,
+    eventName: 'mission_native_goal_auto_ack',
+    eventDetail: { runtime_goal_state: runtimeGoalState },
+  });
 }
 
 function codexNativeGoalReplaceAction(newMission, activeMission, runtimeGoalState = null, commands = {}) {
@@ -5211,16 +5266,18 @@ function codexNativeGoalBlockPayload(mission) {
   };
 }
 
-function maybeBlockUntilCodexNativeGoalStarted(mission, asJson) {
+function maybeBlockUntilCodexNativeGoalStarted(mission, asJson, options = {}) {
   if (!isCodexGoalMission(mission) || codexNativeGoalAck(mission)) return;
+  if (options.manualAck === false) return;
   const payload = codexNativeGoalBlockPayload(mission);
   if (asJson) console.log(JSON.stringify(payload, null, 2));
   else console.error(payload.next_action);
   process.exit(2);
 }
 
-function returnIfCodexNativeGoalNotStarted(mission, asJson) {
+function returnIfCodexNativeGoalNotStarted(mission, asJson, options = {}) {
   if (!isCodexGoalMission(mission) || codexNativeGoalAck(mission)) return false;
+  if (options.manualAck === false) return false;
   const payload = codexNativeGoalBlockPayload(mission);
   if (asJson) console.log(JSON.stringify(payload, null, 2));
   else console.error(payload.next_action);
@@ -5407,7 +5464,10 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
     };
   }
 
-  const { mission, reason, direct_goal_request: directGoalRequest, seeded_continuation_goal: seededContinuationGoal } = selected;
+  let { mission } = selected;
+  const { reason, direct_goal_request: directGoalRequest, seeded_continuation_goal: seededContinuationGoal } = selected;
+  const autoNativeGoalAck = maybeAutoAckCodexNativeGoal(mission, root, options);
+  if (autoNativeGoalAck) mission = autoNativeGoalAck.saved;
   const taskSpine = missionTaskSpine(mission);
   const missionView = missionStatusView(mission);
   const objective = codexGoalObjective(mission);
@@ -5443,6 +5503,10 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
     native_goal_action: nativeGoalAction,
     native_goal_ack_command: codexGoalAckCommand(mission, objective),
     native_goal_ack: ack,
+    auto_native_goal_ack: autoNativeGoalAck ? {
+      native_goal_ack: autoNativeGoalAck.ack,
+      superseded_native_goal_acks: autoNativeGoalAck.supersededNativeGoalAcks,
+    } : null,
     direct_goal_request: directGoalRequest || null,
     seeded_continuation_goal: seededContinuationGoal || null,
     next_action_preview: missionChoosesNextMission(mission) ? chooseNextMissionPreview(mission, root) : (mission.next_action_preview || null),
@@ -5458,6 +5522,7 @@ function buildCodexGoalPayload(root = process.cwd(), options = {}) {
     requires_native_goal_start: goal.requires_native_goal_start,
     requires_native_goal_replace: goal.requires_native_goal_replace,
     native_goal_action: goal.native_goal_action,
+    auto_native_goal_ack: goal.auto_native_goal_ack,
     runtime_goal_state: runtimeGoalState,
   };
 }
@@ -6255,7 +6320,27 @@ async function runMission(args) {
     process.exit(0);
   }
 
-  maybeBlockUntilCodexNativeGoalStarted(runtimeView(mission), asJson);
+  const manualAck = hasFlag(args, '--manual-ack');
+  const nativeGoalStatus = readFlag(args, '--native-goal-status', readFlag(args, '--visible-goal-status', ''));
+  const nativeGoalObjective = readFlag(args, '--native-goal-objective', readFlag(args, '--visible-goal-objective', ''));
+  const nativeGoalRunOptions = {
+    ...(nativeGoalStatus ? { nativeGoalStatus } : {}),
+    ...(nativeGoalObjective ? { nativeGoalObjective } : {}),
+    ...(manualAck ? { manualAck: true } : {}),
+  };
+  const autoAck = maybeAutoAckCodexNativeGoal(mission, process.cwd(), nativeGoalRunOptions);
+  if (autoAck) mission = autoAck.saved;
+  maybeBlockUntilCodexNativeGoalStarted(runtimeView(mission), asJson, { manualAck });
+
+  const preLockRunner = String(runtimeView(mission).runner || '').trim().toLowerCase();
+  const preLockCallerSession = runnerUsesCallerSession(runtimeView(mission).runner);
+  if (!skipClaude && !preLockCallerSession && preLockRunner !== 'atris2') {
+    const probe = probeClaudeBinary();
+    if (!probe.ok) {
+      console.error(`[mission run] claude probe failed: ${probe.error}`);
+      process.exit(2);
+    }
+  }
 
   const lock = acquireMissionLock(mission.id);
   if (!lock.ok) {
@@ -6289,7 +6374,7 @@ async function runMission(args) {
       console.error(`Mission ${mission.id} is ${mission.status}; nothing to run.`);
       return;
     }
-    if (returnIfCodexNativeGoalNotStarted(runtimeMission, asJson)) return;
+    if (returnIfCodexNativeGoalNotStarted(runtimeMission, asJson, { manualAck })) return;
     if (mission.status === 'paused') {
       mission = saveMission({
         ...mission,
@@ -7158,6 +7243,7 @@ function goalMission(args) {
     heartbeat: heartbeatMode,
     ...(nativeGoalStatus ? { nativeGoalStatus } : {}),
     ...(nativeGoalObjective ? { nativeGoalObjective } : {}),
+    ...(hasFlag(args, '--manual-ack') ? { manualAck: true } : {}),
     ...(allowNativeGoalSupersede ? { allowNativeGoalSupersede: true } : {}),
   });
   if (payload.active_goal_conflict) {
@@ -7194,7 +7280,7 @@ function goalMission(args) {
 
 function ackMissionGoal(args) {
   const asJson = wantsJson(args);
-  const ref = stripKnownFlags(args, ['--runtime', '--status', '--objective'], ['--json'])[0] || '';
+  const ref = stripKnownFlags(args, ['--runtime', '--status', '--objective'], ['--json', '--manual-ack'])[0] || '';
   if (!ref) {
     exitMissionError('Usage: atris mission goal ack <mission-id> --runtime codex --status active --objective "<objective>" --json', 1, asJson);
   }
@@ -7204,7 +7290,28 @@ function ackMissionGoal(args) {
   if (!mission) {
     exitMissingMission(ref, 1, asJson);
   }
-  if (runtime !== 'codex' || status !== 'active') {
+  if (runtime !== 'codex') {
+    const payload = {
+      ok: true,
+      action: 'native_goal_ack_skipped',
+      mission: missionStatusView(mission),
+      runtime,
+      status,
+      reason: 'runtime_not_codex',
+      requires_native_goal_start: false,
+      next_command: codexGoalNextCommand(mission),
+    };
+    printJsonOrText(
+      payload,
+      [
+        `Native goal ack skipped for runtime=${runtime}.`,
+        `Next: ${payload.next_command}`,
+      ],
+      asJson,
+    );
+    return;
+  }
+  if (status !== 'active') {
     exitMissionError('Native goal ack requires --runtime codex --status active.', 2, asJson);
   }
 
@@ -7221,22 +7328,7 @@ function ackMissionGoal(args) {
     }
     const canonicalObjective = codexGoalObjective(mission);
     const reportedObjective = readFlag(args, '--objective', canonicalObjective);
-    const objective = canonicalObjective;
-    const ack = {
-      runtime: 'codex',
-      status: 'active',
-      mission_id: mission.id,
-      objective,
-      ...(reportedObjective && reportedObjective !== objective ? { reported_objective: reportedObjective } : {}),
-      acknowledged_at: stampIso(),
-    };
-    const nextMission = {
-      ...mission,
-      native_goal_ack: ack,
-      next_action: codexGoalNextCommand({ ...mission, native_goal_ack: ack }),
-    };
-    const supersededNativeGoalAcks = supersedeOtherCodexNativeGoalAcks(process.cwd(), nextMission, ack);
-    const { mission: saved } = saveMission(nextMission, process.cwd(), 'mission_native_goal_ack', { ack });
+    const { saved, ack, supersededNativeGoalAcks } = recordCodexNativeGoalAck(mission, process.cwd(), { reportedObjective });
     const payload = refreshCodexGoalController(process.cwd());
     printJsonOrText(
       {
@@ -7361,7 +7453,7 @@ atris mission - durable goal + loop + owner + proof state
                        (rolls up sibling git-worktree missions; --local scopes to this checkout)
   atris mission room "<messy input>" [--owner <member>] [--room-auto-run] [--json]   Create a Mission Room card and shareable receipt from messy intent
   atris mission prune-runs [--apply] [--days <n>] [--keep-newest <n>] [--json]   Compress old run receipts into a manifest and prune unreferenced clutter
-  atris mission goal [--runtime codex|atris] [--heartbeat] [--native-goal-status active|paused] [--native-goal-objective "..."] [--allow-native-goal-supersede] [--json]
+  atris mission goal [--runtime codex|atris] [--heartbeat] [--native-goal-status active|paused] [--native-goal-objective "..."] [--manual-ack] [--allow-native-goal-supersede] [--json]
   atris mission goal ack <id> --runtime codex --status active --objective "<objective>" --json
   atris mission goal-loop [--max-wall 28800] [--max-iterations 32] [--no-claude] [--json]
   atris mission tick <id> [--verify ["cmd"]] [--complete-on-pass] [--summary "..."] [--json]
@@ -7369,9 +7461,9 @@ atris mission - durable goal + loop + owner + proof state
   atris mission "<objective>" [--owner <member>]   Shortcut for: atris mission run "<objective>"
   atris mission run --fleet [--slots 3] [--dry-run] [--json]   Staff every idle capable engine on claimable safe-lane tasks: parallel worktree builds, serial rebase-before-ship landings, receipt in atris/runs/
   atris mission run ["objective"|<member> ["objective"]|id|--due] [--owner <member>] [--max-ticks 4] [--max-wall 3600] [--cadence "15m"]
-                                [--native-goal-status active|paused] [--native-goal-objective "..."] [--allow-native-goal-supersede] [--take-goal-slot]
+                                [--native-goal-status active|paused] [--native-goal-objective "..."] [--manual-ack] [--allow-native-goal-supersede] [--take-goal-slot]
                                 [--engine <name>]
-                                [--spend-full-budget|--use-whole-budget|--stop-when-done] [--room-preflight|--no-room-preflight]
+                                [--spend-full-budget|--use-whole-budget|--stop-when-done] [--preflight|--no-preflight|--room-preflight|--no-room-preflight]
                                 [--room-auto-run|--no-room-auto-run]
                                 [--no-claude] [--no-verify] [--complete-on-pass] [--no-drain] [--create-next] [--json]
                        (bare/member-only run prompts; one-word fuzzy intent starts a new visible-goal mission; --due runs the saved queue)

--- a/lib/mission-runtime-loop.js
+++ b/lib/mission-runtime-loop.js
@@ -57,7 +57,10 @@ function missionRunIntentFromMessage(message) {
   rest = cadenceFlag.text;
   const noRun = hasBooleanFlag(rest, '--no-run') || hasBooleanFlag(rest, '--no-loop');
   const noComplete = hasBooleanFlag(rest, '--no-complete');
+  const forceRoomPreflight = hasBooleanFlag(rest, '--preflight') || hasBooleanFlag(rest, '--room-preflight');
+  const skipRoomPreflight = hasBooleanFlag(rest, '--no-preflight') || hasBooleanFlag(rest, '--no-room-preflight') || !forceRoomPreflight;
   rest = stripBooleanFlag(stripBooleanFlag(stripBooleanFlag(rest, '--no-run'), '--no-loop'), '--no-complete');
+  rest = stripBooleanFlag(stripBooleanFlag(stripBooleanFlag(stripBooleanFlag(rest, '--preflight'), '--room-preflight'), '--no-preflight'), '--no-room-preflight');
   rest = rest.replace(/(^|\s)--json(?=\s|$)/g, ' ').replace(/\s+/g, ' ').trim();
 
   const wantsLongRun = /\b(24\s*h|24\s*hours?|overnight|forever)\b/i.test(text);
@@ -69,6 +72,8 @@ function missionRunIntentFromMessage(message) {
     cadence: cadenceFlag.value || (wantsLongRun ? '15m' : ''),
     noRun,
     noComplete,
+    roomPreflight: forceRoomPreflight,
+    noRoomPreflight: skipRoomPreflight,
   };
 }
 
@@ -245,6 +250,8 @@ async function runRuntimeMissionLoop(intent, options = {}) {
 
   const startArgs = ['mission', 'run', intent.objective, '--runner', 'atris2', '--owner', intent.owner || 'mission-lead', '--json'];
   if (intent.cadence) startArgs.push('--cadence', intent.cadence);
+  if (intent.roomPreflight) startArgs.push('--room-preflight');
+  else if (intent.noRoomPreflight) startArgs.push('--no-room-preflight');
   const start = runCliJsonSync(cliPath, startArgs, { cwd, timeoutMs: 30000 });
   const result = { ok: start.ok, status: start.status, start, noRun: intent.noRun === true, achieved: false };
   if (!start.ok || !start.payload?.mission?.id) {

--- a/lib/runner-command.js
+++ b/lib/runner-command.js
@@ -40,6 +40,23 @@ const RUNNER_PROFILE_DEFS = Object.freeze({
     model: '',
     commandTemplate: '{bin} --trust -p {prompt}',
   }),
+  // Compatibility names for fleet rosters. These map to real installed
+  // runners instead of retired or UI-only model names.
+  fable: Object.freeze({
+    bin: 'claude',
+    model: '',
+    commandTemplate: '',
+  }),
+  composer: Object.freeze({
+    bin: 'ax',
+    model: 'composer-2-5-fast',
+    commandTemplate: '{bin} --fast {prompt}',
+  }),
+  haiku: Object.freeze({
+    bin: 'claude',
+    model: 'claude-haiku-4-5',
+    commandTemplate: '',
+  }),
   devin: Object.freeze({
     bin: 'devin',
     model: '',

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -854,12 +854,12 @@ test('runner-profile help lists canonical profile names only', () => {
   try {
     const run = runCli(['run', '--help'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr);
-    assert.match(run.stdout, /--runner-profile NAME\s+Runner profile for this run \(one of: atris-fast, claude, codex, cursor, devin, hermes\)/);
+    assert.match(run.stdout, /--runner-profile NAME\s+Runner profile for this run \(one of: atris-fast, claude, codex, cursor, fable, composer, haiku, devin, hermes\)/);
     assert.doesNotMatch(run.stdout, /atris2-fast|atris-2-fast/);
 
     const autopilot = runCli(['autopilot', '--legacy', '--help'], { cwd: dir });
     assert.equal(autopilot.status, 0, autopilot.stderr);
-    assert.match(autopilot.stdout, /--runner-profile NAME\s+Runner profile for this run \(one of: atris-fast, claude, codex, cursor, devin, hermes\)/);
+    assert.match(autopilot.stdout, /--runner-profile NAME\s+Runner profile for this run \(one of: atris-fast, claude, codex, cursor, fable, composer, haiku, devin, hermes\)/);
     assert.doesNotMatch(autopilot.stdout, /atris2-fast|atris-2-fast/);
   } finally {
     cleanupTempDir(dir);

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -26,7 +26,7 @@ test('engine roster lists every profile with detection state', () => {
     assert.equal(res.status, 0, res.stderr);
     const parsed = JSON.parse(res.stdout);
     const names = parsed.engines.map((e) => e.name);
-    assert.deepEqual(names, ['atris-fast', 'claude', 'codex', 'cursor', 'devin', 'hermes']);
+    assert.deepEqual(names, ['atris-fast', 'claude', 'codex', 'cursor', 'fable', 'composer', 'haiku', 'devin', 'hermes']);
     for (const entry of parsed.engines) {
       assert.equal(typeof entry.installed, 'boolean');
       assert.ok(entry.bin);
@@ -84,7 +84,7 @@ test('--engine flag rides a loop for one run and validates at the boundary', () 
     const bad = runCli(['run', '--legacy', '--dry-run', '--engine', 'gpt-11'], dir);
     assert.equal(bad.status, 1);
     assert.match(bad.stderr, /Unknown --engine "gpt-11"/);
-    assert.match(bad.stderr, /atris-fast, claude, codex, cursor, devin, hermes/);
+    assert.match(bad.stderr, /atris-fast, claude, codex, cursor, fable, composer, haiku, devin, hermes/);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/mission-status.test.js
+++ b/test/mission-status.test.js
@@ -948,6 +948,7 @@ test('mission run objective starts with product takeoff instead of runner plumbi
       'mission',
       'run',
       'human started takeoff',
+      '--no-preflight',
       '--owner',
       'mission-lead',
       '--runner',
@@ -1689,7 +1690,7 @@ test('mission timeline lists saved landing changed and next lines', () => {
       command: 'atris mission run landing-timeline-codex-loop --create-next',
     });
 
-    const run = runCli(['mission', 'run', 'landing-timeline-codex-loop', '--no-drain', '--create-next'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'landing-timeline-codex-loop', '--no-preflight', '--no-drain', '--create-next'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.match(run.stdout, /Changed: Created and claimed next task:/);
 
@@ -1978,7 +1979,7 @@ test('mission timeline lists saved landing changed and next lines', () => {
     assert.match(payload.timeline[0].next, /Created next task:/);
     assert.match(payload.timeline[0].receipt_path, /^atris\/runs\/mission-/);
 
-    const secondRun = runCli(['mission', 'run', 'landing-timeline-codex-loop', '--no-drain', '--create-next'], { cwd: dir });
+    const secondRun = runCli(['mission', 'run', 'landing-timeline-codex-loop', '--no-preflight', '--no-drain', '--create-next'], { cwd: dir });
     assert.equal(secondRun.status, 0, secondRun.stderr || secondRun.stdout);
     assert.match(secondRun.stdout, /Changed: Kept active task:/);
 
@@ -2648,13 +2649,35 @@ test('mission run terminal skips are JSON-readable when mission is explicit', ()
   }
 });
 
-test('mission run with an objective starts a visible-goal mission', () => {
+test('mission run preflights a plain objective by default', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const rawObjective = 'ship the ack fix';
+    const run = runCli(['mission', 'run', rawObjective, '--json'], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, 'mission_run_started');
+    assert.equal(payload.mission.raw_objective, rawObjective);
+    assert.notEqual(payload.mission.objective, rawObjective);
+    assert.equal(payload.mission.objective, payload.mission.mission_run_preflight.shaped_objective);
+    assert.equal(payload.mission.mission_run_preflight.raw_objective, rawObjective);
+    assert.match(payload.mission.objective, /Mission Room with mission-lead/);
+    assert.equal(payload.codex_goal_state.goal.objective, payload.mission.mission_run_preflight.visible_goal_objective);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run with an objective starts a visible-goal mission when preflight is disabled', () => {
   const dir = makeTempDir();
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
     fs.mkdirSync(path.join(dir, 'atris', 'team', 'mission-lead'), { recursive: true });
 
-    const run = runCli(['mission', 'run', 'atris mission run', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'atris mission run', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.equal(run.stderr, '');
     const payload = JSON.parse(run.stdout);
@@ -2680,6 +2703,71 @@ test('mission run with an objective starts a visible-goal mission', () => {
     assert.equal(payload.codex_goal_state.goal.requires_native_goal_start, true);
     assert.equal(payload.codex_goal_state.goal.native_goal_action.tool, 'create_goal');
     assert.match(payload.codex_goal_state.goal.native_goal_ack_command, /mission goal ack/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission run auto-acks when Codex runtime goal already matches objective', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const run = runCli([
+      'mission',
+      'run',
+      'auto ack visible goal',
+      '--no-preflight',
+      '--native-goal-status',
+      'active',
+      '--native-goal-objective',
+      'auto ack visible goal',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.action, 'mission_run_started');
+    assert.equal(payload.mission.native_goal_ack.status, 'active');
+    assert.equal(payload.mission.native_goal_ack.objective, 'auto ack visible goal');
+    assert.equal(payload.requires_native_goal_start, false);
+    assert.equal(payload.native_goal_action, null);
+    assert.equal(payload.codex_goal_state.auto_native_goal_ack.native_goal_ack.objective, 'auto ack visible goal');
+    assert.equal(payload.codex_goal_state.goal.requires_native_goal_start, false);
+    assert.equal(payload.codex_goal_state.goal.visible_goal.status, 'active');
+    assert.doesNotMatch(payload.next_command, /mission goal ack/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('mission goal ack skips native ack for non-Codex runtime', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+
+    const run = runCli(['mission', 'run', 'non codex ack skip', '--runner', 'atris2', '--no-preflight', '--json'], { cwd: dir });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const mission = JSON.parse(run.stdout).mission;
+
+    const ack = runCli([
+      'mission',
+      'goal',
+      'ack',
+      mission.id,
+      '--runtime',
+      'atris',
+      '--status',
+      'active',
+      '--objective',
+      'non codex ack skip',
+      '--json',
+    ], { cwd: dir });
+    assert.equal(ack.status, 0, ack.stderr || ack.stdout);
+    const payload = JSON.parse(ack.stdout);
+    assert.equal(payload.action, 'native_goal_ack_skipped');
+    assert.equal(payload.reason, 'runtime_not_codex');
+    assert.equal(payload.requires_native_goal_start, false);
+    assert.equal(payload.mission.runner, 'atris2');
   } finally {
     cleanupTempDir(dir);
   }
@@ -2738,6 +2826,7 @@ test('mission run reports replace action when a paused native-only goal blocks c
       'mission',
       'run',
       'edited paused goal test',
+      '--no-preflight',
       '--native-goal-status',
       'paused',
       '--native-goal-objective',
@@ -2803,6 +2892,7 @@ test('mission run reports replace action when a paused native-only goal blocks c
       'mission',
       'run',
       'approved paused goal test',
+      '--no-preflight',
       '--native-goal-status',
       'paused',
       '--native-goal-objective',
@@ -2836,7 +2926,7 @@ test('mission run objective reports active visible-goal conflict instead of hidi
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
 
-    const oldRun = runCli(['mission', 'run', 'old visible goal', '--json'], { cwd: dir });
+    const oldRun = runCli(['mission', 'run', 'old visible goal', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(oldRun.status, 0, oldRun.stderr || oldRun.stdout);
     const oldMission = JSON.parse(oldRun.stdout).mission;
     ackNativeCodexGoal(dir, oldMission);
@@ -2845,6 +2935,7 @@ test('mission run objective reports active visible-goal conflict instead of hidi
       'mission',
       'run',
       'runtime paused new goal',
+      '--no-preflight',
       '--native-goal-status',
       'paused',
       '--native-goal-objective',
@@ -2865,7 +2956,7 @@ test('mission run objective reports active visible-goal conflict instead of hidi
     assert.equal(pausedRuntimePayload.codex_goal_state.active_goal_conflict.native_goal_resolution.action, 'replace_visible_goal');
     assert.match(pausedRuntimePayload.next_command, /Resume the paused Codex goal/);
 
-    const newRun = runCli(['mission', 'run', 'new urgent goal', '--json'], { cwd: dir });
+    const newRun = runCli(['mission', 'run', 'new urgent goal', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(newRun.status, 0, newRun.stderr || newRun.stdout);
     const runPayload = JSON.parse(newRun.stdout);
     const newMission = runPayload.mission;
@@ -2989,7 +3080,7 @@ test('mission goal ack supersedes stale older Codex native acks', () => {
       },
     });
 
-    const run = runCli(['mission', 'run', 'new handoff goal', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'new handoff goal', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const runPayload = JSON.parse(run.stdout);
     const newMission = runPayload.mission;
@@ -3041,12 +3132,12 @@ test('mission run --take-goal-slot pauses slot owner in one move', () => {
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
 
-    const oldRun = runCli(['mission', 'run', 'old slot owner goal', '--json'], { cwd: dir });
+    const oldRun = runCli(['mission', 'run', 'old slot owner goal', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(oldRun.status, 0, oldRun.stderr || oldRun.stdout);
     const oldMission = JSON.parse(oldRun.stdout).mission;
     ackNativeCodexGoal(dir, oldMission);
 
-    const newRun = runCli(['mission', 'run', 'new slot taker goal', '--take-goal-slot', '--json'], { cwd: dir });
+    const newRun = runCli(['mission', 'run', 'new slot taker goal', '--no-preflight', '--take-goal-slot', '--json'], { cwd: dir });
     assert.equal(newRun.status, 0, newRun.stderr || newRun.stdout);
     const runPayload = JSON.parse(newRun.stdout);
     const newMission = runPayload.mission;
@@ -3445,12 +3536,12 @@ test('mission prune-runs previews and deletes only old unreferenced run clutter'
   }
 });
 
-test('mission run blocks Codex-goal work until native goal ack', () => {
+test('mission run preserves native goal ack block behind --manual-ack', () => {
   const dir = makeTempDir();
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
 
-    const run = runCli(['mission', 'run', 'handshake test', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'handshake test', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const started = JSON.parse(run.stdout);
     const id = started.mission.id;
@@ -3463,7 +3554,7 @@ test('mission run blocks Codex-goal work until native goal ack', () => {
     assert.equal(blockedTickPayload.native_goal_action.tool, 'create_goal');
     assert.match(blockedTickPayload.next_action, /mission goal ack/);
 
-    const blockedRun = runCli(['mission', 'run', id, '--json', '--no-claude'], { cwd: dir });
+    const blockedRun = runCli(['mission', 'run', id, '--json', '--no-claude', '--manual-ack'], { cwd: dir });
     assert.equal(blockedRun.status, 2, blockedRun.stderr || blockedRun.stdout);
     assert.equal(JSON.parse(blockedRun.stdout).code, 'native_goal_not_started');
 
@@ -3727,6 +3818,7 @@ test('mission run can plan and advance a validated child-goal chain', () => {
       'mission',
       'run',
       'show me 3 or 4 goals done towards a novel mission that is validated and understandable',
+      '--no-preflight',
       '--owner',
       'auto-improver',
       '--json',
@@ -3793,6 +3885,7 @@ test('mission run recognizes set-accomplish-next wording as a child-goal chain',
       'mission',
       'run',
       rawObjective,
+      '--no-preflight',
       '--owner',
       'architect',
       '--json',
@@ -3814,7 +3907,7 @@ test('mission run accepts one-word fuzzy intent as a new mission', () => {
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
 
-    const run = runCli(['mission', 'run', 'improve', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'improve', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const payload = JSON.parse(run.stdout);
     assert.equal(payload.action, 'mission_run_started');
@@ -3831,7 +3924,7 @@ test('mission run with atris2 runner writes Atris-owned goal state without Codex
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
 
-    const run = runCli(['mission', 'run', 'ax fast visible goal', '--runner', 'atris2', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'ax fast visible goal', '--runner', 'atris2', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const payload = JSON.parse(run.stdout);
     assert.equal(payload.action, 'mission_run_started');
@@ -3870,7 +3963,7 @@ test('mission objective shorthand starts a visible-goal mission', () => {
   try {
     fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
 
-    const run = runCli(['mission', 'fix', 'the', 'issue', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'fix', 'the', 'issue', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const payload = JSON.parse(run.stdout);
     assert.equal(payload.action, 'mission_run_started');
@@ -3902,6 +3995,7 @@ test('remote-computer mission run preserves the local mission spine contract', (
       'mission',
       'run',
       'mission parity acceptance',
+      '--no-preflight',
       '--owner',
       'mission-lead',
       '--runner',
@@ -3917,6 +4011,7 @@ test('remote-computer mission run preserves the local mission spine contract', (
       'mission',
       'run',
       'mission parity acceptance remote',
+      '--no-preflight',
       '--owner',
       'mission-lead',
       '--runner',
@@ -4034,7 +4129,7 @@ test('mission run accepts owner prefix before fuzzy intent', () => {
     fs.mkdirSync(path.join(dir, 'atris', 'team', 'validator'), { recursive: true });
     fs.writeFileSync(path.join(dir, 'atris', 'team', 'validator', 'MEMBER.md'), '# Validator\n', 'utf8');
 
-    const run = runCli(['mission', 'run', 'validator', 'check proof', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'validator', 'check proof', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const payload = JSON.parse(run.stdout);
     assert.equal(payload.action, 'mission_run_started');
@@ -4055,6 +4150,7 @@ test('completed mission run seeds the next useful goal', () => {
       'mission',
       'run',
       'ship fuzzy intent',
+      '--no-preflight',
       '--owner',
       'mission-lead',
       '--verify',
@@ -4092,6 +4188,7 @@ test('completed mission run seeds the next useful goal', () => {
       'mission',
       'run',
       'make the next mission real',
+      '--no-preflight',
       '--owner',
       'mission-lead',
       '--json',
@@ -4173,7 +4270,7 @@ test('continuation mission chooses next mission instead of passing on inherited 
     assert.match(ack.codex_goal_state.goal.next_command, /atris mission run 'Make the concrete follow-up real' --owner mission-lead/);
     assert.doesNotMatch(ack.codex_goal_state.goal.next_command, /<next useful mission>/);
 
-    const next = runCli(['mission', 'run', 'Make the concrete follow-up real', '--owner', 'mission-lead', '--json'], { cwd: dir });
+    const next = runCli(['mission', 'run', 'Make the concrete follow-up real', '--owner', 'mission-lead', '--no-preflight', '--json'], { cwd: dir });
     assert.equal(next.status, 0, next.stderr || next.stdout);
     const nextPayload = JSON.parse(next.stdout);
     assert.equal(nextPayload.mission.objective, 'Make the concrete follow-up real');
@@ -5023,7 +5120,7 @@ test('explicit caller-session mission run exits after one recorded tick', () => 
       updated_at: '2026-05-02T00:00:00.000Z',
     });
 
-    const run = runCli(['mission', 'run', 'explicit-codex-loop', '--no-drain', '--json'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'explicit-codex-loop', '--no-preflight', '--no-drain', '--json'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.equal(run.stderr, '');
     const payload = JSON.parse(run.stdout);
@@ -5040,7 +5137,7 @@ test('explicit caller-session mission run exits after one recorded tick', () => 
     assert.equal(payload.ticks[0].verifier_passed, true);
     assert.equal(fs.existsSync(path.join(dir, '.atris', 'state', 'mission-explicit-codex-loop.lock')), false);
 
-    const humanRun = runCli(['mission', 'run', 'explicit-codex-loop', '--no-drain'], { cwd: dir });
+    const humanRun = runCli(['mission', 'run', 'explicit-codex-loop', '--no-preflight', '--no-drain'], { cwd: dir });
     assert.equal(humanRun.status, 0, humanRun.stderr || humanRun.stdout);
     assert.match(humanRun.stdout, /Changed: Recorded a proof heartbeat for this always-on mission\./);
     assert.doesNotMatch(humanRun.stdout, /Changed: explicit codex loop is ready for review\./);
@@ -5073,7 +5170,7 @@ test('mission run landing points to self-improvement seed when no task is queued
       updated_at: '2026-05-02T00:00:00.000Z',
     });
 
-    const run = runCli(['mission', 'run', 'seeded-codex-loop', '--no-drain'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'seeded-codex-loop', '--no-preflight', '--no-drain'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.match(run.stdout, /Next: Create the next proof-backed self-improvement task\./);
     assert.doesNotMatch(run.stdout, /Next: Run the next proof step\./);
@@ -5112,7 +5209,7 @@ test('mission run landing uses evidence-backed self-improvement target', () => {
       updated_at: '2026-05-02T00:00:00.000Z',
     });
 
-    const run = runCli(['mission', 'run', 'evidence-codex-loop', '--no-drain'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'evidence-codex-loop', '--no-preflight', '--no-drain'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.match(run.stdout, /Next: Add a command that creates and claims the suggested self-improvement task from the loop seed\./);
     assert.doesNotMatch(run.stdout, /Next: Run the next proof step\./);
@@ -5151,7 +5248,7 @@ test('mission run --create-next materializes the evidence-backed task', () => {
       updated_at: '2026-05-02T00:00:00.000Z',
     });
 
-    const run = runCli(['mission', 'run', 'create-next-codex-loop', '--no-drain', '--create-next'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'create-next-codex-loop', '--no-preflight', '--no-drain', '--create-next'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     const projection = JSON.parse(fs.readFileSync(path.join(dir, '.atris', 'state', 'tasks.projection.json'), 'utf8'));
     const task = projection.tasks.find((row) => row.title === 'Add mission run create-next so a heartbeat can materialize the suggested loop task');
@@ -5213,7 +5310,7 @@ test('mission run --create-next names the active task when duplicate protection 
     assert.equal(created.status, 0, created.stderr || created.stdout);
     const task = JSON.parse(created.stdout).task;
 
-    const run = runCli(['mission', 'run', 'create-next-active-codex-loop', '--no-drain', '--create-next'], { cwd: dir });
+    const run = runCli(['mission', 'run', 'create-next-active-codex-loop', '--no-preflight', '--no-drain', '--create-next'], { cwd: dir });
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.ok(
       run.stdout.includes(`Changed: Kept active task: ${task.display_id} ${task.title}. No duplicate was created.`),
@@ -6249,10 +6346,11 @@ test('mission help documents status filters', () => {
     assert.match(help.stdout, /mission report \[id\] \[--limit <n>\] \[--local\] \[--json\]/);
     assert.match(help.stdout, /mission timeline \[id\] \[--limit <n>\] \[--all\] \[--prune-preview\] \[--write\] \[--json\]/);
     assert.match(help.stdout, /rolls up sibling git-worktree missions/);
-    assert.match(help.stdout, /mission goal \[--runtime codex\|atris\] \[--heartbeat\] \[--native-goal-status active\|paused\] \[--native-goal-objective "\.\.\."\] \[--allow-native-goal-supersede\] \[--json\]/);
+    assert.match(help.stdout, /mission goal \[--runtime codex\|atris\] \[--heartbeat\] \[--native-goal-status active\|paused\] \[--native-goal-objective "\.\.\."\] \[--manual-ack\] \[--allow-native-goal-supersede\] \[--json\]/);
     assert.match(help.stdout, /mission goal ack <id> --runtime codex --status active --objective "<objective>" --json/);
     assert.match(help.stdout, /mission goal-loop \[--max-wall 28800\] \[--max-iterations 32\] \[--no-claude\] \[--json\]/);
     assert.match(help.stdout, /--spend-full-budget\|--use-whole-budget\|--stop-when-done/);
+    assert.match(help.stdout, /--preflight\|--no-preflight\|--room-preflight\|--no-room-preflight/);
     assert.match(help.stdout, /short time like "20 minutes" means finish early/);
     assert.match(help.stdout, /long\/sleep time like "5 hours" keeps using the budget/);
     assert.match(help.stdout, /Autonomy recipe:/);

--- a/test/runner-command.test.js
+++ b/test/runner-command.test.js
@@ -165,6 +165,41 @@ test('Atris Fast runner profile resolves to ax --fast and atris:fast', () => {
   });
 });
 
+test('compat runner profiles resolve to concrete runner configs', () => {
+  const cases = [
+    {
+      profile: 'fable',
+      bin: 'claude',
+      model: DEFAULT_CLAUDE_RUNNER_MODEL,
+      template: '',
+      command: /claude -p .*--model claude-opus-4-8\b/,
+    },
+    {
+      profile: 'composer',
+      bin: 'ax',
+      model: 'composer-2-5-fast',
+      template: '{bin} --fast {prompt}',
+      command: /^ax --fast "\$\(cat \/tmp\/p\.tmp\)"$/,
+    },
+    {
+      profile: 'haiku',
+      bin: 'claude',
+      model: 'claude-haiku-4-5',
+      template: '',
+      command: /claude -p .*--model claude-haiku-4-5\b/,
+    },
+  ];
+  for (const entry of cases) {
+    withRunnerEnv({ ATRIS_RUNNER_PROFILE: entry.profile }, () => {
+      assert.deepEqual(resolveRunnerProfile(), RUNNER_PROFILE_DEFS[entry.profile]);
+      assert.equal(resolveClaudeRunnerBin(), entry.bin);
+      assert.equal(resolveClaudeRunnerModel({}), entry.model);
+      assert.equal(resolveClaudeRunnerCommandTemplate(), entry.template);
+      assert.match(buildRunnerCommand({ promptFile: '/tmp/p.tmp' }), entry.command);
+    });
+  }
+});
+
 test('generic runner env overrides the Atris Fast profile', () => {
   withRunnerEnv({
     ATRIS_RUNNER_PROFILE: 'atris-fast',


### PR DESCRIPTION
mission run auto-acks codex dispatches (non-codex runners skip ack; --manual-ack opts out), adds --preflight/--no-preflight room preflight control (intent path lazy so message interception short-circuits), and adds fable/composer/haiku runner profiles mapping fleet roster names to installed runners.

Verify: npm test — only the 2 machine-profile play-mode failures remain, proven pre-existing on the primary checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)