### PR TITLE
fix(mission): drop pre-lock claude probe that broke runner-swap tests on CI

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -6332,15 +6332,10 @@ async function runMission(args) {
   if (autoAck) mission = autoAck.saved;
   maybeBlockUntilCodexNativeGoalStarted(runtimeView(mission), asJson, { manualAck });
 
-  const preLockRunner = String(runtimeView(mission).runner || '').trim().toLowerCase();
-  const preLockCallerSession = runnerUsesCallerSession(runtimeView(mission).runner);
-  if (!skipClaude && !preLockCallerSession && preLockRunner !== 'atris2') {
-    const probe = probeClaudeBinary();
-    if (!probe.ok) {
-      console.error(`[mission run] claude probe failed: ${probe.error}`);
-      process.exit(2);
-    }
-  }
+  // No pre-lock claude probe here: the runner profile isn't applied yet, so
+  // probing would test the default claude bin even when the effective runner
+  // (e.g. --engine cursor) never invokes claude. The in-lock probe below runs
+  // after applyMissionRunnerProfile and checks the right binary.
 
   const lock = acquireMissionLock(mission.id);
   if (!lock.ok) {


### PR DESCRIPTION
The pre-lock probe added in #230 runs before applyMissionRunnerProfile, so it probes the default claude bin even when the effective runner is cursor/atris-fast. In CI (no claude binary) it exit(2)s before the lock check — the two mission-runner-swap failures on master CI since #230.

Fix: remove the pre-lock probe; the existing in-lock probe runs after the profile is applied and checks the correct binary.

Verify: mission-runner-swap suite 4/4 on a claude-less PATH (reproduces CI); mission-status + runner-command + engine + cli-smoke suites 214 pass / 1 fail, the 1 being the pre-existing first-contact test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)