### PR TITLE
fix(engine): validate --prompt-file args before probing installed CLIs

### DIFF
--- a/commands/engine.js
+++ b/commands/engine.js
@@ -276,11 +276,8 @@ function runDispatchCommand(args, root) {
     console.error(`engine dispatch: --engine must be one of ${FLEET_CAPABLE.join(', ')}`);
     return 2;
   }
-  const def = RUNNER_PROFILE_DEFS[canonical];
-  if (!binInstalled(def.bin)) {
-    console.error(`engine dispatch: ${canonical} CLI (${def.bin}) is not installed here`);
-    return 2;
-  }
+  // Argument-shape errors surface before environment errors: --prompt-file
+  // with multiple ids is wrong on any machine, installed CLI or not.
   let promptOverride = '';
   if (promptFile) {
     if (taskIds.length > 1) {
@@ -293,6 +290,11 @@ function runDispatchCommand(args, root) {
       console.error(`engine dispatch: could not read --prompt-file ${promptFile}: ${err.message}`);
       return 2;
     }
+  }
+  const def = RUNNER_PROFILE_DEFS[canonical];
+  if (!binInstalled(def.bin)) {
+    console.error(`engine dispatch: ${canonical} CLI (${def.bin}) is not installed here`);
+    return 2;
   }
   return runDispatchFlight({ root, taskIds, engine: canonical, prompt: promptOverride }).then((flight) => {
     if (json) console.log(JSON.stringify(flight, null, 2));


### PR DESCRIPTION
Last red test on master CI. The dispatch test asserts the multi-id error message, but on CI (no cursor-agent installed) binInstalled fired first and printed 'not installed here'. Argument-shape errors now surface before environment errors.

Verify: engine-dispatch suite 17/17 on a CLI-less PATH (reproduces CI), 30/30 with engine.test.js on normal PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)