### PR TITLE
fix(land): salvage worktrees with dirty diffs over 1MB

### DIFF
--- a/commands/land.js
+++ b/commands/land.js
@@ -8,8 +8,8 @@ const DEFAULT_TTL_DAYS = 7;
 const WORKTREE_REAP_GRACE_MS = 60 * 60 * 1000;
 const PROTECTED_BRANCHES = new Set(['main', 'master']);
 
-function runGit(args, { cwd = process.cwd(), check = true } = {}) {
-  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+function runGit(args, { cwd = process.cwd(), check = true, maxBuffer } = {}) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', ...(maxBuffer ? { maxBuffer } : {}) });
   if (check && result.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed: ${(result.stderr || result.stdout || '').trim()}`);
   }
@@ -165,14 +165,18 @@ function remoteHeads(root) {
 // piece could not be saved — the caller then keeps the worktree.
 function salvageWorktree(w, dir, receipt) {
   try {
-    const diff = runGit(['diff', 'HEAD'], { cwd: w.path, check: false });
-    if (diff.status !== 0) return false;
-    if (diff.stdout.trim()) {
-      const patchPath = path.join(dir, `${path.basename(w.path)}.dirty.patch`);
-      fs.writeFileSync(patchPath, diff.stdout);
-      receipt.patches.push(patchPath);
+    // git writes the patch file itself: routing the diff through spawnSync
+    // stdout hits Node's 1MB default maxBuffer, so any worktree more than
+    // ~1MB dirty read as "salvage failed" and was kept on every reap pass.
+    const patchPath = path.join(dir, `${path.basename(w.path)}.dirty.patch`);
+    const diff = runGit(['diff', 'HEAD', `--output=${patchPath}`], { cwd: w.path, check: false });
+    if (diff.status !== 0) {
+      fs.rmSync(patchPath, { force: true });
+      return false;
     }
-    const untracked = runGit(['ls-files', '--others', '--exclude-standard', '-z'], { cwd: w.path, check: false });
+    if (fs.statSync(patchPath).size > 0) receipt.patches.push(patchPath);
+    else fs.rmSync(patchPath, { force: true });
+    const untracked = runGit(['ls-files', '--others', '--exclude-standard', '-z'], { cwd: w.path, check: false, maxBuffer: 64 * 1024 * 1024 });
     if (untracked.status !== 0) return false;
     const files = untracked.stdout.split('\0').filter(Boolean);
     if (files.length > 0) {

--- a/test/land.test.js
+++ b/test/land.test.js
@@ -317,3 +317,30 @@ test('reap leaves a branch alone when it moved after the scan', () => {
     cleanupTempDir(base);
   }
 });
+
+test('reap salvages a worktree whose dirty diff exceeds the 1MB spawn buffer', () => {
+  const { base, repo } = makeTempRepo();
+  try {
+    commitOnBranch(repo, 'big-work', 'big.txt', { backdate: '2026-05-01T00:00:00' });
+    const wtPath = path.join(base, 'wt-big');
+    runGit(['worktree', 'add', wtPath, 'big-work'], repo);
+    fs.writeFileSync(path.join(wtPath, 'big.txt'), `uncommitted ${'x'.repeat(2 * 1024 * 1024)}\n`);
+    // age the worktree past the fresh-worktree grace window
+    const staleStamp = new Date(Date.now() - 61 * 60 * 1000);
+    fs.utimesSync(wtPath, staleStamp, staleStamp);
+
+    const result = runCli(['land', '--reap', '--json'], repo);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const receipt = JSON.parse(result.stdout);
+
+    // macOS reports /var/... worktrees back as /private/var/...
+    const normalize = (p) => p.replace(/^\/private\//, '/');
+    assert.deepEqual(receipt.removedWorktrees.map(normalize), [normalize(wtPath)]);
+    assert.ok(receipt.deletedBranches.includes('big-work'));
+    assert.equal(receipt.patches.length, 1);
+    assert.ok(fs.statSync(receipt.patches[0]).size > 1024 * 1024, 'patch must hold the full oversized diff');
+    assert.ok(!fs.existsSync(wtPath));
+  } finally {
+    cleanupTempDir(base);
+  }
+});


### PR DESCRIPTION
Reap could never clear a worktree whose dirty diff exceeds spawnSync's default 1MB maxBuffer: `git diff HEAD` came back status≠0 (ENOBUFS), salvage returned false, and the worktree was kept on every pass — silently before #261, with a reason after. Four worktrees on the fleet machine (1.15–1.26MB diffs) were stuck exactly this way.

Fix: `git diff HEAD --output=<patch>` writes the patch file directly, so no diff bytes route through Node; the untracked listing gets an explicit 64MB buffer. Adds a regression test with a 2MB dirty file — fails on the old code, passes now. `node --test test/land.test.js` 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)