### PR TITLE
fix(land): stop telling humans to act on fresh-grace worktrees

### DIFF
--- a/commands/land.js
+++ b/commands/land.js
@@ -473,7 +473,12 @@ function printReceipt(receipt) {
     if (receipt.bundleError) console.log(`  backup failed — unlanded work left in place: ${receipt.bundleError}`);
     for (const p of receipt.patches) console.log(`  unsaved edits saved: ${p}`);
     for (const u of receipt.untracked || []) console.log(`  new files saved: ${u}`);
-    for (const k of receipt.keptWorktrees || []) console.log(`  ✋ kept, needs a human: ${k}`);
+    // fresh-grace keeps are healthy active work, not a call to action —
+    // "needs a human" on those trained readers to ignore the real ones.
+    for (const k of receipt.keptWorktrees || []) {
+      if (String(k).includes('(fresh_worktree_grace)')) console.log(`  in use, left alone: ${k.replace(' (fresh_worktree_grace)', '')}`);
+      else console.log(`  ✋ kept, needs a human: ${k}`);
+    }
     for (const m of receipt.keptMovedBranches || []) console.log(`  moved since scan, left alone: ${m}`);
     if (receipt.deletedRemote.length > 0) console.log(`  also cleared on github: ${receipt.deletedRemote.length}`);
   }


### PR DESCRIPTION
Reap's receipt printed active in-grace worktrees with the same '✋ kept, needs a human' line as genuinely blocked ones, so the call-to-action label cried wolf on every pass. Fresh-grace keeps now print as 'in use, left alone'; receipt JSON unchanged. `node --test test/land.test.js` 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)