### PR TITLE
autoland: allow safe python/pytest verify commands (cd prefix, env vars, venv python)

### DIFF
--- a/lib/auto-accept-certified.js
+++ b/lib/auto-accept-certified.js
@@ -16,6 +16,11 @@ const DENIED_TAGS = new Set(['billing', 'deploy', 'feedback', 'voice', 'security
 const SIMPLE_VERIFY_TOKEN_RE = /^[a-zA-Z0-9_./:@=+-]+$/;
 const GIT_WORKTREE_PATH_RE = /^[a-zA-Z0-9_./@=+-]+$/;
 const GIT_REV_TOKEN_RE = /^[a-zA-Z0-9_./@=+~^-]+$/;
+const SAFE_RELATIVE_PATH_RE = /^[a-zA-Z0-9_./-]+$/;
+const SAFE_ENV_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
+const SAFE_ENV_VALUE_RE = /^[A-Za-z0-9._/:-]*$/;
+const PYTHON_SHORT_FLAG_RE = /^-[a-zA-Z-]+$/;
+const PYTHON_LONG_FLAG_RE = /^--[a-zA-Z-]+(?:=[A-Za-z0-9._:-]+)?$/;
 
 function hasUnsafePathSegment(token) {
   const text = String(token || '');
@@ -56,6 +61,58 @@ function safeGitRevToken(token) {
 
 function safeNodePathArgs(args) {
   return args.every(token => safeRelativePathToken(token));
+}
+
+function safeCdPathToken(token) {
+  const text = String(token || '');
+  return Boolean(text)
+    && !text.startsWith('-')
+    && !text.includes(':')
+    && SAFE_RELATIVE_PATH_RE.test(text)
+    && !hasUnsafePathSegment(text);
+}
+
+function safePythonPathToken(token) {
+  const text = String(token || '');
+  return Boolean(text)
+    && SAFE_RELATIVE_PATH_RE.test(text)
+    && !/^[a-zA-Z]:[\\/]/.test(text);
+}
+
+function safePythonBinaryToken(token) {
+  const text = String(token || '');
+  return text === 'python'
+    || text === 'python3'
+    || (safePythonPathToken(text) && /(^|\/)venv\/bin\/python3?$/.test(text));
+}
+
+function safePythonRelativePathToken(token) {
+  const text = String(token || '');
+  return Boolean(text)
+    && !text.startsWith('-')
+    && !text.includes(':')
+    && SAFE_RELATIVE_PATH_RE.test(text)
+    && !hasUnsafePathSegment(text);
+}
+
+function safePythonFlagToken(token) {
+  const text = String(token || '');
+  return PYTHON_SHORT_FLAG_RE.test(text) || PYTHON_LONG_FLAG_RE.test(text);
+}
+
+function safePytestArg(token) {
+  return safePythonRelativePathToken(token) || safePythonFlagToken(token);
+}
+
+function safePythonScriptPath(token) {
+  const text = String(token || '');
+  return text.startsWith('scripts/')
+    && text.endsWith('.py')
+    && safePythonRelativePathToken(text);
+}
+
+function safePythonScriptArg(token) {
+  return safePythonRelativePathToken(token) || safePythonFlagToken(token);
 }
 
 function safeNodeTestArgs(args) {
@@ -110,15 +167,51 @@ function isInsidePath(candidate, root) {
   return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
-function validateGitWorktreePath(argv, workspaceRoot) {
+function parentArenaDir(workspace) {
+  let cursor = path.resolve(workspace);
+  while (cursor && cursor !== path.dirname(cursor)) {
+    if (path.basename(cursor) === 'arena') return cursor;
+    cursor = path.dirname(cursor);
+  }
+  return path.dirname(path.resolve(workspace));
+}
+
+function validateCommandCwd(parsed, workspaceRoot) {
+  const workspace = path.resolve(workspaceRoot || process.cwd());
+  if (!parsed.cwd) return { ok: true, cwd: workspace };
+  const target = path.resolve(workspace, parsed.cwd);
+  if (!isInsidePath(target, workspace)) return { ok: false, reason: 'verify_command_not_allowed' };
+  try {
+    if (!fs.existsSync(target) || !fs.statSync(target).isDirectory()) {
+      return { ok: false, reason: 'verify_workdir_missing' };
+    }
+  } catch {
+    return { ok: false, reason: 'verify_workdir_missing' };
+  }
+  return { ok: true, cwd: target };
+}
+
+function validateGitWorktreePath(argv, workspaceRoot, commandCwd) {
   if (!(argv[0] === 'git' && argv[1] === '-C')) return { ok: true };
   const workspace = path.resolve(workspaceRoot || process.cwd());
-  const target = path.resolve(workspace, argv[2]);
+  const target = path.resolve(commandCwd || workspace, argv[2]);
   const allowedRoot = path.dirname(workspace);
   if (!isInsidePath(target, workspace) && !isInsidePath(target, allowedRoot)) {
     return { ok: false, reason: 'verify_command_not_allowed' };
   }
   if (!fs.existsSync(target)) return { ok: false, reason: 'verify_worktree_missing' };
+  return { ok: true };
+}
+
+function validatePythonBinaryPath(argv, workspaceRoot, commandCwd) {
+  const bin = argv[0];
+  if (bin === 'python' || bin === 'python3' || !safePythonBinaryToken(bin)) return { ok: true };
+  const workspace = path.resolve(workspaceRoot || process.cwd());
+  const target = path.resolve(commandCwd || workspace, bin);
+  const allowedRoot = parentArenaDir(workspace);
+  if (!isInsidePath(target, workspace) && !isInsidePath(target, allowedRoot)) {
+    return { ok: false, reason: 'verify_command_not_allowed' };
+  }
   return { ok: true };
 }
 
@@ -189,20 +282,71 @@ function distinctReviewActors(task) {
   return reviewIntegrity.reviewEventActors(task);
 }
 
+function parseCdPrefix(cmd) {
+  const match = cmd.match(/^cd\s+(\S+)\s+&&\s+(.+)$/);
+  if (!match) return { ok: true, command: cmd };
+  const cwd = match[1];
+  const command = String(match[2] || '').trim();
+  if (!safeCdPathToken(cwd) || !command) {
+    return { ok: false, reason: 'verify_command_not_allowed' };
+  }
+  return { ok: true, cwd, command };
+}
+
+function parseLeadingEnv(tokens) {
+  const env = {};
+  let index = 0;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    const equals = token.indexOf('=');
+    if (equals <= 0) break;
+    const key = token.slice(0, equals);
+    const value = token.slice(equals + 1);
+    if (!SAFE_ENV_KEY_RE.test(key) || !SAFE_ENV_VALUE_RE.test(value)) {
+      return { ok: false, reason: 'verify_command_not_allowed' };
+    }
+    env[key] = value;
+    index += 1;
+  }
+  return { ok: true, env, argv: tokens.slice(index) };
+}
+
+function safeVerifyArgv(argv) {
+  return argv.every((token, index) => {
+    if (safePythonBinaryToken(argv[0]) && index === 0) return true;
+    if (argv[0] === 'git' && argv[1] === '-C' && index === 2) {
+      return safeGitWorktreePathToken(token);
+    }
+    if (argv[0] === 'git' && ['diff', '-C'].includes(argv[1]) && index >= (argv[1] === '-C' ? 5 : 3)) {
+      return safeGitRevToken(token);
+    }
+    return safeVerifyToken(token);
+  });
+}
+
+function isAllowedPythonCommand(argv) {
+  const [bin, first, second] = argv;
+  if (!safePythonBinaryToken(bin)) return false;
+  if (first === '-m' && second === 'pytest') {
+    return argv.slice(3).every(safePytestArg);
+  }
+  if (safePythonScriptPath(first)) {
+    return argv.slice(2).every(safePythonScriptArg);
+  }
+  return false;
+}
+
 function parseVerifyCommand(verify) {
   const cmd = String(verify || '').trim();
   if (!cmd) return { ok: false, reason: 'no_verify_command' };
-  if (/[;&|`$<>\n\r]/.test(cmd)) return { ok: false, reason: 'verify_command_not_allowed' };
-  const argv = cmd.split(/\s+/).filter(Boolean);
-  if (!argv.length || argv.some((token, index) => {
-    if (argv[0] === 'git' && argv[1] === '-C' && index === 2) {
-      return !safeGitWorktreePathToken(token);
-    }
-    if (argv[0] === 'git' && ['diff', '-C'].includes(argv[1]) && index >= (argv[1] === '-C' ? 5 : 3)) {
-      return !safeGitRevToken(token);
-    }
-    return !safeVerifyToken(token);
-  })) {
+  const prefixed = parseCdPrefix(cmd);
+  if (!prefixed.ok) return prefixed;
+  if (/[;&|`$<>\n\r]/.test(prefixed.command)) return { ok: false, reason: 'verify_command_not_allowed' };
+  const tokens = prefixed.command.split(/\s+/).filter(Boolean);
+  const envParsed = parseLeadingEnv(tokens);
+  if (!envParsed.ok) return envParsed;
+  const argv = envParsed.argv;
+  if (!argv.length || !safeVerifyArgv(argv)) {
     return { ok: false, reason: 'verify_command_not_allowed' };
   }
   const [bin, first, second] = argv;
@@ -217,9 +361,15 @@ function parseVerifyCommand(verify) {
     ))
     || (bin === 'tsc' && argv.length === 1)
     || isAllowedAtrisCleanDryRun(argv)
-    || isAllowedGitDiffCheck(argv);
+    || isAllowedGitDiffCheck(argv)
+    || isAllowedPythonCommand(argv);
   if (!allowed) return { ok: false, reason: 'verify_command_not_allowed' };
-  return { ok: true, argv };
+  return {
+    ok: true,
+    argv,
+    ...(prefixed.cwd ? { cwd: prefixed.cwd } : {}),
+    ...(Object.keys(envParsed.env).length ? { env: envParsed.env } : {}),
+  };
 }
 
 function isAutoCertifyVerifyCommandAllowed(verify) {
@@ -229,10 +379,15 @@ function isAutoCertifyVerifyCommandAllowed(verify) {
 function runVerifyCommand(verify, workspaceRoot) {
   const parsed = parseVerifyCommand(verify);
   if (!parsed.ok) return parsed;
-  const gitPathCheck = validateGitWorktreePath(parsed.argv, workspaceRoot);
+  const cwdCheck = validateCommandCwd(parsed, workspaceRoot);
+  if (!cwdCheck.ok) return cwdCheck;
+  const gitPathCheck = validateGitWorktreePath(parsed.argv, workspaceRoot, cwdCheck.cwd);
   if (!gitPathCheck.ok) return gitPathCheck;
+  const pythonPathCheck = validatePythonBinaryPath(parsed.argv, workspaceRoot, cwdCheck.cwd);
+  if (!pythonPathCheck.ok) return pythonPathCheck;
   const result = spawnSync(parsed.argv[0], parsed.argv.slice(1), {
-    cwd: workspaceRoot,
+    cwd: cwdCheck.cwd,
+    env: parsed.env ? { ...process.env, ...parsed.env } : process.env,
     shell: false,
     encoding: 'utf8',
     timeout: 120000,

--- a/test/auto-accept-certified.test.js
+++ b/test/auto-accept-certified.test.js
@@ -189,6 +189,76 @@ test('strict verify parser rejects path and npm config escapes', () => {
   assert.equal(parseVerifyCommand('node --check file:///tmp/pwn.js').ok, false);
 });
 
+test('strict verify parser allows safe backend python commands with cd and env', () => {
+  const commands = [
+    'cd backend && OFFLINE_MODE=1 ../venv/bin/python -m pytest tests/test_api_tracking_service.py tests/test_api_key_usage.py -q',
+    'cd backend && OFFLINE_MODE=1 ../venv/bin/python -m pytest tests/test_api_tracking_service.py -q',
+    'cd backend && /Users/keshavrao/arena/atrisos-backend/venv/bin/python -m pytest tests/test_org_decision_loop.py -q',
+    '/Users/keshavrao/arena/atrisos-backend/venv/bin/python scripts/measure_reward_ab.py',
+  ];
+
+  for (const command of commands) {
+    assert.equal(parseVerifyCommand(command).ok, true, command);
+  }
+
+  assert.deepEqual(parseVerifyCommand(commands[0]), {
+    ok: true,
+    cwd: 'backend',
+    env: { OFFLINE_MODE: '1' },
+    argv: [
+      '../venv/bin/python',
+      '-m',
+      'pytest',
+      'tests/test_api_tracking_service.py',
+      'tests/test_api_key_usage.py',
+      '-q',
+    ],
+  });
+});
+
+test('strict verify parser rejects unsafe python command forms', () => {
+  const denied = [
+    'python -c "print(1)"',
+    'cd .. && python -m pytest x',
+    'cd backend; python -m pytest x',
+    'python -m pytest tests/a.py && rm -rf /',
+    'FOO=$(whoami) python -m pytest t.py',
+    'python -m pytest tests/a.py `whoami`',
+    'python -m pytest tests/a.py | cat',
+    'python -m pytest tests/a.py; rm -rf /',
+    '/usr/bin/python -m pytest tests/a.py',
+  ];
+
+  for (const command of denied) {
+    assert.equal(parseVerifyCommand(command).ok, false, command);
+  }
+});
+
+test('strict verify runtime uses cd cwd and env assignments without a shell', () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-verify-workspace-'));
+  const scriptsDir = path.join(workspace, 'backend', 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(scriptsDir, 'check-env.js'),
+    'if (process.env.OFFLINE_MODE !== "1") process.exit(7);\n',
+  );
+
+  const result = runVerifyCommand('cd backend && OFFLINE_MODE=1 node scripts/check-env.js', workspace);
+  assert.equal(result.ok, true);
+  assert.equal(result.reason, 'verify_passed');
+});
+
+test('strict verify runtime rejects absolute venv python outside the workspace arena', () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-verify-workspace-'));
+  const outsidePython = path.join(os.homedir(), '.atris-verify-outside', 'venv', 'bin', 'python');
+  const command = `${outsidePython} -m pytest tests/a.py`;
+
+  assert.equal(parseVerifyCommand(command).ok, true);
+  const result = runVerifyCommand(command, workspace);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'verify_command_not_allowed');
+});
+
 test('strict verify parser allows bounded git worktree diff checks', () => {
   const sibling = path.join(os.tmpdir(), 'sibling-worktree');
   const parsed = parseVerifyCommand(`git -C ${sibling} diff --check origin/master^ origin/master`);


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-verify-allowlist-python-20260706-075451
Target: master