### PR TITLE
xp: write rejected-review receipts (outcome=rejected, xp 0) so negatives are captured

### DIFF
--- a/commands/report.js
+++ b/commands/report.js
@@ -179,7 +179,7 @@ function buildXp(root, cutoff) {
       };
     })
     .filter(row => row.amount > 0)
-    .filter(row => !row.receipt?.outcome || row.receipt.outcome === 'accepted')
+    .filter(row => row.receipt?.outcome === 'accepted')
     .filter(row => Number(row.timestamp_ms) >= cutoff)
     .sort((a, b) => Number(b.timestamp_ms || 0) - Number(a.timestamp_ms || 0))
     .map((row) => ({

--- a/commands/xp.js
+++ b/commands/xp.js
@@ -890,30 +890,33 @@ function readTaskEpisodeTail(episodePath, cursorPath, options = {}) {
 }
 
 function receiptFromTaskEpisode(episode) {
+  const episodeId = episode?.episode_id;
+  const label = episode?.rl?.label;
+  const rejected = label === 'rework_requested' || label === 'rejected';
   const doneForXp = String(episode?.state?.status || '').toLowerCase() === 'done';
   const hasExplicitCareerXp = episode?.career_xp && typeof episode.career_xp === 'object';
   const eligible = doneForXp && (
     episode?.career_xp?.eligible === true
-      || (!hasExplicitCareerXp && episode?.rl?.label === 'accepted')
+      || (!hasExplicitCareerXp && label === 'accepted')
   );
   const proof = String(episode?.proof || '').trim();
   const reward = asNumber(episode?.career_xp?.reward ?? episode?.reward?.value, 0);
-  if (!eligible || !proof || reward <= 0 || !episode?.episode_id) return null;
+  if (!episodeId || (!rejected && (!eligible || !proof || reward <= 0))) return null;
 
   return {
     schema: 'atris.career_xp_receipt.v1',
-    receipt_id: `task_review:${episode.episode_id}`,
+    receipt_id: `task_review:${episodeId}${rejected ? ':rejected' : ''}`,
     source: 'atris-cli',
     source_type: 'task_review',
     source_task_id: episode.task_id || null,
-    source_episode_id: episode.episode_id,
+    source_episode_id: episodeId,
     workspace_root: episode.workspace_root || null,
     actor: episode.action?.actor || null,
-    outcome: 'accepted',
-    xp: reward,
-    reward,
-    proof,
-    proof_ref: proof,
+    outcome: rejected ? 'rejected' : 'accepted',
+    xp: rejected ? 0 : reward,
+    reward: rejected ? 0 : reward,
+    proof: proof || null,
+    proof_ref: proof || null,
     source_episode_hash: hashPayload(episode),
     title: episode.state?.title || null,
     goal: episode.goal || null,

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -144,6 +144,13 @@ test('buildWeekReportData sums only fresh Career XP receipts', () => {
         title: 'Old accepted task',
         accepted_at: new Date(NOW - 12 * DAY_MS).toISOString(),
       },
+      {
+        receipt_id: 'task_review:rejected:rejected',
+        outcome: 'rejected',
+        xp: 100,
+        title: 'Rejected report task',
+        accepted_at: new Date(NOW - DAY_MS).toISOString(),
+      },
     ]);
     const data = buildWeekReportData(dir, { days: 7, now: NOW });
     assert.equal(data.empty, false);

--- a/test/xp.test.js
+++ b/test/xp.test.js
@@ -1282,6 +1282,57 @@ test('xp status cursor stays byte-aligned after newline-terminated JSONL append'
   }
 });
 
+test('xp status records rejected reviews without adding XP', () => {
+  const workspace = makeTempDir();
+  try {
+    const rejected = taskEpisode(workspace, {
+      episode_id: 'review-outcome',
+      task_id: 'task-review-outcome',
+      title: 'Capture review outcomes',
+      xp: 2,
+      proof: 'accepted proof still earns XP',
+    });
+    rejected.state.status = 'claimed';
+    rejected.reward.value = 0;
+    rejected.proof = null;
+    rejected.career_xp = { eligible: false, reward: 0 };
+    rejected.rl = { label: 'rework_requested', reward: 0 };
+
+    writeJsonl(path.join(workspace, '.atris', 'state', 'task_episodes.jsonl'), [
+      rejected,
+      taskEpisode(workspace, {
+        episode_id: 'review-outcome',
+        task_id: 'task-review-outcome',
+        title: 'Capture review outcomes',
+        xp: 2,
+        proof: 'accepted proof still earns XP',
+      }),
+    ]);
+
+    const result = runCli(['xp', 'status', '--local', '--json'], { cwd: workspace });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.collected_receipts, 2);
+    assert.equal(payload.receipts_count, 1);
+    assert.equal(payload.total_xp, 2);
+    assert.equal(payload.contribution_graph.total_xp, 2);
+
+    const receiptsPath = path.join(workspace, '.atris', 'state', 'career_xp_receipts.jsonl');
+    const receipts = fs.readFileSync(receiptsPath, 'utf8').trim().split(/\r?\n/).map(line => JSON.parse(line));
+    const rejectedReceipt = receipts.find(receipt => receipt.outcome === 'rejected');
+    assert.equal(rejectedReceipt.receipt_id, 'task_review:review-outcome:rejected');
+    assert.equal(rejectedReceipt.xp, 0);
+    assert.equal(rejectedReceipt.reward, 0);
+    assert.equal(rejectedReceipt.proof, null);
+
+    const acceptedReceipt = receipts.find(receipt => receipt.outcome === 'accepted');
+    assert.equal(acceptedReceipt.receipt_id, 'task_review:review-outcome');
+    assert.equal(acceptedReceipt.xp, 2);
+  } finally {
+    cleanupTempDir(workspace);
+  }
+});
+
 test('xp status replays accepted episodes when the receipt ledger is missing', () => {
   const workspace = makeTempDir();
   try {


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-xp-reject-receipts-20260713-042333
Target: master