### PR TITLE
MAP ref healer stops treating annotations like PATCH and NEW as symbols

### DIFF
--- a/commands/clean.js
+++ b/commands/clean.js
@@ -417,6 +417,10 @@ function extractSymbol(context) {
 
   if (!cleaned) return null;
 
+  // MAP.md uses all-caps editorial annotations such as (NEW) and (PATCH +177).
+  // These describe the ref rather than naming a symbol to verify.
+  if (/^[A-Z][A-Z0-9_]*(?:\s+\+\d+)?$/.test(cleaned)) return null;
+
   // Try to extract a function/class/variable name
   // Pattern: word that looks like an identifier
   const identifierMatch = cleaned.match(/\b([a-zA-Z_][a-zA-Z0-9_]*(?:Atris|Entry|Handler|Cmd|Function|Class)?)\b/i);

--- a/test/clean-heal.test.js
+++ b/test/clean-heal.test.js
@@ -79,6 +79,73 @@ test('healer still handles post-ref symbol context (baseline)', () => {
   }
 });
 
+test('healer ignores editorial annotations on valid refs', () => {
+  const { dir, atrisDir } = makeTempAtris();
+  try {
+    const source = [
+      '// header',
+      'function annotatedTarget() {',
+      '  return true;',
+      '}',
+      '',
+    ].join('\n');
+    const srcFile = path.join(dir, 'commands', 'annotated.js');
+    fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+    fs.writeFileSync(srcFile, source);
+
+    const mapContent = [
+      '# MAP',
+      '`commands/annotated.js:1` (WIP)',
+      '`commands/annotated.js:2` (PATCH +177)',
+      '`commands/annotated.js:3` (NEW)',
+      '`commands/annotated.js:4` (TODO)',
+      '`commands/annotated.js:5` (DEPRECATED)',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'), mapContent);
+
+    const result = healBrokenMapRefs(dir, atrisDir, false);
+
+    assert.equal(result.healed, 0);
+    assert.deepEqual(result.unhealable, []);
+    assert.equal(fs.readFileSync(path.join(atrisDir, 'MAP.md'), 'utf8'), mapContent);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('healer still reports a genuine symbol mismatch as unhealable', () => {
+  const { dir, atrisDir } = makeTempAtris();
+  try {
+    const source = [
+      '// header',
+      'function actualTarget() {',
+      '  return true;',
+      '}',
+      '',
+    ].join('\n');
+    const srcFile = path.join(dir, 'commands', 'mismatch.js');
+    fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+    fs.writeFileSync(srcFile, source);
+
+    const mapContent = [
+      '# MAP',
+      '`commands/mismatch.js:2` (missingTarget function)',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'), mapContent);
+
+    const result = healBrokenMapRefs(dir, atrisDir, false);
+
+    assert.equal(result.healed, 0);
+    assert.deepEqual(result.unhealable, [
+      { file: 'commands/mismatch.js', line: 2, reason: 'Symbol "missingTarget" not found' },
+    ]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('healer resolves tilde refs from an injected home and preserves missing refs', () => {
   const { dir, atrisDir } = makeTempAtris();
   const fakeHome = path.join(dir, 'home');


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-bck-1299-symbol-annotations-20260713-045059
Target: master