### PR TITLE
MAP ref healer stops mistaking prose descriptions for code symbols

### DIFF
--- a/commands/clean.js
+++ b/commands/clean.js
@@ -408,32 +408,30 @@ function findFunctionEnd(lines, startLine) {
 function extractSymbol(context) {
   if (!context) return null;
 
-  // Clean up the context
-  const cleaned = context.trim()
-    .replace(/`/g, '')                // Strip backticks
-    .replace(/^[\(\[—\-:]+\s*/, '')  // Remove leading punctuation
-    .replace(/[\)\]]+$/, '')          // Remove trailing brackets
+  const original = context;
+
+  // Clean up the context without stripping parentheses from a symbol ending in ().
+  const unquoted = context.trim().replace(/`/g, '');
+  const wrapper = unquoted.match(/^([\(\[])/)?.[1];
+  let cleaned = unquoted
+    .replace(/^[\(\[—\-:]+\s*/, '')
     .trim();
+  if (wrapper === '(') cleaned = cleaned.replace(/\)$/, '').trim();
+  if (wrapper === '[') cleaned = cleaned.replace(/\]$/, '').trim();
 
   if (!cleaned) return null;
 
-  // MAP.md uses all-caps editorial annotations such as (NEW) and (PATCH +177).
-  // These describe the ref rather than naming a symbol to verify.
-  if (/^[A-Z][A-Z0-9_]*(?:\s+\+\d+)?$/.test(cleaned)) return null;
+  const tokenMatch = cleaned.match(/^([a-zA-Z_][a-zA-Z0-9_]*)(\(\))?/);
+  if (!tokenMatch) return null;
 
-  // Try to extract a function/class/variable name
-  // Pattern: word that looks like an identifier
-  const identifierMatch = cleaned.match(/\b([a-zA-Z_][a-zA-Z0-9_]*(?:Atris|Entry|Handler|Cmd|Function|Class)?)\b/i);
+  const symbol = tokenMatch[1];
+  const token = tokenMatch[0];
+  const codeShaped = symbol.includes('_') || /[a-z][A-Z]/.test(symbol) || token.endsWith('()');
+  if (codeShaped) return symbol;
 
-  if (identifierMatch) {
-    return identifierMatch[1];
-  }
-
-  // Fallback: first word
-  const firstWord = cleaned.split(/\s+/)[0];
-  if (firstWord && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(firstWord)) {
-    return firstWord;
-  }
+  const isSingleWord = cleaned === symbol;
+  const isBackticked = original.includes(`\`${symbol}\``);
+  if (isSingleWord && isBackticked) return symbol;
 
   return null;
 }

--- a/test/clean-heal.test.js
+++ b/test/clean-heal.test.js
@@ -146,6 +146,67 @@ test('healer still reports a genuine symbol mismatch as unhealable', () => {
   }
 });
 
+test('healer treats prose after an in-bounds ref as a description', () => {
+  const { dir, atrisDir } = makeTempAtris();
+  try {
+    const source = [
+      '// header',
+      'const fleetState = {};',
+      '',
+    ].join('\n');
+    const srcFile = path.join(dir, 'commands', 'fleet.js');
+    fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+    fs.writeFileSync(srcFile, source);
+
+    const mapContent = [
+      '# MAP',
+      '`commands/fleet.js:2` - Single source of truth for fleet state',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'), mapContent);
+
+    const result = healBrokenMapRefs(dir, atrisDir, false);
+
+    assert.equal(result.healed, 0);
+    assert.deepEqual(result.unhealable, []);
+    assert.equal(fs.readFileSync(path.join(atrisDir, 'MAP.md'), 'utf8'), mapContent);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('healer still treats camelCase context as a symbol', () => {
+  const { dir, atrisDir } = makeTempAtris();
+  try {
+    const source = [
+      '// header',
+      'function actualTarget() {',
+      '  return true;',
+      '}',
+      '',
+    ].join('\n');
+    const srcFile = path.join(dir, 'commands', 'mission.js');
+    fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+    fs.writeFileSync(srcFile, source);
+
+    const mapContent = [
+      '# MAP',
+      '`commands/mission.js:2` - resolveMission helper',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'), mapContent);
+
+    const result = healBrokenMapRefs(dir, atrisDir, false);
+
+    assert.equal(result.healed, 0);
+    assert.deepEqual(result.unhealable, [
+      { file: 'commands/mission.js', line: 2, reason: 'Symbol "resolveMission" not found' },
+    ]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('healer resolves tilde refs from an injected home and preserves missing refs', () => {
   const { dir, atrisDir } = makeTempAtris();
   const fakeHome = path.join(dir, 'home');


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-bck-1299-prose-not-symbols-20260713-045350
Target: master