### PR TITLE
clean: MAP healer ignores prose annotations, keeps flagging real symbol drift

### DIFF
--- a/commands/clean.js
+++ b/commands/clean.js
@@ -324,7 +324,15 @@ function healBrokenMapRefs(cwd, atrisDir, dryRun = false, homeDir = os.homedir()
     // Find where the symbol actually is now
     const newStart = findSymbolLine(file.content, symbol);
     if (!newStart) {
-      unhealable.push({ file: filePath, line: startLine, reason: `Symbol "${symbol}" not found` });
+      // A "symbol" that appears nowhere in the file is often descriptive
+      // prose from the annotation ("PATCH /api/...", "mission drain"), not
+      // a code identifier. Suppress those for in-bounds refs to existing
+      // files; still flag out-of-bounds refs and vanished identifiers
+      // (camelCase/snake_case words were plausibly real symbols).
+      const identifierLike = /[a-z][^\s]*[A-Z]|_/.test(symbol);
+      if (outOfBounds || identifierLike) {
+        unhealable.push({ file: filePath, line: startLine, reason: `Symbol "${symbol}" not found` });
+      }
       continue;
     }
 

--- a/test/clean-heal.test.js
+++ b/test/clean-heal.test.js
@@ -221,3 +221,38 @@ test('healer uses absolute refs as-is and preserves missing refs', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('healer ignores descriptive annotations that are not code symbols', () => {
+  const { dir, atrisDir } = makeTempAtris();
+  try {
+    const source = [
+      '// header',
+      'function realTarget() {',
+      '  return true;',
+      '}',
+      '',
+    ].join('\n');
+    const srcFile = path.join(dir, 'api.js');
+    fs.writeFileSync(srcFile, source);
+
+    const mapContent = [
+      '# MAP',
+      // in-bounds ref, annotation is prose ("PATCH /api/...") not a symbol
+      '`api.js:2` (PATCH endpoint handler)',
+      // out-of-bounds ref with an unfindable symbol stays unhealable
+      '`api.js:99` (GHOST function)',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(atrisDir, 'MAP.md'), mapContent);
+
+    const result = healBrokenMapRefs(dir, atrisDir, false);
+
+    assert.deepEqual(result.unhealable, [
+      { file: 'api.js', line: 99, reason: 'Symbol "GHOST" not found' },
+    ]);
+    const updated = fs.readFileSync(path.join(atrisDir, 'MAP.md'), 'utf8');
+    assert.ok(updated.includes('api.js:2'));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/claude-map-heal-descriptive-annotations-20260713-045353
Target: master