### PR TITLE
skill audit stops flagging placeholders inside code blocks

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1593,7 +1593,8 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris/skills/drive/SKILL.md` — Google Drive + Sheets integration v1.0.0 (files, sheets CRUD)
 - `atris/skills/README.md` — Skills pattern + Claude symlink instructions
 - `atris/skills/copy-editor/SKILL.md` — Repo-owned anti-slop copy editor skill, including memo-specific slop gate
-- `commands/skill.js:591-640` — `atris skill create <customer>/<skill>` scaffolds customer skills under `atris/customers/<customer>/skills/`
+- `commands/skill.js` and `test/skill-audit-codeblocks.test.js` - Skill audit checks and code-block XML regression coverage
+- `commands/skill.js:668-719` - `atris skill create <customer>/<skill>` scaffolds customer skills under `atris/customers/<customer>/skills/`
 - `commands/plugin.js:176` — `buildPlugin` packages universal `atris/skills` into `atris-workspace.plugin`
 - `commands/plugin.js:336` — `publishPlugin` syncs universal skills to a marketplace repo; no customer-specific publish path yet
 - `atris/features/customer-skill-zones/` — parked feature notes for customer skill scaffold vs private plugin publishing

--- a/commands/skill.js
+++ b/commands/skill.js
@@ -123,6 +123,52 @@ function findReadableSkills() {
 
 // --- Audit Checks ---
 
+function stripMarkdownCode(content) {
+  let fenceLength = 0;
+
+  return content.split('\n').map((line) => {
+    if (fenceLength > 0) {
+      const closingFence = line.match(/^ {0,3}(`+)[ \t]*$/);
+      if (closingFence && closingFence[1].length >= fenceLength) fenceLength = 0;
+      return '';
+    }
+
+    const openingFence = line.match(/^ {0,3}(`{3,})([^`]*)$/);
+    if (openingFence) {
+      fenceLength = openingFence[1].length;
+      return '';
+    }
+
+    let prose = '';
+    for (let index = 0; index < line.length;) {
+      if (line[index] !== '`') {
+        prose += line[index++];
+        continue;
+      }
+
+      const start = index;
+      while (line[index] === '`') index++;
+      const delimiterLength = index - start;
+      let closingStart = index;
+
+      while (closingStart < line.length) {
+        closingStart = line.indexOf('`', closingStart);
+        if (closingStart === -1) break;
+        let closingEnd = closingStart;
+        while (line[closingEnd] === '`') closingEnd++;
+        if (closingEnd - closingStart === delimiterLength) {
+          index = closingEnd;
+          break;
+        }
+        closingStart = closingEnd;
+      }
+
+      if (closingStart === -1) prose += line.slice(start, index);
+    }
+    return prose;
+  }).join('\n');
+}
+
 function runAuditChecks(skill) {
   const fm = skill.frontmatter || {};
   const checks = [];
@@ -183,9 +229,7 @@ function runAuditChecks(skill) {
   });
 
   // 7. no XML tags in content (skip placeholders like <name>, <keyword>, code blocks)
-  const proseContent = skill.content
-    .replace(/```[\s\S]*?```/g, '')   // fenced code blocks
-    .replace(/`[^`\n]*`/g, '');        // inline code spans
+  const proseContent = stripMarkdownCode(skill.content);
   const xmlMatches = proseContent.match(/<[a-zA-Z][^>]*>/g) || [];
   // Single-letter tags like <X>/<N> are prose placeholders, not real XML.
   const placeholders = /^<(name|keyword|placeholder|value|type|path|file|dir|id|url|tag|description|your-|user-|project-|skill-|[a-zA-Z]>)/i;

--- a/test/skill-audit-codeblocks.test.js
+++ b/test/skill-audit-codeblocks.test.js
@@ -44,12 +44,36 @@ test('placeholders inside fenced code blocks do not count as XML', () => {
   assert.equal(check.pass, true, check.message);
 });
 
+test('placeholders inside longer fenced code examples do not count as XML', () => {
+  const check = xmlCheck(makeSkill([
+    '# Fixture',
+    '',
+    '1. Show the nested example below.',
+    '',
+    '````markdown',
+    '```bash',
+    'cd <worktree-path>',
+    '```',
+    '````',
+  ].join('\n')));
+  assert.equal(check.pass, true, check.message);
+});
+
 test('placeholders inside inline code spans do not count as XML', () => {
   const check = xmlCheck(makeSkill([
     '# Fixture',
     '',
     '1. Save the draft to `/workspace/atris/aeo/drafts/<slug>.md` first.',
     '2. Then audit `<slug>-<date>.md` for citations.',
+  ].join('\n')));
+  assert.equal(check.pass, true, check.message);
+});
+
+test('placeholders inside longer inline code spans do not count as XML', () => {
+  const check = xmlCheck(makeSkill([
+    '# Fixture',
+    '',
+    '1. Run ``cd <worktree-path>`` before shipping.',
   ].join('\n')));
   assert.equal(check.pass, true, check.message);
 });


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-skill-audit-codeblock-false-fails-20260713-052107
Target: master