### PR TITLE
atris2 relay: send tool results base64-encoded so the Cloudflare WAF stops blocking shell-like output (BCK-1338)

### DIFF
--- a/commands/probe.js
+++ b/commands/probe.js
@@ -28,6 +28,7 @@ const https = require('https');
 const http = require('http');
 const { getApiBaseUrl } = require('../utils/api');
 const { loadCredentials } = require('../utils/auth');
+const { encodeToolResult } = require('../lib/tool-result-encode');
 
 // G2's honest blocked message (tool_policy_bench.MAX_TURNS_EXHAUSTED_MESSAGE)
 // starts with this — an answer that is only this marker is a dead-end.
@@ -350,7 +351,7 @@ async function runAtris2Turn(opts = {}) {
                 unsupported.push(`tool:${name || '?'}`);
               }
               await postJson(`${base}/atris2/turn/tool-result`, token,
-                { call_id: ev.call_id || ev.id, result: out }, 30000);
+                { call_id: ev.call_id || ev.id, result_base64: encodeToolResult(out) }, 30000);
               resetIdle();
             }).catch((e) => reject(e));
           } else if (et === 'result') {

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { getLogPath } = require('../lib/journal');
+const { encodeToolResult } = require('../lib/tool-result-encode');
 
 function wrapWorkflowText(text, width = 76) {
   const normalized = String(text || '').replace(/\s+/g, ' ').trim();
@@ -139,7 +140,7 @@ function postToolResult(callId, result, base = 'http://127.0.0.1:8000') {
   const url = new URL('/api/atris2/turn/tool-result', base);
   const transport = url.protocol === 'https:' ? require('https') : require('http');
   return new Promise((resolve, reject) => {
-    const postData = JSON.stringify({ call_id: callId, result });
+    const postData = JSON.stringify({ call_id: callId, result_base64: encodeToolResult(result) });
     const req = transport.request({
       hostname: url.hostname,
       port: url.port || (url.protocol === 'https:' ? 443 : 80),

--- a/lib/tool-result-encode.js
+++ b/lib/tool-result-encode.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function encodeToolResult(result) {
+  return Buffer.from(JSON.stringify(result), 'utf8').toString('base64');
+}
+
+module.exports = { encodeToolResult };

--- a/test/tool-result-encode.test.js
+++ b/test/tool-result-encode.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { encodeToolResult } = require('../lib/tool-result-encode');
+
+test('tool result encoding round-trips relay output that can trigger the WAF', () => {
+  const result = {
+    status: 'error',
+    stdout: '$(whoami)\nSELECT * FROM tasks;\n<script>alert(1)</script>',
+    exit_code: 1,
+  };
+
+  const encoded = encodeToolResult(result);
+
+  assert.deepEqual(JSON.parse(Buffer.from(encoded, 'base64').toString('utf8')), result);
+});


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-waf-relay-b64-20260713-183848
Target: master