### PR TITLE
boot shows newest wiki brief in one line

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -649,7 +649,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris task lineage <id> [--json]` — endgame → parents → target → children chain + commits grepped by display refs (`cmdLineage` in `commands/task.js`; test: `test/commands.test.js` 'task lineage')
 - `atris member history <name> [--limit N] [--json]` — git log per identity file (MEMBER.md/SOUL.md) (`memberHistory` in `commands/member.js`; test: `test/member-history.test.js`)
 - `atris lesson sweep [--dry-run] [--json]` — contradiction detection (opposite outcomes, dead file refs) → idempotent dissolve tasks (`lib/lesson-contradiction.js`, `commands/lesson.js`; test: `test/lesson-sweep.test.js`)
-- Boot impression: boot status `endgame` row renders active slug+horizon verbatim (`bin/atris.js` showWelcomeVisualization); `listTasks` ranks `tag='endgame'` first within status (`lib/task-db.js`; test: `test/boot-impression.test.js`)
+- Boot impression: boot status shows the newest `atris/wiki/briefs/*.md` mtime as one `learned ... overnight` line, renders the active endgame slug+horizon verbatim (`bin/atris.js` showWelcomeVisualization), and `listTasks` ranks `tag='endgame'` first within status (`lib/task-db.js`; test: `test/boot-impression.test.js`)
 - Layer receipts: every mission tick stores `layer`/`layer_source` (explicit `layer: x` receipt line or path-class fallback) + `last_tick_layer` on the mission; heartbeat shows it (`extractLayerFromReceiptText`/`classifyPathsByLayer` in `commands/mission.js`; test: `test/mission-layer-receipts.test.js`)
 
 ### Feature: Task Production Readiness

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -1528,6 +1528,7 @@ function showWelcomeVisualization() {
     activeTitles: [], backlogTitles: [], certifiedTitles: []
   };
   let journalEntries = 0;
+  let latestBriefName = '';
   const isInitialized = fs.existsSync(atrisDir);
   let endgameState = { slug: 'unset', horizon: '' };
 
@@ -1542,6 +1543,16 @@ function showWelcomeVisualization() {
       endgameState = readEndgameState(cwd);
     } catch {
       // Silently fail - show unset if reading fails
+    }
+
+    try {
+      const briefsDir = path.join(atrisDir, 'wiki', 'briefs');
+      latestBriefName = fs.readdirSync(briefsDir, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+        .map((entry) => ({ name: entry.name, mtimeMs: fs.statSync(path.join(briefsDir, entry.name)).mtimeMs }))
+        .sort((a, b) => b.mtimeMs - a.mtimeMs || a.name.localeCompare(b.name))[0]?.name || '';
+    } catch {
+      // Briefs are optional, so missing or unreadable directories stay silent.
     }
 
     // Count journal entries today
@@ -1580,6 +1591,10 @@ function showWelcomeVisualization() {
     console.log(row('next', 'atris init  (set up this folder)'));
     console.log('');
     return;
+  }
+
+  if (latestBriefName) {
+    console.log(`  learned ${path.basename(latestBriefName, '.md')} overnight -> atris/wiki/briefs/${latestBriefName}`);
   }
 
   // Show the work itself, not counts. A newcomer in any domain (code, docs,

--- a/test/boot-impression.test.js
+++ b/test/boot-impression.test.js
@@ -99,3 +99,33 @@ test('boot panel renders active endgame verbatim and task next prefers endgame-t
     cleanupTempDir(dir);
   }
 });
+
+test('boot panel shows only the newest wiki brief and stays silent without briefs', () => {
+  const dir = makeTempDir();
+  try {
+    const atrisDir = path.join(dir, 'atris');
+    fs.mkdirSync(atrisDir, { recursive: true });
+
+    const emptyBoot = runCli(['atris.md'], { cwd: dir });
+    assert.equal(emptyBoot.status, 0, emptyBoot.stderr);
+    assert.deepEqual(emptyBoot.stdout.split('\n').filter((line) => line.includes('learned ')), []);
+
+    const briefsDir = path.join(atrisDir, 'wiki', 'briefs');
+    fs.mkdirSync(briefsDir, { recursive: true });
+    const olderBrief = path.join(briefsDir, 'zzz-older-brief.md');
+    const newestBrief = path.join(briefsDir, 'aaa-newest-brief.md');
+    fs.writeFileSync(olderBrief, '# Older brief\n', 'utf8');
+    fs.writeFileSync(newestBrief, '# Newest brief\n', 'utf8');
+    fs.utimesSync(olderBrief, new Date('2026-07-20T00:00:00Z'), new Date('2026-07-20T00:00:00Z'));
+    fs.utimesSync(newestBrief, new Date('2026-07-21T00:00:00Z'), new Date('2026-07-21T00:00:00Z'));
+
+    const boot = runCli(['atris.md'], { cwd: dir });
+    assert.equal(boot.status, 0, boot.stderr);
+    assert.deepEqual(
+      boot.stdout.split('\n').filter((line) => line.includes('learned ')),
+      ['  learned aaa-newest-brief overnight -> atris/wiki/briefs/aaa-newest-brief.md'],
+    );
+  } finally {
+    cleanupTempDir(dir);
+  }
+});


### PR DESCRIPTION
When atris/wiki/briefs/ has files, boot prints one plain line naming the newest brief; silent when none. Verified: node --test boot-impression 2/2 pass re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)