### PR TITLE
boot brief line shows the brief's title, not its filename

### DIFF
--- a/bin/atris.js
+++ b/bin/atris.js
@@ -1529,6 +1529,7 @@ function showWelcomeVisualization() {
   };
   let journalEntries = 0;
   let latestBriefName = '';
+  let latestBriefTitle = '';
   const isInitialized = fs.existsSync(atrisDir);
   let endgameState = { slug: 'unset', horizon: '' };
 
@@ -1551,6 +1552,16 @@ function showWelcomeVisualization() {
         .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
         .map((entry) => ({ name: entry.name, mtimeMs: fs.statSync(path.join(briefsDir, entry.name)).mtimeMs }))
         .sort((a, b) => b.mtimeMs - a.mtimeMs || a.name.localeCompare(b.name))[0]?.name || '';
+      if (latestBriefName) {
+        // Prefer the brief's own H1 over its filename; strip miner boilerplate
+        // like "YouTube brief: <slug>" so boot reads like a sentence.
+        const head = fs.readFileSync(path.join(briefsDir, latestBriefName), 'utf8').slice(0, 2000);
+        const h1 = head.split('\n').find((line) => line.startsWith('# '));
+        let title = h1 ? h1.slice(2).trim() : '';
+        title = title.replace(/^youtube brief:\s*/i, '').trim();
+        const slug = path.basename(latestBriefName, '.md');
+        latestBriefTitle = title && title.toLowerCase() !== slug.toLowerCase() ? title : slug;
+      }
     } catch {
       // Briefs are optional, so missing or unreadable directories stay silent.
     }
@@ -1594,7 +1605,7 @@ function showWelcomeVisualization() {
   }
 
   if (latestBriefName) {
-    console.log(`  learned ${path.basename(latestBriefName, '.md')} overnight -> atris/wiki/briefs/${latestBriefName}`);
+    console.log(`  learned \"${latestBriefTitle}\" overnight -> atris/wiki/briefs/${latestBriefName}`);
   }
 
   // Show the work itself, not counts. A newcomer in any domain (code, docs,

--- a/test/boot-impression.test.js
+++ b/test/boot-impression.test.js
@@ -115,7 +115,7 @@ test('boot panel shows only the newest wiki brief and stays silent without brief
     const olderBrief = path.join(briefsDir, 'zzz-older-brief.md');
     const newestBrief = path.join(briefsDir, 'aaa-newest-brief.md');
     fs.writeFileSync(olderBrief, '# Older brief\n', 'utf8');
-    fs.writeFileSync(newestBrief, '# Newest brief\n', 'utf8');
+    fs.writeFileSync(newestBrief, '# YouTube brief: How agents compound\n', 'utf8');
     fs.utimesSync(olderBrief, new Date('2026-07-20T00:00:00Z'), new Date('2026-07-20T00:00:00Z'));
     fs.utimesSync(newestBrief, new Date('2026-07-21T00:00:00Z'), new Date('2026-07-21T00:00:00Z'));
 
@@ -123,7 +123,7 @@ test('boot panel shows only the newest wiki brief and stays silent without brief
     assert.equal(boot.status, 0, boot.stderr);
     assert.deepEqual(
       boot.stdout.split('\n').filter((line) => line.includes('learned ')),
-      ['  learned aaa-newest-brief overnight -> atris/wiki/briefs/aaa-newest-brief.md'],
+      ['  learned "How agents compound" overnight -> atris/wiki/briefs/aaa-newest-brief.md'],
     );
   } finally {
     cleanupTempDir(dir);


### PR DESCRIPTION
Reads the newest brief's H1, strips miner boilerplate, falls back to the
slug when the title is generic. learned "How agents compound" overnight
beats learned youtube-VbqaL-eHhKY overnight.

Co-authored-by: Atris <299057014+atris-builder[bot]@users.noreply.github.com>
