### PR TITLE
Let the CLI ask for mission fan-out the backend already accepts

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -10433,6 +10433,7 @@ atris mission - durable goal + loop + owner + proof state
   atris mission "<objective>" [--owner <member>]   Shortcut for: atris mission run "<objective>"
   atris mission run --fleet [--slots 3] [--dry-run] [--json]   Staff every idle capable engine on claimable safe-lane tasks: parallel worktree builds, serial rebase-before-ship landings, receipt in atris/runs/
   atris mission run "<objective>" --cloud [--lane fast|pro|max] [--agent <id>]   Enqueue on the Atris backend instead of running local ticks
+  atris mission run "<objective>" --cloud --fanout "<role>:<task>" [--fanout ...]   Split one cloud mission across up to 8 roles that run at the same time
   atris mission run ["objective"|<member> ["objective"]|id|--due] [--owner <member>] [--budget quick|long|deep] [--max-ticks 4] [--max-wall 3600] [--cadence "15m"] [--detach] [--land --repo <path> --verify "git diff --check"]
                                 [--native-goal-status active|paused|usageLimited] [--native-goal-objective "..."] [--manual-ack] [--allow-native-goal-supersede] [--take-goal-slot]
                                 [--engine <name>]

--- a/lib/cloud-mission.js
+++ b/lib/cloud-mission.js
@@ -35,6 +35,46 @@ function valueFlag(args, name) {
   return { present: false, value: '', index: -1 };
 }
 
+const MAX_FANOUT_ENTRIES = 8;
+
+// --fanout is repeatable and reads "role:task". The backend contract also takes
+// a per-entry lane and agent id, but the CLI keeps the flag to the two parts an
+// operator actually types; entries inherit the mission lane and agent.
+function collectFlagValues(args, name) {
+  const prefix = `${name}=`;
+  const values = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = String(args[i]);
+    if (arg.startsWith(prefix)) {
+      values.push(arg.slice(prefix.length));
+      continue;
+    }
+    if (arg !== name) continue;
+    const next = args[i + 1];
+    values.push(next && !String(next).startsWith('--') ? String(next) : '');
+    i += 1;
+  }
+  return values;
+}
+
+function parseFanoutEntries(rawValues) {
+  if (!rawValues.length) return null;
+  if (rawValues.length > MAX_FANOUT_ENTRIES) {
+    throw new CloudMissionError(`--fanout takes at most ${MAX_FANOUT_ENTRIES} roles, got ${rawValues.length}`, 2);
+  }
+  return rawValues.map((raw) => {
+    const value = String(raw || '').trim();
+    if (!value) throw new CloudMissionError('--fanout requires "<role>:<task>"', 2);
+    const split = value.indexOf(':');
+    const role = split >= 0 ? value.slice(0, split).trim() : '';
+    const task = split >= 0 ? value.slice(split + 1).trim() : '';
+    if (!role || !task) {
+      throw new CloudMissionError(`--fanout needs a role and a task, like "researcher:read the docs". got "${value}"`, 2);
+    }
+    return { role, task };
+  });
+}
+
 function parseCloudRunArgs(args) {
   const laneFlag = valueFlag(args, '--lane');
   const agentFlag = valueFlag(args, '--agent');
@@ -63,6 +103,11 @@ function parseCloudRunArgs(args) {
       continue;
     }
     if (arg.startsWith('--agent=')) continue;
+    if (arg === '--fanout') {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--fanout=')) continue;
     if (arg.startsWith('--')) {
       throw new CloudMissionError(`unsupported cloud mission flag: ${arg}`, 2);
     }
@@ -70,10 +115,12 @@ function parseCloudRunArgs(args) {
   }
   const text = textParts.join(' ').trim();
   if (!text) {
-    throw new CloudMissionError('usage: atris mission run "<intent>" --cloud [--lane fast|pro|max]', 2);
+    throw new CloudMissionError('usage: atris mission run "<intent>" --cloud [--lane fast|pro|max] [--fanout "<role>:<task>"]', 2);
   }
   const parsed = { text, lane, asJson: args.includes('--json') };
   if (agentFlag.present) parsed.agentId = agentFlag.value;
+  const fanout = parseFanoutEntries(collectFlagValues(args, '--fanout'));
+  if (fanout) parsed.fanout = fanout;
   return parsed;
 }
 
@@ -118,7 +165,7 @@ function withReceiptVoice(text) {
   return `${body}\n\n${RECEIPT_VOICE_CONTRACT}`;
 }
 
-async function enqueueCloudMission({ text, lane = 'fast', agentId }, deps = {}) {
+async function enqueueCloudMission({ text, lane = 'fast', agentId, fanout }, deps = {}) {
   if (!VALID_CLOUD_LANES.has(lane)) {
     throw new CloudMissionError(`invalid --lane "${lane}". expected fast, pro, or max`, 2);
   }
@@ -126,6 +173,7 @@ async function enqueueCloudMission({ text, lane = 'fast', agentId }, deps = {}) 
   const request = deps.apiRequestJson || apiRequestJson;
   const body = { text: withReceiptVoice(text), lane };
   if (agentId) body.agent_id = agentId;
+  if (Array.isArray(fanout) && fanout.length) body.fanout = fanout;
   const response = await request('/atris2/missions', {
     method: 'POST',
     token,
@@ -197,6 +245,7 @@ async function runCloudMissionCommand(args, options = {}) {
       task_id: mission.task_id,
       lane: mission.lane || parsed.lane,
       text: parsed.text,
+      ...(parsed.fanout ? { fanout: parsed.fanout } : {}),
     };
     appendCloudMissionReceipt(options.root || process.cwd(), receipt);
     if (parsed.asJson) {
@@ -204,6 +253,9 @@ async function runCloudMissionCommand(args, options = {}) {
     } else {
       log(`cloud mission queued: ${mission.task_id}`);
       log(`lane: ${receipt.lane}`);
+      if (parsed.fanout) {
+        log(`working in parallel: ${parsed.fanout.map((entry) => entry.role).join(', ')}`);
+      }
       log(`next: atris mission status --cloud ${mission.task_id}`);
     }
     return { exitCode: 0, mission, receipt };

--- a/test/cloud-mission.test.js
+++ b/test/cloud-mission.test.js
@@ -113,6 +113,86 @@ test('cloud mission enqueue passes an explicit agent id to the backend', async (
   }
 });
 
+test('cloud mission fanout sends one entry per role and names them back', async () => {
+  const root = tempDir();
+  const calls = [];
+  const output = capture();
+  try {
+    const result = await runCloudMissionCommand([
+      'ship the launch',
+      '--cloud',
+      '--fanout',
+      'researcher:read the competitor pricing pages',
+      '--fanout=builder:draft the pricing table',
+    ], {
+      root,
+      ...output,
+      loadCredentials: () => ({ token: 'test-token' }),
+      apiRequestJson: async (pathname, options) => {
+        calls.push({ pathname, options });
+        return {
+          ok: true,
+          status: 200,
+          data: { task_id: 'task-fanout-1', status: 'pending', lane: 'fast' },
+        };
+      },
+    });
+
+    assert.equal(result.exitCode, 0, output.stderr.join('\n'));
+    assert.deepEqual(calls[0].options.body.fanout, [
+      { role: 'researcher', task: 'read the competitor pricing pages' },
+      { role: 'builder', task: 'draft the pricing table' },
+    ]);
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(path.join(root, '.atris', 'state', 'missions.jsonl'), 'utf8').trim()).fanout,
+      [
+        { role: 'researcher', task: 'read the competitor pricing pages' },
+        { role: 'builder', task: 'draft the pricing table' },
+      ],
+    );
+    assert.match(output.stdout.join('\n'), /working in parallel: researcher, builder/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a mission with no fanout flag still sends the plain body', async () => {
+  const root = tempDir();
+  const calls = [];
+  try {
+    await runCloudMissionCommand(['ship the launch', '--cloud'], {
+      root,
+      log: () => {},
+      error: () => {},
+      loadCredentials: () => ({ token: 'test-token' }),
+      apiRequestJson: async (pathname, options) => {
+        calls.push({ pathname, options });
+        return { ok: true, status: 200, data: { task_id: 'task-plain', status: 'pending', lane: 'fast' } };
+      },
+    });
+    assert.equal('fanout' in calls[0].options.body, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('cloud mission fanout refuses a role with no task and more than eight roles', () => {
+  assert.throws(
+    () => parseCloudRunArgs(['do work', '--cloud', '--fanout', 'researcher']),
+    /needs a role and a task/,
+  );
+  assert.throws(
+    () => parseCloudRunArgs(['do work', '--cloud', '--fanout', ':read the docs']),
+    /needs a role and a task/,
+  );
+  const nine = [];
+  for (let i = 0; i < 9; i += 1) nine.push('--fanout', `role${i}:task ${i}`);
+  assert.throws(
+    () => parseCloudRunArgs(['do work', '--cloud', ...nine]),
+    /at most 8 roles, got 9/,
+  );
+});
+
 test('cloud mission status parses the cloud task id and prints backend status', async () => {
   const calls = [];
   const output = capture();


### PR DESCRIPTION
## Why

`POST /atris2/missions` has accepted a `fanout` list since the runner learned to emit `computer_tasks` (BCK-1327), but nothing on the CLI side could ask for it. The capability shipped server-side and stayed unreachable from where operators actually work.

Found while auditing the open backlog: BCK-1304 ("one mission can use several cloud computers at once") was blocked on this last hop, not on the feature.

## What

```
atris mission run "<objective>" --cloud --fanout "<role>:<task>" [--fanout ...]
```

Repeatable, up to the eight entries the backend allows. Entries inherit the mission lane and agent, so the flag stays down to the two parts someone actually types. The roles are echoed back on enqueue and recorded on the local receipt.

## Verify

- `node --test test/cloud-mission.test.js` — 9/9, three new cases: entries reach both the request body and the local receipt; a mission with no `--fanout` still sends the plain body (no stray key); a role with no task, or a ninth role, is refused before any network call
- Live check against the backend: the request cleared Pydantic validation, the same-business check, and reached the runner, stopping at `No AI Computer instance found for business` — a provisioning condition on this account, not a contract mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)