### PR TITLE
Say so when a proof names a command that nothing ran

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -499,6 +499,51 @@ function warnIfLandingNeedsDayOnePm(landing, title) {
   return warning;
 }
 
+// A proof that names a command reads like evidence, but nothing ran it. The
+// 2026-07-26 reward-ledger audit found 131 of 802 accepted proofs carried no
+// falsifier at all, and the ones that named a command are the recoverable
+// case: --verify would have run the same string and gated on exit 0. Advisory
+// only, in the same voice as the landing advisory above.
+// A target must look like a path or a package, never a bare English word.
+// Replayed over the live ledger, the loose version turned the prose "node
+// --check plus focused task tests" into the suggestion "node --check plus".
+const TARGET = String.raw`[\w@.\/-]*[.\/][\w@.\/-]*`;
+const PROOF_COMMAND_PATTERN = new RegExp(
+  String.raw`(?:^|[\s\`"'(])((?:(?:cd\s+\S+\s*&&\s*)?(?:[A-Z_][A-Z0-9_]*=\S+\s+)*)` +
+  String.raw`(?:npm run [\w:-]+|npx [\w@.\/-]+ [\w:-]+|node --test ${TARGET}|node --check ${TARGET}` +
+  String.raw`|(?:\S*\/)?pytest ${TARGET}|python3? -m pytest ${TARGET}|cargo test|go test ${TARGET}|make [\w:-]+))`,
+  'i',
+);
+
+// When the writer quoted the command, take what they quoted: the head of the
+// match alone would suggest a half command like `npx vitest`, which is a worse
+// nudge than none.
+function proofNamesUnrunCommand(proof) {
+  const text = String(proof || '');
+  if (!text.trim()) return '';
+  const match = text.match(PROOF_COMMAND_PATTERN);
+  if (!match) return '';
+  const head = match[1].trim();
+  const opener = text[match.index];
+  if (opener === '`' || opener === '"' || opener === "'") {
+    const close = text.indexOf(opener, match.index + 1);
+    if (close > match.index + 1) {
+      const quoted = text.slice(match.index + 1, close).trim();
+      if (quoted.startsWith(head)) return quoted;
+    }
+  }
+  return head;
+}
+
+function warnIfProofNamesUnrunCommand(proof, usedVerify) {
+  if (usedVerify) return null;
+  const command = proofNamesUnrunCommand(proof);
+  if (!command) return null;
+  const warning = `Advisory: this proof names a command but nothing ran it. Pass it as --verify "${command}" so a failing check can actually stop the accept.`;
+  console.error(warning);
+  return warning;
+}
+
 function requireExplicitLandingDayOnePm(label, landing, title) {
   const sentence = landing && typeof landing === 'object' ? normalizedLandingSentence(landing.happened) : '';
   if (!sentence || !landingNeedsDayOnePm(sentence, title)) return;
@@ -9356,6 +9401,7 @@ function cmdReady(args) {
   // live against the current checkout later, instead of re-deriving it from
   // text or trusting a receipt file that may no longer exist.
   if (usedVerify) stampReadyVerifyMetadata(taskDb, db, taskId, usedVerify);
+  warnIfProofNamesUnrunCommand(proof, usedVerify);
   const landingAdvisory = warnIfLandingNeedsDayOnePm(landing, result.row && result.row.title);
   const { projection, outPath } = writeDefaultProjection(taskDb, db);
   const agentCertified = result.event.payload.agent_certified === true;
@@ -12330,6 +12376,7 @@ async function run(args) {
 
 module.exports = {
   run,
+  proofNamesUnrunCommand,
   taskDayGroups,
   taskDayTextGroups,
   taskDayTitle,

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -12453,7 +12453,10 @@ test('task ready and finish accept landing capability sentences', () => {
       '--json',
     ], { cwd: dir, env });
     assert.equal(ready.status, 0, ready.stderr);
-    assert.equal(ready.stderr, '');
+    assert.doesNotMatch(ready.stderr, /Advisory: add --landing/);
+    // This proof names a command that nothing ran, so the verifier advisory is
+    // expected here; the landing is what this case is asserting stays clean.
+    assert.match(ready.stderr, /names a command but nothing ran it/);
     const readyPayload = JSON.parse(ready.stdout);
     assert.equal(readyPayload.landing_advisory, null);
     assert.equal(readyPayload.task.review.landing.happened, readySentence);

--- a/test/proof-names-command.test.js
+++ b/test/proof-names-command.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { proofNamesUnrunCommand } = require('../commands/task');
+
+test('a proof that names a runnable command is spotted so it can become a verifier', () => {
+  const cases = [
+    ['Ran: npm run test:alpha-scout and it passed', 'npm run test:alpha-scout'],
+    ['node --test test/cloud-mission.test.js -> 9/9', 'node --test test/cloud-mission.test.js'],
+    ['checked with node --check bin/atris.js', 'node --check bin/atris.js'],
+    ['cd backend && ATRIS_OFFLINE=1 ../venv/bin/pytest tests/test_x.py -q passed',
+      'cd backend && ATRIS_OFFLINE=1 ../venv/bin/pytest tests/test_x.py'],
+    ['I ran `npx vitest run app/api` green', 'npx vitest run app/api'],
+    ['make lint came back clean', 'make lint'],
+  ];
+  for (const [proof, expected] of cases) {
+    assert.equal(proofNamesUnrunCommand(proof), expected, proof);
+  }
+});
+
+test('prose with no command in it stays quiet', () => {
+  const quiet = [
+    '',
+    '   ',
+    'Concrete command, file, receipt, or verifier evidence for the member experiment.',
+    'The customer confirmed the report looks right.',
+    'Receipt saved in mission history.',
+    // The audit found these two accepted as proof; neither names anything runnable.
+    'Task proof must name the loop command, guardrail, and receipt before Review.',
+    'scoped rg proof; git diff --check on touched docs; live heartbeat status smoke',
+    // Real ledger rows. A bare English word after the binary is prose, not a
+    // target, and suggesting "node --check plus" as a verifier is worse than
+    // staying quiet.
+    'node --check plus focused/full task command tests, installed atris smoke',
+    'node --test focused task tests plus installed atris smoke and codex review',
+  ];
+  for (const proof of quiet) {
+    assert.equal(proofNamesUnrunCommand(proof), '', proof);
+  }
+});


### PR DESCRIPTION
## Why

The reward-ledger audit ([atrisos-backend#2405](https://github.com/atrislabs/atrisos-backend/pull/2405), BCK-1264) found 131 of 802 accepted proofs carried nothing that could fail.

Reading the code sharpened that finding: `atris task ready --verify "<cmd>"` already runs the command and gates on exit 0. The bad proofs came in through the other door — `--proof` prose, accepted on pattern-matching alone. A proof reading `node --test x.js passed` looks like evidence and proves nothing.

## What

When `--proof` names a runnable command and no `--verify` was given, print an advisory naming that command and suggesting `--verify`. Same voice as the existing landing advisory.

**What gets accepted does not change.** Tightening the gate to reject an unrunnable proof changes acceptance behaviour and is left as a human call.

## The suggestion has to be real

A bad suggestion is worse than silence. Replaying the matcher over the live ledger turned the prose `node --check plus focused task tests` into the suggestion `node --check plus`. So:

- a target must look like a path or package, never a bare English word
- a quoted command is taken whole (`npx vitest run app/api`) rather than truncated to its head (`npx vitest`)

Both are locked by tests using real ledger rows. Over a 280-row sample the matcher now advises on 96 and stays quiet on the rest.

## One existing test changed

`task ready and finish accept landing capability sentences` asserted `ready.stderr === ''`. Its own fixture passes `--proof 'node --test test/autoland.test.js passed'` with no `--verify` — exactly the anti-pattern, so the advisory is correct to fire. The assertion now checks that the *landing* advisory stays silent, which is what that case is about.

## Verify

- `node --test test/proof-names-command.test.js` — 2/2
- `node --test test/commands.test.js` — 426/428. The 2 failures (`member wake`, `member loop`) are present on clean master before this change; baseline confirmed by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)