### PR TITLE
Make a proof prove itself before it counts

### DIFF
--- a/commands/task.js
+++ b/commands/task.js
@@ -9296,6 +9296,20 @@ function cmdReady(args) {
       if (receipt.receiptPath) console.error(`receipt: ${receipt.receiptPath}`);
       process.exit(1);
     }
+    // Exit 0 says the check passed. It does not say the check could have
+    // failed. Run it again with none of the work present: a check anchored to
+    // this codebase fails there, and one that passes anywhere passes there too.
+    if (!hasFlag(args, '--no-falsify-check')) {
+      const { probeVerifierCanFail } = require('../lib/falsifier-probe');
+      const probe = probeVerifierCanFail({ command: verifyFlag });
+      if (probe.probed && probe.canFail === false) {
+        console.error(`atris task ready: this check cannot fail — ${probe.reason}`);
+        console.error(`  command: ${verifyFlag}`);
+        console.error('  give a check that fails when the work is missing, or pass --no-falsify-check to accept anyway.');
+        process.exit(1);
+      }
+      if (!probe.probed && !wantsJson(args)) console.log(`  ${probe.reason}`);
+    }
     const base = proof.trim();
     proof = `[verified] \`${verifyFlag}\` passed (exit 0)${base ? ` — ${base}` : ''}${receipt.output ? `\n${receipt.output}` : ''}\nReceipt: ${receipt.receiptPath}`;
     if (!wantsJson(args)) console.log(`✓ verified: \`${verifyFlag}\` exited 0 (receipt ${receipt.receiptPath})`);

--- a/lib/falsifier-probe.js
+++ b/lib/falsifier-probe.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// A check that cannot fail is not a check. `task ready --verify` runs a command
+// and accepts the work on exit 0, which catches a command that fails but never
+// catches one that could not have failed. The 2026-07-26 reward-ledger audit
+// found 131 of 802 accepted proofs carrying nothing falsifiable.
+//
+// The probe: run the same command again in an empty directory, with none of
+// the work present. A check anchored to this codebase fails there. One that
+// passes anywhere - `true`, `echo done`, a check of something outside the
+// repo - passes there too, and proves nothing about the work.
+//
+// Scope, stated plainly: this asks whether a check depends on the codebase at
+// all. It does not ask whether the check exercises the change. `git diff
+// --check` fails in an empty directory and still says nothing about whether
+// the code works, so it clears this probe. The probe raises the floor; it is
+// not a ceiling.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PROBE_TIMEOUT_MS = 60_000;
+
+// An absolute path reaches back into a real checkout no matter where the
+// command runs, so the empty directory proves nothing about it. Say so rather
+// than reporting a false verdict.
+function absolutePathIn(command) {
+  const match = String(command || '').match(/(?:^|[\s"'`=(])(\/[^\s"'`)]+)/);
+  return match ? match[1] : '';
+}
+
+function probeVerifierCanFail({ command, runner, tmpRoot } = {}) {
+  const cmd = String(command || '').trim();
+  if (!cmd) return { probed: false, canFail: null, reason: 'no command to probe' };
+
+  const absolute = absolutePathIn(cmd);
+  if (absolute) {
+    return {
+      probed: false,
+      canFail: null,
+      reason: `not probed: the command reaches an absolute path (${absolute}), so running it away from this checkout proves nothing`,
+    };
+  }
+
+  const dir = fs.mkdtempSync(path.join(tmpRoot || os.tmpdir(), 'atris-falsifier-probe-'));
+  try {
+    const run = runner || spawnSync;
+    const result = run('bash', ['-lc', cmd], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: PROBE_TIMEOUT_MS,
+    });
+    if (result.error) {
+      const timedOut = /ETIMEDOUT/i.test(String(result.error.code || result.error.message || ''));
+      return {
+        probed: false,
+        canFail: null,
+        reason: timedOut
+          ? `not probed: the command ran past ${PROBE_TIMEOUT_MS / 1000}s with none of the work present`
+          : `not probed: the command could not start away from this checkout (${result.error.message})`,
+      };
+    }
+    if (result.status === 0) {
+      return {
+        probed: true,
+        canFail: false,
+        exit: 0,
+        reason: 'this check passes in an empty directory, with none of the work present, so passing here says nothing about the work',
+      };
+    }
+    return {
+      probed: true,
+      canFail: true,
+      exit: result.status,
+      reason: 'this check fails when the work is absent, so passing it means something',
+    };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+module.exports = { probeVerifierCanFail, absolutePathIn, PROBE_TIMEOUT_MS };

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -11033,7 +11033,7 @@ test('task ready uses autoland-aware handoff copy when policy is on', () => {
     assert.equal(runCli(['task', 'claim', externalRef, '--as', 'codex'], { cwd: dir, env }).status, 0);
     const externalReady = runCli([
       'task', 'ready', externalRef,
-      '--verify', 'printf proof',
+      '--verify', 'ls atris',
       '--result', 'Teammates can trust the handoff faster because the finished proof is checked before review.',
       '--as', 'codex',
     ], { cwd: dir, env });
@@ -13730,7 +13730,7 @@ test('task reviews gives a compact certified accept queue', () => {
     assert.equal(runCli(['task', 'claim', unsafeTask.display_id, '--as', 'codex'], { cwd: dir, env }).status, 0);
     const unsafeReady = runCli([
       'task', 'ready', unsafeTask.display_id,
-      '--verify', 'printf proof',
+      '--verify', 'ls atris',
       '--result', 'Operators can now confirm finished work with a familiar file check, reducing the risk of approving missing proof.',
       '--as', 'codex',
     ], { cwd: dir, env });

--- a/test/falsifier-probe.test.js
+++ b/test/falsifier-probe.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { probeVerifierCanFail, absolutePathIn } = require('../lib/falsifier-probe');
+
+const cliPath = path.join(__dirname, '..', 'bin', 'atris.js');
+
+test('a check that passes with none of the work present is caught', () => {
+  for (const cmd of ['true', 'echo done', 'exit 0', 'test 1 -eq 1']) {
+    const probe = probeVerifierCanFail({ command: cmd });
+    assert.equal(probe.probed, true, cmd);
+    assert.equal(probe.canFail, false, cmd);
+    assert.match(probe.reason, /passes in an empty directory/);
+  }
+});
+
+test('a check anchored to the codebase fails without it, which is the point', () => {
+  for (const cmd of ['node --test test/falsifier-probe.test.js', 'npm run test:nothing', 'test -f package.json']) {
+    const probe = probeVerifierCanFail({ command: cmd });
+    assert.equal(probe.probed, true, cmd);
+    assert.equal(probe.canFail, true, cmd);
+    assert.notEqual(probe.exit, 0, cmd);
+  }
+});
+
+test('an absolute path is reported as unprobeable instead of getting a false verdict', () => {
+  const probe = probeVerifierCanFail({ command: 'cd /Users/someone/repo && npm test' });
+  assert.equal(probe.probed, false);
+  assert.equal(probe.canFail, null);
+  assert.match(probe.reason, /absolute path/);
+  assert.equal(absolutePathIn('cd /Users/someone/repo && npm test'), '/Users/someone/repo');
+  assert.equal(absolutePathIn('npm test'), '');
+});
+
+test('the probe leaves no directory behind, on either verdict', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'probe-parent-'));
+  try {
+    probeVerifierCanFail({ command: 'true', tmpRoot });
+    probeVerifierCanFail({ command: 'exit 3', tmpRoot });
+    assert.deepEqual(fs.readdirSync(tmpRoot), []);
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test('a command that cannot start is reported, not counted as a verdict', () => {
+  const probe = probeVerifierCanFail({
+    command: 'npm test',
+    runner: () => ({ error: new Error('spawn ENOENT') }),
+  });
+  assert.equal(probe.probed, false);
+  assert.equal(probe.canFail, null);
+  assert.match(probe.reason, /could not start/);
+});
+
+test('task ready refuses a verifier that cannot fail, and takes the same work with a real one', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-falsify-cli-'));
+  try {
+    const env = {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ATRIS_TASKS_DB: path.join(dir, 'tasks.db'),
+      ATRIS_AGENT_ID: 'tester',
+    };
+    const run = (args) => spawnSync(process.execPath, [cliPath, ...args], { cwd: dir, encoding: 'utf8', env });
+    spawnSync('git', ['init', '-q'], { cwd: dir });
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"probe-fixture","version":"1.0.0"}\n');
+
+    const added = run(['task', 'add', 'prove the checker refuses a check that cannot fail', '--json']);
+    assert.equal(added.status, 0, added.stderr || added.stdout);
+    const ref = JSON.parse(added.stdout).task.display_id;
+    assert.equal(run(['task', 'claim', ref, '--as', 'tester']).status, 0);
+
+    const landing = 'Someone can trust that a signed-off check would have caught a mistake.';
+    const result = 'Someone reviewing finished work can trust the check behind it would have failed if the work were wrong, so the record means something.';
+
+    const fake = run(['task', 'ready', ref, '--verify', 'true', '--landing', landing, '--result', result, '--as', 'tester']);
+    assert.equal(fake.status, 1, fake.stdout);
+    assert.match(fake.stderr, /this check cannot fail/);
+
+    const real = run(['task', 'ready', ref, '--verify', 'test -f package.json', '--landing', landing, '--result', result, '--as', 'tester']);
+    assert.equal(real.status, 0, real.stderr || real.stdout);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The gap

Exit 0 says a check passed. It never said the check *could have failed*.

The reward-ledger audit ([atrisos-backend#2405](https://github.com/atrislabs/atrisos-backend/pull/2405)) found 131 of 802 accepted proofs carrying nothing falsifiable. `atris task ready --verify true` would sail through every gate we have today.

## What this does

`task ready --verify` now runs the command a second time in an empty directory, with none of the work present.

- a check anchored to this codebase **fails** there — that is what makes passing it mean something
- a check that passes anywhere (`true`, `echo done`, `printf proof`) **passes** there too, and is refused with the command named and `--no-falsify-check` offered as the escape hatch

## Scope, stated rather than oversold

This asks whether a check depends on the codebase **at all**. It does not ask whether the check exercises the change. `git diff --check` fails in an empty directory and still says almost nothing about whether the code works — it clears the probe. This raises the floor; it is not a ceiling.

"I could not probe" is never reported as "this cannot fail":

- an **absolute path** in the command reaches a real checkout from anywhere, so it is reported unprobeable
- a command that **cannot start**, or outruns 60s, is reported the same way

## Two fixtures changed

`task ready uses autoland-aware handoff copy` and `task reviews gives a compact certified accept queue` both verified with `printf proof` — a command that passes anywhere, which is exactly what this refuses. Both now use `ls atris`: fails without the workspace, still outside the auto-certify allowlist, so what those cases assert is unchanged.

## Verify

- `node --test test/falsifier-probe.test.js` — 6/6, including end to end: `--verify true` is refused, the same task is accepted with a real check
- `node --test test/commands.test.js` — 426/428. The 2 failures (`member wake`, `member loop`) are on clean master before this change; baseline confirmed by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)