### PR TITLE
business simulate: keep prepositions out of derived business names

### DIFF
--- a/lib/business-simulate.js
+++ b/lib/business-simulate.js
@@ -7,8 +7,9 @@ const SIMULATE_USAGE = 'Usage: atris business simulate "<idea>" [--roles a,b,c,d
 const DEFAULT_ROLE_NAMES = Object.freeze(['maker', 'voice', 'builder', 'ops']);
 
 const NAME_STOP_WORDS = new Set([
-  'a', 'an', 'and', 'build', 'create', 'for', 'from', 'launch', 'make', 'my',
-  'of', 'our', 'sell', 'start', 'the', 'to', 'with',
+  'a', 'an', 'and', 'at', 'build', 'by', 'create', 'for', 'from', 'in',
+  'launch', 'make', 'my', 'of', 'on', 'our', 'sell', 'start', 'the', 'to',
+  'with',
 ]);
 
 const ROLE_TEMPLATES = Object.freeze([

--- a/test/business-simulate.test.js
+++ b/test/business-simulate.test.js
@@ -22,6 +22,7 @@ test('deriveBusinessName returns at most three meaningful title-case words with 
   assert.equal(deriveBusinessName(IDEA), 'T-Shirt Brand Sunset');
   assert.equal(deriveBusinessName('build a neighborhood coffee subscription service'), 'Neighborhood Coffee Subscription');
   assert.equal(deriveBusinessName('the and for'), 'Business Simulation');
+  assert.equal(deriveBusinessName('espresso cart at farmers markets'), 'Espresso Cart Farmers');
   assert.equal(deriveBusinessName('!!!'), 'Business Simulation');
 });
 


### PR DESCRIPTION
Dry-run smoke after landing #570 surfaced this: `atris business simulate "espresso cart at farmers markets" --dry-run` derived the business name **Espresso Cart At** — the three-word cap kept a dangling preposition.

Fix: add `at`, `by`, `in`, `on` to `NAME_STOP_WORDS`. Same idea now derives **Espresso Cart Farmers**. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)