### PR TITLE
Refresh stale tokens and retry when private pack downloads 404

### DIFF
--- a/commands/pack.js
+++ b/commands/pack.js
@@ -3,8 +3,8 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
-const { getAppBaseUrl, httpRequest } = require('../utils/api');
-const { loadCredentials } = require('../utils/auth');
+const { apiRequestJson, getAppBaseUrl, httpRequest } = require('../utils/api');
+const { loadCredentials, performTokenRefresh } = require('../utils/auth');
 const { createZipBuffer, readZipBuffer } = require('../lib/zip');
 const { craftPack } = require('./pack-craft');
 const { gatherAtrisContext } = require('./console');
@@ -509,6 +509,55 @@ function optionalAuthHeaders(deps = {}) {
   return credentials && credentials.token ? { Authorization: `Bearer ${credentials.token}` } : {};
 }
 
+function refreshApiWithoutProviderHint(deps = {}) {
+  const requestJson = deps.apiRequestJson || apiRequestJson;
+  return (pathname, options = {}) => {
+    if (pathname !== '/auth/refresh') return requestJson(pathname, options);
+    const body = options.body && typeof options.body === 'object' ? { ...options.body } : {};
+    delete body.provider;
+    return requestJson(pathname, { ...options, body });
+  };
+}
+
+async function refreshRegistryCredentials(credentials, deps = {}) {
+  const refresh = deps.performTokenRefresh || performTokenRefresh;
+  try {
+    const result = await refresh(credentials, refreshApiWithoutProviderHint(deps));
+    if (!result || !result.ok) return null;
+    return result.payload?.credentials || (deps.loadCredentials || loadCredentials)();
+  } catch {
+    return null;
+  }
+}
+
+async function requestRegistryZip(url, deps = {}, options = {}) {
+  const request = deps.httpRequest || httpRequest;
+  const readCredentials = deps.loadCredentials || loadCredentials;
+  const credentials = readCredentials();
+  const authenticated = Boolean(credentials && credentials.token);
+  const requestWithToken = (token) => request(url, {
+    ...options,
+    method: 'GET',
+    headers: token ? { ...(options.headers || {}), Authorization: `Bearer ${token}` } : { ...(options.headers || {}) },
+  });
+
+  let response = await requestWithToken(credentials?.token);
+  if (response.status === 404 && authenticated) {
+    const refreshedCredentials = await refreshRegistryCredentials(credentials, deps);
+    if (refreshedCredentials && refreshedCredentials.token) {
+      response = await requestWithToken(refreshedCredentials.token);
+    }
+  }
+  return { response, authenticated };
+}
+
+function registryNotFoundError(slug, authenticated) {
+  if (authenticated) {
+    return new Error('pack not found or you do not have access (your login may be stale; try atris login)');
+  }
+  return new Error(`pack not found: ${slug}`);
+}
+
 function requiredAuthHeaders(deps = {}) {
   const headers = optionalAuthHeaders(deps);
   if (!headers.Authorization) {
@@ -551,19 +600,18 @@ async function postPackToRegistry(manifest, zipBuffer, deps = {}) {
 }
 
 async function fetchRegistryZip(slug, deps = {}) {
-  const request = deps.httpRequest || httpRequest;
   const url = registryUrl(`/api/pack/registry/${encodeURIComponent(slug)}`, deps);
-  let response;
+  let result;
   try {
-    response = await request(url, {
-      method: 'GET',
+    result = await requestRegistryZip(url, deps, {
       timeoutMs: REGISTRY_TIMEOUT_MS,
-      headers: optionalAuthHeaders(deps),
     });
   } catch {
     throw new Error('could not reach pack registry. check your connection and try again.');
   }
+  const { response, authenticated } = result;
   if (response.status < 200 || response.status >= 300) {
+    if (response.status === 404) throw registryNotFoundError(slug, authenticated);
     throw new Error(responseErrorText(response, `registry lookup failed for ${slug} with status ${response.status}`));
   }
   if (!response.body || response.body.length === 0) {
@@ -887,16 +935,8 @@ async function loadZipPayload(source, cwd, deps = {}) {
   }
 
   const slug = slugify(source);
-  const readCredentials = deps.loadCredentials || loadCredentials;
-  const credentials = readCredentials();
-  const headers = credentials && credentials.token ? { Authorization: `Bearer ${credentials.token}` } : {};
-  const apiBaseUrl = deps.getAppBaseUrl || getAppBaseUrl;
-  const url = `${apiBaseUrl()}/api/pack/registry/${encodeURIComponent(slug)}`;
-  const response = await request(url, { method: 'GET', headers });
-  if (response.status < 200 || response.status >= 300) {
-    throw new Error(`registry lookup failed for ${slug} with status ${response.status}`);
-  }
-  return { buffer: response.body, fallbackSlug: slug, sourceType: 'registry', sourceSlug: slug };
+  const buffer = await fetchRegistryZip(slug, deps);
+  return { buffer, fallbackSlug: slug, sourceType: 'registry', sourceSlug: slug };
 }
 
 function parseManifest(entries, fallbackSlug) {
@@ -1509,11 +1549,22 @@ async function updatePack(rawArgs, cwd = process.cwd(), options = {}) {
   const url = origin.type === 'registry'
     ? `${(deps.getAppBaseUrl || getAppBaseUrl)()}/api/pack/registry/${encodeURIComponent(origin.slug)}`
     : origin.url;
-  const readCredentials = deps.loadCredentials || loadCredentials;
-  const credentials = readCredentials();
-  const headers = credentials && credentials.token ? { Authorization: `Bearer ${credentials.token}` } : {};
-  const response = await request(url, { method: 'GET', headers });
+  let response;
+  let authenticated = false;
+  if (origin.type === 'registry') {
+    const result = await requestRegistryZip(url, deps);
+    response = result.response;
+    authenticated = result.authenticated;
+  } else {
+    const readCredentials = deps.loadCredentials || loadCredentials;
+    const credentials = readCredentials();
+    const headers = credentials && credentials.token ? { Authorization: `Bearer ${credentials.token}` } : {};
+    response = await request(url, { method: 'GET', headers });
+  }
   if (response.status < 200 || response.status >= 300) {
+    if (origin.type === 'registry' && response.status === 404) {
+      throw registryNotFoundError(origin.slug, authenticated);
+    }
     throw new Error(`download failed with status ${response.status}`);
   }
 

--- a/test/pack.test.js
+++ b/test/pack.test.js
@@ -667,6 +667,122 @@ test('pack update upgrades registry packs and preserves user files', async () =>
   }
 });
 
+test('pack update refreshes stale credentials after a private registry 404', async () => {
+  const dir = makeTempDir();
+  try {
+    const target = path.join(dir, 'private-pack');
+    writePackDir(target, {
+      slug: 'private-pack',
+      version: '0.1.0',
+      origin: { type: 'registry', slug: 'private-pack' },
+    });
+    const zipBuffer = packZipBuffer(dir, sampleManifest({ slug: 'private-pack', version: '0.2.0' }));
+    let credentials = {
+      token: 'stale-token',
+      refresh_token: 'refresh-token',
+      provider: 'google',
+    };
+    const downloadCalls = [];
+    const refreshCalls = [];
+
+    const result = await updatePack([target], dir, {
+      deps: {
+        getAppBaseUrl: () => 'https://app.test',
+        loadCredentials: () => credentials,
+        httpRequest: async (url, options) => {
+          downloadCalls.push({ url, options });
+          if (downloadCalls.length === 1) return { status: 404, body: Buffer.alloc(0) };
+          return { status: 200, body: zipBuffer };
+        },
+        apiRequestJson: async (pathname, options) => {
+          refreshCalls.push({ pathname, options });
+          return { ok: true, status: 200, data: { access_token: 'fresh-token' } };
+        },
+        performTokenRefresh: async (loadedCredentials, requestJson) => {
+          const refreshed = await requestJson('/auth/refresh', {
+            method: 'POST',
+            body: {
+              refresh_token: loadedCredentials.refresh_token,
+              provider: loadedCredentials.provider,
+            },
+          });
+          credentials = { ...loadedCredentials, token: refreshed.data.access_token };
+          return { ok: true, payload: { credentials } };
+        },
+      },
+    });
+
+    assert.equal(result.upToDate, false);
+    assert.equal(downloadCalls.length, 2);
+    assert.equal(downloadCalls[0].options.headers.Authorization, 'Bearer stale-token');
+    assert.equal(downloadCalls[1].options.headers.Authorization, 'Bearer fresh-token');
+    assert.equal(refreshCalls.length, 1);
+    assert.equal(refreshCalls[0].pathname, '/auth/refresh');
+    assert.deepEqual(refreshCalls[0].options.body, { refresh_token: 'refresh-token' });
+    assert.equal(JSON.parse(fs.readFileSync(path.join(target, 'pack.json'), 'utf8')).version, '0.2.0');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('pack update reports stale access after one refreshed retry still returns 404', async () => {
+  const dir = makeTempDir();
+  try {
+    const target = path.join(dir, 'private-pack');
+    writePackDir(target, {
+      slug: 'private-pack',
+      origin: { type: 'registry', slug: 'private-pack' },
+    });
+    const calls = [];
+
+    await assert.rejects(
+      () => updatePack([target], dir, {
+        deps: {
+          getAppBaseUrl: () => 'https://app.test',
+          loadCredentials: () => ({ token: 'stale-token', refresh_token: 'refresh-token' }),
+          httpRequest: async (url, options) => {
+            calls.push({ url, options });
+            return { status: 404, body: Buffer.alloc(0) };
+          },
+          performTokenRefresh: async () => ({
+            ok: true,
+            payload: { credentials: { token: 'fresh-token', refresh_token: 'refresh-token' } },
+          }),
+        },
+      }),
+      /pack not found or you do not have access \(your login may be stale; try atris login\)/,
+    );
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].options.headers.Authorization, 'Bearer fresh-token');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('anonymous registry 404 stays a plain pack not found error', async () => {
+  const dir = makeTempDir();
+  try {
+    const calls = [];
+    await assert.rejects(
+      () => installPack(['missing-pack', '--dir', path.join(dir, 'target')], dir, {
+        deps: {
+          getAppBaseUrl: () => 'https://app.test',
+          loadCredentials: () => null,
+          httpRequest: async (url, options) => {
+            calls.push({ url, options });
+            return { status: 404, body: Buffer.alloc(0) };
+          },
+        },
+      }),
+      /pack not found: missing-pack/,
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].options.headers.Authorization, undefined);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('pack pull stages newer remote in upstream and preserves local edits', async () => {
   const dir = makeTempDir();
   let server = null;


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/codex-pack-auth-refresh-retry-20260802-043746
Target: master