### PR TITLE
Map coverage counts folders, so verify stops crying wolf on new files

### DIFF
--- a/commands/verify.js
+++ b/commands/verify.js
@@ -318,6 +318,61 @@ function runTests(cwd) {
   return result;
 }
 
+// Backtick-quoted spans, plus bare tokens that carry at least one slash.
+const MAP_PATH_PATTERN = /`([^`\n]+)`|((?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]*)/g;
+
+/**
+ * Normalize a path-looking token from MAP.md into a repo-relative path.
+ * Returns null for anything that is not usable as a path.
+ */
+function normalizeMapPath(raw) {
+  if (!raw) return null;
+  let value = String(raw).trim();
+  if (!value || /\s/.test(value) || value.includes('://')) return null;
+  value = value.replace(/^\.\//, '').replace(/^\/+/, '');
+  // Sentence punctuation trailing a path in prose, never a trailing slash.
+  value = value.replace(/[),.;:]+$/, '');
+  if (!value || value === '/' || value.split('/').includes('..')) return null;
+  return value;
+}
+
+/**
+ * Split MAP.md into the exact file paths it names and the directory prefixes it covers.
+ * A compact map documents areas, so `backend/routers/` stands in for every file beneath it.
+ */
+function mapCoverage(mapContent, isDirectory = () => false) {
+  const files = new Set();
+  const dirSet = new Set();
+  const seen = new Set();
+  const pattern = new RegExp(MAP_PATH_PATTERN.source, 'g');
+  let match;
+
+  while ((match = pattern.exec(mapContent)) !== null) {
+    const value = normalizeMapPath(match[1] || match[2]);
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+
+    if (value.endsWith('/')) {
+      dirSet.add(value);
+    } else {
+      files.add(value);
+      if (isDirectory(value)) dirSet.add(`${value}/`);
+    }
+  }
+
+  return { files, dirs: [...dirSet] };
+}
+
+/**
+ * A file is documented when the map names it outright or covers the area it lives in.
+ */
+function isPathCovered(file, coverage) {
+  const target = normalizeMapPath(file);
+  if (!target || !coverage) return false;
+  if (coverage.files.has(target)) return true;
+  return coverage.dirs.some((dir) => target.startsWith(dir) && target.length > dir.length);
+}
+
 /**
  * Check if recent git changes are documented in MAP.md
  */
@@ -354,12 +409,25 @@ function checkDocsVsChanges(cwd, atrisDir) {
     significantExtensions.some(ext => f.endsWith(ext))
   );
 
+  if (significantChanges.length === 0) {
+    return result;
+  }
+
+  const isDirectory = (candidate) => {
+    try {
+      return fs.statSync(path.join(cwd, candidate)).isDirectory();
+    } catch {
+      return false;
+    }
+  };
+  const coverage = mapCoverage(mapContent, isDirectory);
+
   for (const file of significantChanges) {
     const basename = path.basename(file);
-    if (!mapContent.includes(basename) && !mapContent.includes(file)) {
-      result.upToDate = false;
-      result.issues.push(`${file} changed but not in MAP.md`);
-    }
+    if (mapContent.includes(basename) || mapContent.includes(file)) continue;
+    if (isPathCovered(file, coverage)) continue;
+    result.upToDate = false;
+    result.issues.push(`${file} changed and its area is not in MAP.md`);
   }
 
   // Limit reported issues
@@ -653,5 +721,8 @@ module.exports = {
   verifyRubric,
   verifyArtifact,
   findTaskInContent,
-  escapeRegExp
+  escapeRegExp,
+  mapCoverage,
+  isPathCovered,
+  normalizeMapPath
 };

--- a/test/verify-map-prefix-coverage.test.js
+++ b/test/verify-map-prefix-coverage.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { mapCoverage, isPathCovered, normalizeMapPath } = require('../commands/verify');
+
+const COMPACT_MAP = `
+# MAP
+
+| Area | Where |
+|------|-------|
+| Routers | \`backend/routers/\` |
+| Services | \`backend/services\` |
+| Entry point | \`backend/main.py\` |
+
+Frontend work lives in web/src/components/.
+`;
+
+// The map names backend/services without a slash, so the repo decides it is a directory.
+const isDirectory = (p) => p === 'backend/services' || p === 'web/src/components';
+
+test('exact file paths in the map count as documented', () => {
+  const coverage = mapCoverage(COMPACT_MAP, isDirectory);
+  assert.equal(isPathCovered('backend/main.py', coverage), true);
+});
+
+test('a directory named in the map covers the files under it', () => {
+  const coverage = mapCoverage(COMPACT_MAP, isDirectory);
+  assert.equal(isPathCovered('backend/routers/event_tickets_router.py', coverage), true);
+});
+
+test('coverage reaches nested subdirectories too', () => {
+  const coverage = mapCoverage(COMPACT_MAP, isDirectory);
+  assert.equal(isPathCovered('backend/routers/admin/billing_router.py', coverage), true);
+});
+
+test('files in an unmapped area are still flagged', () => {
+  const coverage = mapCoverage(COMPACT_MAP, isDirectory);
+  assert.equal(isPathCovered('workers/queue_drain.py', coverage), false);
+  assert.equal(isPathCovered('backend_extras/thing.py', coverage), false);
+});
+
+test('directory entries work with or without a trailing slash', () => {
+  const coverage = mapCoverage(COMPACT_MAP, isDirectory);
+  // backend/routers/ carries the slash; backend/services relies on the repo check.
+  assert.equal(isPathCovered('backend/routers/tickets.py', coverage), true);
+  assert.equal(isPathCovered('backend/services/billing.py', coverage), true);
+  // Plain prose paths are picked up as well.
+  assert.equal(isPathCovered('web/src/components/Button.tsx', coverage), true);
+});
+
+test('a mapped file never acts as a directory prefix', () => {
+  const coverage = mapCoverage(COMPACT_MAP, isDirectory);
+  assert.equal(isPathCovered('backend/main_extra.py', coverage), false);
+  assert.equal(isPathCovered('backend/main.pyc', coverage), false);
+});
+
+test('a directory only covers what is beneath it, not itself as a file', () => {
+  const coverage = mapCoverage('`backend/routers/`', () => false);
+  assert.equal(isPathCovered('backend/routers/', coverage), false);
+  assert.equal(isPathCovered('backend/routers', coverage), false);
+});
+
+test('non-path noise in the map is ignored', () => {
+  const coverage = mapCoverage('run `atris task claim <id>` and see https://example.com/docs/x.py', () => false);
+  assert.equal(coverage.dirs.length, 0);
+  assert.equal(isPathCovered('docs/x.py', coverage), false);
+});
+
+test('leading ./ and trailing prose punctuation are trimmed', () => {
+  assert.equal(normalizeMapPath('./backend/routers/'), 'backend/routers/');
+  assert.equal(normalizeMapPath('atris/MAP.md.'), 'atris/MAP.md');
+  assert.equal(normalizeMapPath('  '), null);
+  assert.equal(normalizeMapPath('two words'), null);
+});


### PR DESCRIPTION
Automated Atris worktree ship.

Branch: codex/cursor-verify-map-coverage-by-prefix-20260809-220936
Target: master