### PR TITLE
Ready probe sends the login with the health check

### DIFF
--- a/commands/human-missions.js
+++ b/commands/human-missions.js
@@ -784,7 +784,7 @@ async function readyCommand(args, options = {}) {
     token
       ? safeProbe(request, '/ai-computer/user/status', { method: 'GET', token })
       : Promise.resolve(null),
-    safeProbe(request, '/atris2/health', { method: 'GET' }),
+    safeProbe(request, '/atris2/health', token ? { method: 'GET', token } : { method: 'GET' }),
     token
       ? safeProbe(request, '/atris2/missions/atris-ready-probe', { method: 'GET', token })
       : Promise.resolve(null),


### PR DESCRIPTION
atris ready always reported not-ready against production because the health endpoint requires a login there and the probe called it anonymously. One line: send the stored login when present. Found while running the live One-Shot demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)