### PR TITLE
Tell the truth about auth failures and fix profile refresh

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1168,12 +1168,13 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
   1. Browser OAuth: opens `{APP_BASE}/auth/cli`, user pastes code, CLI exchanges via `POST /auth/cli/exchange`
   2. Manual token: user pastes raw token, saved + validated
   3. Non-interactive: `--token <t>` flag for CI/scripts
-- **Token refresh:** `utils/auth.js:424-509` (`performTokenRefresh`) — saves new access token, optionally rotates refresh token, re-validates, updates user metadata
-- **Credential guard:** `utils/auth.js:511-564` (`ensureValidCredentials`) — proactive refresh if within 5-min buffer, validate, fallback refresh
+- **Token refresh:** `utils/auth.js:456-541` (`performTokenRefresh`) — saves new access token, optionally rotates refresh token, re-validates, updates user metadata. Profile-sourced creds write back to the profile file. `refreshAccessToken` (`:423`) sends `refresh_token` and omits `provider=google` unless the token is a Google OAuth refresh (`1//...`); that hint makes `/auth/refresh` skip app-JWT refresh and return `google_refresh_failed`.
+- **Credential guard:** `utils/auth.js:543-608` (`ensureValidCredentials`) — proactive refresh if within 5-min buffer, validate, fallback refresh
+- **Wake auth abort:** `utils/auth.js:438-454` (`isAuthFailure` / `abortOnAuthFailure`) — status/wake 401/403 stop polling and print login guidance instead of a computer timeout. Used by `commands/terminal.js:35`, `commands/computer.js:2259`, `commands/aeo.js:98`, `commands/pull.js:361`, `commands/push.js:530`, `commands/align.js:180`.
 - **Dependencies:** `utils/auth.js` for token management, `utils/api.js` for HTTP
 - **Consumers:**
   - `commands/auth.js` (login/logout/whoami) — uses modular `utils/auth.js`
-  - `commands/workflow.js` (plan/do/review --execute) — `ensureValidCredentials()` (full refresh flow, `:580/:950/:1338`)
+  - `commands/workflow.js` (plan/do/review --execute, plus `2 pro --business`) — `ensureValidCredentials()` (full refresh flow, `:311/:588/:963/:1351`)
   - `commands/brainstorm.js` (brainstorm/autopilot --execute) — `ensureValidCredentials()` (full refresh flow, `:70`)
   - `commands/log-sync.js` — `ensureValidCredentials()` (full refresh flow)
   - `commands/integrations.js` (gmail/calendar/twitter/slack) — `ensureValidCredentials()` (full refresh flow, `:28`)
@@ -1603,8 +1604,10 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - Lines 73-109: JWT decode + expiry check (`decodeJwtClaims`, `getTokenExpiryEpochSeconds`, `shouldRefreshToken`)
 - Lines 112-170: Credential CRUD (`getCredentialsPath`, `saveCredentials`, `loadCredentials`, `deleteCredentials`)
 - Lines 173-196: `validateAccessToken()` + `refreshAccessToken()` — API calls to `/auth/validate` and `/auth/refresh`
-- Lines 198-250: `performTokenRefresh()` — Full refresh: call API, save new token, re-validate, update user metadata
-- Lines 252-304: `ensureValidCredentials()` — Entry point for auth guard: proactive refresh (5-min buffer) -> validate -> fallback refresh
+- Lines 410-436: `refreshProviderHint()` + `refreshAccessToken()` — omit `provider=google` for app JWTs
+- Lines 438-454: `isAuthFailure()` / `abortOnAuthFailure()` — stop wake polls on 401/403
+- Lines 456-541: `performTokenRefresh()` — Full refresh: call API, save new token to profile or credentials.json, re-validate
+- Lines 543-608: `ensureValidCredentials()` — Entry point for auth guard: proactive refresh (5-min buffer) -> validate -> fallback refresh
 - Lines 306-324: `fetchMyAgents()` — GET `/agent/my-agents`
 - Lines 326-369: `displayAccountSummary()` — Print auth status + agent list
 
@@ -1826,9 +1829,9 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 **Key functions:**
 
-- `ensureValidCredentials()` (lines 125-256): Auto-refresh flow
-- `refreshAccessToken()` (lines 68-99): Token refresh logic
-- `validateAccessToken()` (lines 35-66): Token validation
+- `ensureValidCredentials()` (lines 543-608): Auto-refresh flow
+- `refreshAccessToken()` (lines 423-436): Token refresh logic; omits google provider hint for app JWTs
+- `abortOnAuthFailure()` (lines 448-454): Wake loops stop on 401/403
 
 **Impact:** Cloud features depend on this working correctly
 

--- a/commands/aeo.js
+++ b/commands/aeo.js
@@ -22,7 +22,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
-const { loadCredentials } = require('../utils/auth');
+const { loadCredentials, abortOnAuthFailure } = require('../utils/auth');
 const { apiRequestJson } = require('../utils/api');
 const { loadBusinesses, saveBusinesses } = require('./business');
 
@@ -97,13 +97,16 @@ function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
 
 async function ensureAwake(token, businessId, maxWaitSec = 90) {
   const status = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token });
+  abortOnAuthFailure(status);
   if (status.ok && status.data && status.data.status === 'running' && status.data.endpoint) return true;
   process.stdout.write('  Waking EC2 computer... ');
-  await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token });
+  const wake = await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token });
+  abortOnAuthFailure(wake, true);
   const start = Date.now();
   while (Date.now() - start < maxWaitSec * 1000) {
     await sleep(3000);
     const s = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token });
+    abortOnAuthFailure(s, true);
     if (s.ok && s.data && s.data.status === 'running' && s.data.endpoint) {
       console.log(`awake (${Math.floor((Date.now() - start) / 1000)}s)`);
       return true;

--- a/commands/align.js
+++ b/commands/align.js
@@ -21,7 +21,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const { loadCredentials } = require('../utils/auth');
+const { loadCredentials, abortOnAuthFailure } = require('../utils/auth');
 const { apiRequestJson } = require('../utils/api');
 const { loadBusinesses, saveBusinesses } = require('./business');
 
@@ -179,17 +179,20 @@ async function walkCloud(token, businessId, workspaceId) {
  */
 async function ensureAwake(token, businessId, maxWaitSec = 90) {
   const status = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token });
+  abortOnAuthFailure(status);
   if (status.ok && status.data && status.data.status === 'running' && status.data.endpoint) {
     return status.data.endpoint;
   }
 
   process.stdout.write('  Waking EC2 computer... ');
-  await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token });
+  const wake = await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token });
+  abortOnAuthFailure(wake, true);
 
   const start = Date.now();
   while (Date.now() - start < maxWaitSec * 1000) {
     await sleep(3000);
     const s = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token });
+    abortOnAuthFailure(s, true);
     if (s.ok && s.data && s.data.status === 'running' && s.data.endpoint) {
       const elapsed = Math.floor((Date.now() - start) / 1000);
       console.log(`awake (${elapsed}s)`);

--- a/commands/computer.js
+++ b/commands/computer.js
@@ -22,7 +22,7 @@ const os = require('os');
 const path = require('path');
 const readline = require('readline');
 const { spawnSync } = require('child_process');
-const { loadCredentials, decodeJwtClaims, promptUser } = require('../utils/auth');
+const { loadCredentials, decodeJwtClaims, promptUser, abortOnAuthFailure } = require('../utils/auth');
 const { apiRequestJson, getApiBaseUrl, getAppBaseUrl } = require('../utils/api');
 const { loadBusinesses, saveBusinesses } = require('./business');
 const {
@@ -2258,15 +2258,18 @@ async function runBusinessPromptViaRunnerProxy(token, ctx, prompt, options = {})
 
 async function ensureBusinessAwake(token, ctx, maxWaitSec = 90, options = {}) {
   const status = await apiRequestJson(`/business/${ctx.businessId}/ai-computer/status`, { method: 'GET', token });
+  abortOnAuthFailure(status);
   if (status.ok && status.data && status.data.status === 'running' && status.data.endpoint) {
     return true;
   }
   if (!options.quiet) process.stdout.write('  Waking business computer... ');
-  await apiRequestJson(`/business/${ctx.businessId}/ai-computer/wake`, { method: 'POST', token, body: {} });
+  const wake = await apiRequestJson(`/business/${ctx.businessId}/ai-computer/wake`, { method: 'POST', token, body: {} });
+  abortOnAuthFailure(wake, !options.quiet);
   const start = Date.now();
   while (Date.now() - start < maxWaitSec * 1000) {
     await sleep(3000);
     const next = await apiRequestJson(`/business/${ctx.businessId}/ai-computer/status`, { method: 'GET', token });
+    abortOnAuthFailure(next, !options.quiet);
     if (next.ok && next.data && next.data.status === 'running' && next.data.endpoint) {
       const elapsed = Math.floor((Date.now() - start) / 1000);
       if (!options.quiet) console.log(`awake (${elapsed}s)`);

--- a/commands/pull.js
+++ b/commands/pull.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { loadCredentials } = require('../utils/auth');
+const { loadCredentials, abortOnAuthFailure } = require('../utils/auth');
 const { apiRequestJson } = require('../utils/api');
 const { findAllMembers } = require('./member');
 const { loadConfig } = require('../utils/config');
@@ -358,15 +358,18 @@ async function pullBusiness(slug) {
   const autoWake = process.argv.includes('--auto-wake');
   if (autoWake) {
     const statusResult = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token: creds.token });
+    abortOnAuthFailure(statusResult);
     const computerStatus = statusResult.ok && statusResult.data ? statusResult.data.status : 'unknown';
     if (computerStatus !== 'running' || !(statusResult.data && statusResult.data.endpoint)) {
       process.stdout.write('  Waking EC2 computer... ');
       _coldWake = true;
-      await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token: creds.token });
+      const wake = await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token: creds.token });
+      abortOnAuthFailure(wake, true);
       const wakeStart = Date.now();
       while (Date.now() - wakeStart < 90000) {
         await new Promise((r) => setTimeout(r, 3000));
         const s = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token: creds.token });
+        abortOnAuthFailure(s, true);
         if (s.ok && s.data && s.data.status === 'running' && s.data.endpoint) {
           const elapsed = Math.floor((Date.now() - wakeStart) / 1000);
           console.log(`awake (${elapsed}s)`);

--- a/commands/push.js
+++ b/commands/push.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const readline = require('readline');
-const { loadCredentials } = require('../utils/auth');
+const { loadCredentials, abortOnAuthFailure } = require('../utils/auth');
 const { apiRequestJson } = require('../utils/api');
 const { loadBusinesses, saveBusinesses, businessMatchesSlug } = require('./business');
 const { loadManifest, saveManifest, buildManifest, computeLocalHashes, isIgnoredSyncPath, filterSyncFiles } = require('../lib/manifest');
@@ -527,15 +527,18 @@ async function pushAtris() {
   const autoWake = process.argv.includes('--auto-wake');
   if (autoWake) {
     const statusResult = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token: creds.token });
+    abortOnAuthFailure(statusResult);
     const computerStatus = statusResult.ok && statusResult.data ? statusResult.data.status : 'unknown';
     if (computerStatus !== 'running' || !(statusResult.data && statusResult.data.endpoint)) {
       process.stdout.write('  Waking EC2 computer... ');
       _coldWake = true;
-      await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token: creds.token });
+      const wake = await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token: creds.token });
+      abortOnAuthFailure(wake, true);
       const wakeStart = Date.now();
       while (Date.now() - wakeStart < 90000) {
         await new Promise((r) => setTimeout(r, 3000));
         const s = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token: creds.token });
+        abortOnAuthFailure(s, true);
         if (s.ok && s.data && s.data.status === 'running' && s.data.endpoint) {
           const elapsed = Math.floor((Date.now() - wakeStart) / 1000);
           console.log(`awake (${elapsed}s)`);

--- a/commands/terminal.js
+++ b/commands/terminal.js
@@ -24,7 +24,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { loadCredentials } = require('../utils/auth');
+const { loadCredentials, abortOnAuthFailure } = require('../utils/auth');
 const { apiRequestJson } = require('../utils/api');
 const { loadBusinesses, saveBusinesses } = require('./business');
 
@@ -34,15 +34,18 @@ function sleep(ms) {
 
 async function ensureAwake(token, businessId, maxWaitSec = 90) {
   const status = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token });
+  abortOnAuthFailure(status);
   if (status.ok && status.data && status.data.status === 'running' && status.data.endpoint) {
     return true;
   }
   process.stdout.write('  Waking EC2 computer... ');
-  await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token });
+  const wake = await apiRequestJson(`/business/${businessId}/ai-computer/wake`, { method: 'POST', token });
+  abortOnAuthFailure(wake, true);
   const start = Date.now();
   while (Date.now() - start < maxWaitSec * 1000) {
     await sleep(3000);
     const s = await apiRequestJson(`/business/${businessId}/ai-computer/status`, { method: 'GET', token });
+    abortOnAuthFailure(s, true);
     if (s.ok && s.data && s.data.status === 'running' && s.data.endpoint) {
       const elapsed = Math.floor((Date.now() - start) / 1000);
       console.log(`awake (${elapsed}s)`);

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -305,13 +305,20 @@ async function runAtris2Local(userInput, atris2Mode) {
   };
 
   if (businessSlug) {
-    const { loadCredentials } = require('../utils/auth');
+    const { ensureValidCredentials } = require('../utils/auth');
+    const { apiRequestJson } = require('../utils/api');
     const { resolveBusiness, ensureAwake } = require('./terminal');
-    const creds = loadCredentials();
-    if (!creds || !creds.token) {
+    const ensured = await ensureValidCredentials(apiRequestJson);
+    if (ensured.error === 'not_logged_in' || !ensured.credentials?.token) {
       console.error('Not logged in. Run: atris login');
       process.exit(1);
     }
+    if (ensured.error) {
+      console.error(`Authentication failed: ${ensured.detail || ensured.error}. Run: atris login`);
+      console.error('Check with: atris whoami');
+      process.exit(1);
+    }
+    const creds = ensured.credentials;
     const biz = await resolveBusiness(creds.token, businessSlug);
     if (!biz || !biz.workspaceId) {
       console.error(`Business "${businessSlug}" not found or has no workspace.`);

--- a/test/auth-profile-refresh.test.js
+++ b/test/auth-profile-refresh.test.js
@@ -87,3 +87,100 @@ test('performTokenRefresh without a profile still writes credentials.json', asyn
   assert.equal(result.ok, true);
   assert.equal(readJson(globalPath).token, 'new-token');
 });
+
+test('refreshAccessToken sends refresh_token and omits the google provider hint for app JWTs', async () => {
+  let captured;
+  const api = async (pathname, options) => {
+    captured = { pathname, options };
+    return { ok: true, data: { access_token: 'new-token' } };
+  };
+  const jwtRefresh = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.sig';
+  await auth.refreshAccessToken(jwtRefresh, 'google', api);
+  assert.equal(captured.pathname, '/auth/refresh');
+  assert.deepEqual(captured.options.body, { refresh_token: jwtRefresh });
+});
+
+test('refreshAccessToken still forwards a non-google provider hint', async () => {
+  let captured;
+  const api = async (_pathname, options) => {
+    captured = options.body;
+    return { ok: true, data: { access_token: 'x' } };
+  };
+  await auth.refreshAccessToken('rt', 'email', api);
+  assert.deepEqual(captured, { refresh_token: 'rt', provider: 'email' });
+});
+
+test('refreshAccessToken keeps provider=google only for Google OAuth refresh tokens', async () => {
+  let captured;
+  const api = async (_pathname, options) => {
+    captured = options.body;
+    return { ok: true, data: { access_token: 'x' } };
+  };
+  await auth.refreshAccessToken('1//google-oauth-refresh', 'google', api);
+  assert.deepEqual(captured, { refresh_token: '1//google-oauth-refresh', provider: 'google' });
+});
+
+test('performTokenRefresh for a google profile omits the google hint and writes the profile file', async () => {
+  writeProfile('keshav', PROFILE_CREDS);
+  process.env.ATRIS_PROFILE = 'keshav';
+  try {
+    const creds = auth.loadCredentials();
+    let refreshBody;
+    const api = async (pathname, options) => {
+      if (pathname === '/auth/refresh') {
+        refreshBody = options.body;
+        return { ok: true, data: { access_token: 'new-token', refresh_token: 'new-refresh' } };
+      }
+      if (pathname === '/auth/validate') {
+        return { ok: true, data: { valid: true, user: { email: 'keshav@atrislabs.com', id: 'user-1', provider: 'google' } } };
+      }
+      return { ok: false, status: 404, error: 'unexpected call: ' + pathname };
+    };
+    const result = await auth.performTokenRefresh(creds, api);
+    assert.equal(result.ok, true);
+    assert.deepEqual(refreshBody, { refresh_token: 'old-refresh' });
+    const profile = readJson(path.join(scratchHome, '.atris', 'profiles', 'keshav.json'));
+    assert.equal(profile.token, 'new-token');
+    assert.equal(profile.refresh_token, 'new-refresh');
+  } finally {
+    delete process.env.ATRIS_PROFILE;
+  }
+});
+
+test('ensureValidCredentials writes profile metadata back to the profile file, not credentials.json', async () => {
+  const globalPath = path.join(scratchHome, '.atris', 'credentials.json');
+  if (fs.existsSync(globalPath)) fs.unlinkSync(globalPath);
+  writeProfile('keshav', { ...PROFILE_CREDS, email: 'old@example.com' });
+  process.env.ATRIS_PROFILE = 'keshav';
+  try {
+    const api = async (pathname) => {
+      if (pathname === '/auth/validate') {
+        return {
+          ok: true,
+          data: { valid: true, user: { email: 'keshav@atrislabs.com', id: 'user-1', provider: 'google' } },
+        };
+      }
+      return { ok: false, status: 404, error: 'unexpected call: ' + pathname };
+    };
+    const result = await auth.ensureValidCredentials(api);
+    assert.equal(result.error, undefined);
+    assert.equal(fs.existsSync(globalPath), false);
+    const profile = readJson(path.join(scratchHome, '.atris', 'profiles', 'keshav.json'));
+    assert.equal(profile.email, 'keshav@atrislabs.com');
+    assert.equal('source_profile' in profile, false);
+  } finally {
+    delete process.env.ATRIS_PROFILE;
+  }
+});
+
+test('abortOnAuthFailure stops on 401/403 and ignores other statuses', () => {
+  let exited = null;
+  const exitFn = (code) => { exited = code; };
+  assert.equal(auth.isAuthFailure({ status: 401 }), true);
+  assert.equal(auth.isAuthFailure({ status: 403 }), true);
+  assert.equal(auth.isAuthFailure({ status: 500 }), false);
+  assert.equal(auth.abortOnAuthFailure({ status: 200 }, false, exitFn), false);
+  assert.equal(exited, null);
+  assert.equal(auth.abortOnAuthFailure({ status: 401 }, false, exitFn), true);
+  assert.equal(exited, 1);
+});

--- a/test/fast-tests.txt
+++ b/test/fast-tests.txt
@@ -3,6 +3,7 @@ test/agent-spawn.test.js
 test/analytics-productivity.test.js
 test/api-stream.test.js
 test/apps.test.js
+test/auth-profile-refresh.test.js
 test/attempted-ledger.test.js
 test/auto-accept-certified.test.js
 test/autopilot-glass-logging.test.js

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -407,18 +407,50 @@ async function validateAccessToken(token, apiRequestJson) {
   });
 }
 
+function refreshProviderHint(provider, refreshToken) {
+  const hint = typeof provider === 'string' ? provider.trim().toLowerCase() : '';
+  if (!hint) return null;
+  // provider=google makes /auth/refresh skip app-JWT refresh and POST the
+  // minted refresh JWT to Google OAuth, which returns google_refresh_failed.
+  // Only send that hint when the stored token is actually a Google OAuth
+  // refresh token (they start with 1//). Pack refresh already strips this.
+  if (hint === 'google' && !String(refreshToken || '').startsWith('1//')) {
+    return null;
+  }
+  return hint;
+}
+
 async function refreshAccessToken(refreshToken, provider, apiRequestJson) {
   if (!refreshToken) {
     return { ok: false, status: 0, error: 'Missing refresh token' };
   }
   const body = { refresh_token: refreshToken };
-  if (provider) {
-    body.provider = provider;
+  const hint = refreshProviderHint(provider, refreshToken);
+  if (hint) {
+    body.provider = hint;
   }
   return apiRequestJson('/auth/refresh', {
     method: 'POST',
     body,
   });
+}
+
+function isAuthFailure(result) {
+  const status = result && result.status;
+  return status === 401 || status === 403;
+}
+
+function printAuthRequired() {
+  console.error('Auth problem. Run: atris login');
+  console.error('Check with: atris whoami');
+}
+
+function abortOnAuthFailure(result, printedWake = false, exitFn = (code) => process.exit(code)) {
+  if (!isAuthFailure(result)) return false;
+  if (printedWake) console.log('auth failed');
+  printAuthRequired();
+  exitFn(1);
+  return true;
 }
 
 async function performTokenRefresh(credentials, apiRequestJson) {
@@ -535,13 +567,24 @@ async function ensureValidCredentials(apiRequestJson, options = {}) {
         updatedProvider !== credentials.provider ||
         updatedUserId !== credentials.user_id)
     ) {
-      saveCredentials(
-        credentials.token,
-        credentials.refresh_token,
-        updatedEmail,
-        updatedUserId,
-        updatedProvider
-      );
+      if (credentials.source_profile) {
+        const { source_profile, source, ...rest } = { ...credentials };
+        saveProfile(credentials.source_profile, {
+          ...rest,
+          email: updatedEmail,
+          user_id: updatedUserId,
+          provider: updatedProvider,
+          saved_at: new Date().toISOString(),
+        });
+      } else {
+        saveCredentials(
+          credentials.token,
+          credentials.refresh_token,
+          updatedEmail,
+          updatedUserId,
+          updatedProvider
+        );
+      }
     }
 
     return {
@@ -639,8 +682,12 @@ module.exports = {
   promptUser,
   validateAccessToken,
   refreshAccessToken,
+  refreshProviderHint,
   performTokenRefresh,
   ensureValidCredentials,
+  isAuthFailure,
+  printAuthRequired,
+  abortOnAuthFailure,
   fetchMyAgents,
   displayAccountSummary,
   // Profile switching


### PR DESCRIPTION
Two bugs found live tonight while proving the business CLI path:

1. Auth failures masqueraded as computer failures. Expired tokens made every wake loop print 'Waking EC2 computer... timeout' while the polls 401'd. Now any 401/403 aborts immediately with 'Auth problem. Run: atris login'. The business path also refreshes credentials before waking instead of using the raw stored token.

2. google_refresh_failed root-caused: the refresh call sent provider=google for app-JWT refresh tokens, routing them to Google OAuth where they can never succeed. The provider hint is now only sent for real Google OAuth refresh tokens (1// prefix). Verified live: a stale profile that failed for a month now refreshes and reports logged in.

Tests: new test/auth-profile-refresh.test.js green; node --check on all changed files; live whoami verification under the previously-broken profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)