### PR TITLE
Release 3.45.1 with version and lockfile aligned

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.44.0",
+  "version": "3.45.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.44.0",
+      "version": "3.45.1",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.45.0",
+  "version": "3.45.1",
   "description": "you say what you want in plain words. atris builds it, checks it, and shows you proof.",
   "main": "bin/atris.js",
   "bin": {


### PR DESCRIPTION
The 3.45.0 publish failed its release gate: package.json was bumped but package-lock.json still said 3.44.0. This bumps both to 3.45.1 together. Gate test passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)