### PR TITLE
design: prefer icon-led compact selectors (D14)

### DIFF
--- a/atris/skills/design/SKILL.md
+++ b/atris/skills/design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design
 description: Frontend aesthetics policy. Use when building UI, components, landing pages, dashboards, or any frontend work. Prevents generic ai-generated look.
-version: 3.1.0
+version: 3.1.1
 allowed-tools: Read, Write, Edit, Bash, Glob
 tags:
   - design
@@ -112,6 +112,7 @@ Every entry: id, rule, detector, status. A detector is a regex/command a gate ca
 | D11 | layout contracts, not dioramas: min-height over fixed height, fluid max-width over fixed px, every overflow reachable (scroll or +N more), stress-test with hostile content before shipping | judgment | active |
 | D12 | one accent moment per card: brand accent for the primary action only, gold for confidence/progress fills, green only for completed; everything else tonal | judgment | active |
 | D13 | motion is calm and eased: 120-300ms ease-out on opacity/transform only, loops match a measured source cadence, prefers-reduced-motion always freezes them | judgment | active |
+| D14 | compact selectors lead with the chosen name and a discriminating icon; remove redundant field labels and visible type explanations when icon, title, and accessible label carry them | judgment | active |
 
 Measured recipes live in the mimic studies: `~/arena/mimic-beautiful-ui/LESSONS.md` (18 AI-interface components with exact tokens) and its `remix.css` :root block (the portable Atris token sheet, coffee + paper themes). Start there before designing an agent surface.
 


### PR DESCRIPTION
Rescues a taste lesson that was stranded as a local-only commit on a shared checkout: compact selectors lead with the chosen name and a discriminating icon; redundant field labels and visible type explanations go away when icon, title, and accessible label already carry them. Doc-only, bumps the design skill to 3.1.1.

Co-authored-by: Atris <299057014+atris-builder[bot]@users.noreply.github.com>