### PR TITLE
youtube: route any link through the rail before the model speaks (3.48.1)

### DIFF
--- a/.claude/hooks/youtube-route.js
+++ b/.claude/hooks/youtube-route.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// UserPromptSubmit hook: any youtube link in the prompt forces the graded notes rail.
+// Silent (no output) when the prompt has no youtube link.
+let raw = '';
+process.stdin.on('data', (d) => { raw += d; });
+process.stdin.on('end', () => {
+  let prompt = '';
+  try { prompt = String(JSON.parse(raw).prompt || ''); } catch { process.exit(0); }
+  const links = [...prompt.matchAll(/https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?[^\s)>\]]*v=[\w-]{6,}[^\s)>\]]*|youtu\.be\/[\w-]{6,}[^\s)>\]]*)/g)]
+    .map((m) => m[0]);
+  if (!links.length) process.exit(0);
+  const cmds = links.map((u) => `atris youtube notes "${u}"`).join(' ; ');
+  console.log(
+    `youtube gate: this message contains a youtube link. Before saying anything about the video, run exactly: ${cmds} ` +
+    `and base every claim on its output (notes land in $TMPDIR/ytnotes/). ` +
+    `Summarizing a video from model memory or cached notes without running the command is fabrication and forbidden. ` +
+    `If the command fails, report the failure honestly instead of improvising.`
+  );
+  process.exit(0);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/youtube-route.js\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/atris/CLAUDE.md
+++ b/atris/CLAUDE.md
@@ -100,6 +100,8 @@ The human approves work by reading, so how you report IS the product.
 
 ## Rules (Non‑Negotiable)
 
+- YouTube link in a message: run `atris youtube notes <url>` before saying anything about the video. The transcript is the source; notes from model memory are fabrication.
+
 - Plan = ASCII visualization + approval gate. Do not execute during planning.
 - Execute step-by-step, verify as you go, update artifacts (`TODO.md`, `MAP.md`) when reality changes.
 - Delete completed tasks (validator cleans to target state = 0).

--- a/atris/skills/youtube/SKILL.md
+++ b/atris/skills/youtube/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: youtube
-description: "Process YouTube videos: extract insights, answer questions, store as knowledge. 5 credits per video. Triggers on: youtube, video, process video, watch this, learn from video."
-version: 2.3.0
+description: "A YouTube link in any message routes here. Run atris youtube notes <url> FIRST: free, about 30 seconds, quotes verified against the transcript. Never summarize a video from model memory, that is fabrication. Use atris youtube process only to store it as queryable knowledge (5 credits). Triggers on: any youtube.com or youtu.be link, youtube, video, watch this, notes on this."
+version: 2.4.0
 tags:
   - youtube
   - research

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.48.0",
+  "version": "3.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.48.0",
+      "version": "3.48.1",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.48.0",
+  "version": "3.48.1",
   "description": "you say what you want in plain words. atris builds it, checks it, and shows you proof.",
   "main": "bin/atris.js",
   "bin": {


### PR DESCRIPTION
Clean-chat testing with a cheap model exposed a routing gap: given a bare youtube link, one of three fresh sessions ran the rail; the other two summarized from model memory without disclosure, one of them a pure fabrication presented as notes.

Fix: the skill description and the shipped project adapter now state the rule imperatively. Retest after the fix (plus upgrading this machine's stale global binary, which was the second cause): direct notes requests route correctly 2/2 with quotes verified 6/6; the vaguest phrasing ('watch this and tell me what matters') still reads the transcript but bypasses the graded command. Next step for that tail is a deterministic link-detecting hook, queued to the youtube member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)