### PR TITLE
Add atris release preflight before tag-driven publishes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Guidance for working on the **Atris CLI itself** (this repo builds the `atris` p
 
 **Verify unpiped.** `npm test | tail` masks exit codes. Run gates bare and read the real exit status.
 
-**Publishing** is tag-driven: push a `v*` tag from master and CI (`publish.yml`) runs the strict test gate and publishes. Never publish from a feature branch. The post-publish read-back in CI can race npm propagation; confirm with `npm view atris version` before calling a release failed.
+**Publishing** is tag-driven: run `atris release preflight`, then push a `v*` tag from master and CI (`publish.yml`) runs the strict test gate and publishes. Never publish from a feature branch. The post-publish read-back in CI can race npm propagation; confirm with `npm view atris version` before calling a release failed.
 
 **Commits** credit Atris, not Claude: end with `Co-authored-by: Atris <299057014+atris-builder[bot]@users.noreply.github.com>`. No `--no-verify`; a blocked commit means stop and report.
 

--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -83,7 +83,7 @@ rg "renderCard|renderPageSection|renderEmailLine|renderMorningCardRow|directProo
 rg "radarCommand|collectRadar|Operator radar|Agent process top|findTaskWorkspaceRoot|task_reason|task_action|task_load|whats going on|loadBusinessCollaboration|ctop" commands/radar.js bin/atris.js test/radar.test.js test/commands.test.js  # Live Atris OS radar: agent processes joined with nearest workspace task projection, ctop unmapped-session reasons/actions and task-load pileups, mission/loop, worktree, AgentXP, team/member, business collaboration readiness, brain scorecard, Swarlo/delegation, and Codex goal state
 rg "launchpadCommand|collectLaunchpad|chooseNextAction|renderLaunchpad|suggestedNextMoves|taskNeedsAgentReview|taskIsHumanGatedClaimed|atris.launchpad.v1" commands/launchpad.js bin/atris.js test/commands.test.js  # Launchpad command-center card: single next action + 3 suggested moves from local task projection, missions, brain STATUS, and TODO endgame; ranks own-claimed > mission tick > proof review > human-accept queue > open claim > endgame seed > brain move; skips human-gated claimed work; --json (atris.launchpad.v1) and plain card
 rg "unknownsCommand|gatherTerritoryContext|buildUnknownsPrompt|renderUnknownsMarkdown|unknowns --help" commands/unknowns.js bin/atris.js test/unknowns.test.js  # Unknowns command: blindspot pass from MAP/lessons/logs/git/task_events through shared runner into SQLite unknowns ledger plus .atris/state/unknowns.md projection
-rg "releaseAtris" commands/release.js      # Release command
+rg "releaseAtris|releasePreflight|release preflight" commands/release.js bin/atris.js test/release-preflight.test.js  # Release command plus pre-tag preflight
 rg "showSearchHelp|searchJournal|search help flags" bin/atris.js test/commands.test.js # Search command + workspace-free help flags
 rg "showLearnHelp|learnAtris|learn help" commands/learn.js test/commands.test.js # Project learnings command + workspace-free help
 rg "showSoulHelp|async function soul|soul help" commands/soul.js test/commands.test.js # Soul/persona command + workspace-free help
@@ -918,17 +918,19 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 **Purpose:** Tag a release, bump version, create GitHub release, draft /launch post
 
-- **Entry point:** `commands/release.js:15` (releaseAtris function)
-- **Dispatch/help:** `bin/atris.js:1275-1284` handles `release --help` before git/package mutation paths
-- **Flags:** `--dry-run` — print draft without mutating
+- **Entry point:** `commands/release.js:16` (releaseAtris function)
+- **Preflight:** `commands/release.js:213` (`releasePreflight`) checks master, a clean tree, local master vs origin/master, no existing `v<version>` tag, then `npm test` with `CI=true`; git failures skip the suite
+- **Dispatch/help:** `bin/atris.js:2596` routes `release`, `bin/atris.js:2602` routes `release preflight`, `bin/atris.js:853` (`showReleaseHelp`) and `bin/atris.js:546` list the preflight command
+- **Flags:** `--dry-run` prints the draft without mutating
 - **Steps:** git log since last tag → determine bump (minor if scorecard reward≥5, else patch) → run `npm version --no-git-tag-version` so package.json and package-lock.json move together → commit both files → tag → push → `gh release create` → print launch post
 - **Helpers:**
-  - `determineBumpType()` → `commands/release.js:127`
-  - `bumpVersion()` → `commands/release.js:149`
-  - `printLaunchPost()` → `commands/release.js:163`
-- **Regression:** `test/commands.test.js:4249-4264` covers `release --help` without package version changes
+  - `determineBumpType()` → `commands/release.js:129`
+  - `bumpVersion()` → `commands/release.js:151`
+  - `printLaunchPost()` → `commands/release.js:165`
+  - `runFullTestSuite()` → `commands/release.js:194`
+- **Regression:** `test/commands.test.js:18159` covers `release --help` without package version changes; `test/release-preflight.test.js:1` covers help wiring, off-master refusal, dirty/tag/origin failures, CI=true suite pass, and the real suite exit code
 
-**Search:** `rg "showReleaseHelp|releaseAtris|release --help|bumpVersion" bin/atris.js commands/release.js test/commands.test.js`
+**Search:** `rg "showReleaseHelp|releaseAtris|releasePreflight|release --help|bumpVersion" bin/atris.js commands/release.js test/commands.test.js test/release-preflight.test.js`
 
 ### Feature: Analytics (`atris analytics`)
 
@@ -1779,7 +1781,8 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `activateAtris()` → `commands/activate.js:158-306`
 - `cleanAtris()` → `commands/clean.js:15-186`
 - `verifyAtris()` → `commands/verify.js:13-35`
-- `releaseAtris()` → `commands/release.js:15-122`
+- `releaseAtris()` → `commands/release.js:16-123`
+- `releasePreflight()` → `commands/release.js:213-282`
 - `gmailCommand()` etc. → `commands/integrations.js`
 
 **Risk:** Breaking changes affect all users

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -543,7 +543,7 @@ function showHelp() {
   console.log('    atris autoland tick   # second check runs, task lands');
   console.log('  mission    - Goal + loop + member owner + verifier + receipt; --budget quick|long|deep sets bounded tiers');
   console.log('  decide     - Answer open mission asks and send the decision to the next tick');
-  console.log('  release    - Tag release, bump version, create GitHub release, draft /launch');
+  console.log('  release    - Tag release, bump version, create GitHub release, draft /launch; atris release preflight before a v* tag');
   console.log('  learn      - Project learnings (patterns, pitfalls, preferences)');
   console.log('  study      - On-demand learning feed: ingest topic, start server, open browser');
   console.log('  rainmaker  - Relationship manager dashboard (atrisos-backend/scripts/rainmaker.py)');
@@ -853,9 +853,11 @@ function showUpgradeHelp() {
 function showReleaseHelp() {
   console.log('');
   console.log('Usage: atris release [--dry-run]');
+  console.log('       atris release preflight');
   console.log('');
   console.log('Description:');
   console.log('  Draft or publish a release from local git history.');
+  console.log('  preflight checks master, a clean tree, origin/master, the version tag, and the full test suite with CI=true.');
   console.log('');
   console.log('Options:');
   console.log('  --dry-run    Print the planned release without committing, tagging, or pushing.');
@@ -2596,6 +2598,10 @@ if (command === 'init') {
   if (args.includes('--help') || args.includes('-h') || args[0] === 'help') {
     showReleaseHelp();
     process.exit(0);
+  }
+  if (args[0] === 'preflight') {
+    const code = require('../commands/release').releasePreflight();
+    process.exit(typeof code === 'number' ? code : 1);
   }
   const dryRun = process.argv.includes('--dry-run');
   require('../commands/release').releaseAtris({ dryRun })

--- a/commands/release.js
+++ b/commands/release.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
+const { runGit } = require('../lib/checkout-sync');
 
 /**
  * atris release [--dry-run] - Tag a release, create GitHub release, draft /launch post
@@ -181,4 +182,103 @@ function printLaunchPost(version, commitLines) {
   console.log('--- end launch post ---');
 }
 
-module.exports = { releaseAtris };
+function readPackageVersion(cwd) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    return typeof pkg.version === 'string' && pkg.version.trim() ? pkg.version.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function runFullTestSuite(cwd) {
+  return spawnSync('npm', ['test'], {
+    cwd,
+    env: { ...process.env, CI: 'true' },
+    stdio: 'inherit',
+  });
+}
+
+function gitStdout(result) {
+  return result && result.status === 0 ? String(result.stdout || '').trim() : '';
+}
+
+/**
+ * atris release preflight
+ *
+ * Enforced checks before pushing a v* tag from master. Prints pass/fail for
+ * each check and exits nonzero if any fail. Skips the test suite when earlier
+ * git checks already failed so a bad checkout does not burn a full run.
+ */
+function releasePreflight({ cwd = process.cwd(), runTests = runFullTestSuite } = {}) {
+  let failed = false;
+
+  const branchResult = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+  const branch = gitStdout(branchResult);
+  if (branch === 'master') {
+    console.log('pass: current branch is master');
+  } else {
+    failed = true;
+    console.log(`fail: current branch is ${branch || 'unknown'}, need master`);
+  }
+
+  const statusResult = runGit(['status', '--porcelain'], cwd);
+  if (statusResult.status === 0 && String(statusResult.stdout || '').trim() === '') {
+    console.log('pass: working tree is clean');
+  } else {
+    failed = true;
+    console.log('fail: working tree is not clean');
+  }
+
+  const localMaster = gitStdout(runGit(['rev-parse', 'master'], cwd));
+  const originMaster = gitStdout(runGit(['rev-parse', 'origin/master'], cwd));
+  if (!localMaster) {
+    failed = true;
+    console.log('fail: local master is missing');
+  } else if (!originMaster) {
+    failed = true;
+    console.log('fail: origin/master is missing');
+  } else if (localMaster !== originMaster) {
+    failed = true;
+    console.log('fail: local master does not match origin/master');
+  } else {
+    console.log('pass: local master matches origin/master');
+  }
+
+  const version = readPackageVersion(cwd);
+  if (!version) {
+    failed = true;
+    console.log('fail: package.json version is missing');
+  } else {
+    const tagName = `v${version}`;
+    const tagList = gitStdout(runGit(['tag', '--list', tagName], cwd));
+    if (tagList) {
+      failed = true;
+      console.log(`fail: tag ${tagName} already exists`);
+    } else {
+      console.log(`pass: no tag ${tagName}`);
+    }
+  }
+
+  if (failed) {
+    console.log('skip: test suite (earlier checks failed)');
+  } else {
+    const testResult = runTests(cwd);
+    if (testResult && testResult.error) {
+      failed = true;
+      console.log(`fail: test suite could not run (${testResult.error.message})`);
+    } else if (testResult && testResult.status === 0) {
+      console.log('pass: test suite');
+    } else {
+      const code = testResult && typeof testResult.status === 'number' ? testResult.status : 1;
+      failed = true;
+      console.log(`fail: test suite exited ${code}`);
+    }
+  }
+
+  console.log('');
+  console.log(failed ? 'release preflight failed' : 'release preflight passed');
+  return failed ? 1 : 0;
+}
+
+module.exports = { releaseAtris, releasePreflight, runFullTestSuite };

--- a/test/release-preflight.test.js
+++ b/test/release-preflight.test.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+const releaseSrc = fs.readFileSync(path.join(repoRoot, 'commands', 'release.js'), 'utf8');
+
+function runCli(args, cwd, extraEnv = {}) {
+  const env = {
+    ...process.env,
+    ATRIS_SKIP_UPDATE_CHECK: '1',
+    ...extraEnv,
+  };
+  delete env.CI;
+
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env,
+    timeout: 30000,
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function makeReleaseRepo({
+  branch = 'master',
+  dirty = false,
+  version = '1.2.3',
+  tagged = false,
+  localAhead = false,
+  testScript = "node -e \"process.exit(process.env.CI === 'true' ? 0 : 1)\"",
+} = {}) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-release-preflight-'));
+  const origin = path.join(base, 'origin.git');
+  const repo = path.join(base, 'repo');
+  fs.mkdirSync(repo);
+
+  execFileSync('git', ['init', '--bare', '--initial-branch=master', origin]);
+  execFileSync('git', ['init', '--initial-branch=master'], { cwd: repo });
+  git(repo, 'config', 'user.email', 'preflight@test.invalid');
+  git(repo, 'config', 'user.name', 'preflight test');
+  git(repo, 'config', 'commit.gpgsign', 'false');
+
+  fs.writeFileSync(path.join(repo, 'package.json'), `${JSON.stringify({
+    name: 'release-preflight-fixture',
+    version,
+    scripts: { test: testScript },
+  }, null, 2)}\n`);
+  git(repo, 'add', 'package.json');
+  git(repo, 'commit', '-m', 'seed');
+  git(repo, 'remote', 'add', 'origin', origin);
+  git(repo, 'push', '-u', 'origin', 'master');
+
+  if (tagged) git(repo, 'tag', `v${version}`);
+  if (localAhead) {
+    git(repo, 'commit', '--allow-empty', '-m', 'local ahead');
+  }
+  if (branch !== 'master') git(repo, 'checkout', '-b', branch);
+  if (dirty) fs.writeFileSync(path.join(repo, 'dirty.txt'), 'dirt\n');
+
+  return { base, repo };
+}
+
+test('release help names preflight', () => {
+  const top = runCli(['--help'], repoRoot);
+  assert.equal(top.status, 0, top.stderr);
+  assert.match(top.stdout, /release preflight/);
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-release-help-'));
+  try {
+    const res = runCli(['release', '--help'], dir);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /atris release preflight/);
+    assert.match(res.stdout, /CI=true/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('release preflight refuses off-master', () => {
+  const { base, repo } = makeReleaseRepo({ branch: 'feature' });
+  try {
+    const res = runCli(['release', 'preflight'], repo);
+    assert.equal(res.status, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /fail: current branch is feature, need master/);
+    assert.match(res.stdout, /skip: test suite \(earlier checks failed\)/);
+    assert.match(res.stdout, /release preflight failed/);
+    assert.doesNotMatch(res.stdout, /\u2014/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('release preflight refuses a dirty tree', () => {
+  const { base, repo } = makeReleaseRepo({ dirty: true });
+  try {
+    const res = runCli(['release', 'preflight'], repo);
+    assert.equal(res.status, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /fail: working tree is not clean/);
+    assert.match(res.stdout, /release preflight failed/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('release preflight refuses when the version tag already exists', () => {
+  const { base, repo } = makeReleaseRepo({ tagged: true });
+  try {
+    const res = runCli(['release', 'preflight'], repo);
+    assert.equal(res.status, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /fail: tag v1\.2\.3 already exists/);
+    assert.match(res.stdout, /release preflight failed/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('release preflight refuses when local master does not match origin/master', () => {
+  const { base, repo } = makeReleaseRepo({ localAhead: true });
+  try {
+    const res = runCli(['release', 'preflight'], repo);
+    assert.equal(res.status, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /fail: local master does not match origin\/master/);
+    assert.match(res.stdout, /release preflight failed/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('release preflight passes on a clean master with CI=true tests', () => {
+  const { base, repo } = makeReleaseRepo();
+  try {
+    const res = runCli(['release', 'preflight'], repo);
+    assert.equal(res.status, 0, res.stdout + res.stderr);
+    assert.match(res.stdout, /pass: current branch is master/);
+    assert.match(res.stdout, /pass: working tree is clean/);
+    assert.match(res.stdout, /pass: local master matches origin\/master/);
+    assert.match(res.stdout, /pass: no tag v1\.2\.3/);
+    assert.match(res.stdout, /pass: test suite/);
+    assert.match(res.stdout, /release preflight passed/);
+    assert.doesNotMatch(res.stdout, /\u2014/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('release preflight uses the real test-suite exit code', () => {
+  const { base, repo } = makeReleaseRepo({
+    testScript: 'node -e "process.exit(2)"',
+  });
+  try {
+    const res = runCli(['release', 'preflight'], repo);
+    assert.equal(res.status, 1, res.stdout + res.stderr);
+    assert.match(res.stdout, /fail: test suite exited 2/);
+    assert.match(res.stdout, /release preflight failed/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('release preflight runs npm test with CI=true', () => {
+  assert.match(releaseSrc, /spawnSync\('npm', \['test'\]/);
+  assert.match(releaseSrc, /CI:\s*'true'/);
+});


### PR DESCRIPTION
Tag publishes relied on memory. New command 'atris release preflight' checks branch, clean tree, origin sync, version tag, and the full suite with CI=true, exiting nonzero on any failure.

Verified: node --test test/cli-smoke.test.js test/release-preflight.test.js, 51 pass, exit 0, re-run independently.

Task: CLI-1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)