### PR TITLE
fix(cli): dogfood pass-2 P0-13/14/15 proof, unknown verbs, mission bind

### DIFF
--- a/bin/atris.js
+++ b/bin/atris.js
@@ -75,7 +75,7 @@ const {
   DEFAULT_CLIENT_ID, DEFAULT_USER_AGENT,
 } = require('../utils/api');
 const missionRuntime = require('../lib/mission-runtime-loop');
-const { knownCommands, suggestCommand } = require('../lib/known-commands');
+const { knownCommands, suggestCommand, suggestCommands } = require('../lib/known-commands');
 const { recordUsage } = require('../lib/usage');
 
 // Bind DI wrappers (utils/auth uses dependency injection for apiRequestJson)
@@ -1166,14 +1166,18 @@ if (!command || !knownCommands.includes(command)) {
     process.exit(2);
   }
 
-  // Warn if this looks like a mistyped single-word command (no spaces)
+  // A single unmatched argv[1] that looks like a verb is a typo or missing
+  // command, not a request to create work. Free-sentence task creation needs
+  // atris "<request>", task new, or wish.
   if (command && !natural.multiword && !directSingleWordNatural) {
-    console.log(`⚠ Unknown command: "${command}". Run "atris help" for available commands.`);
-    const suggestion = suggestCommand(command);
-    if (suggestion) {
-      console.log(`  Did you mean "atris ${suggestion}"?`);
+    const suggestions = suggestCommands(command);
+    console.error(`Unknown command: "${command}". Run "atris help" for available commands.`);
+    if (suggestions.length) {
+      console.error(`Did you mean ${suggestions.map((name) => `"atris ${name}"`).join(' or ')}?`);
+    } else {
+      console.error('To create work from a sentence, run: atris "<request>" (quoted), or atris task new / atris wish.');
     }
-    console.log('  Treating as natural language input...\n');
+    process.exit(2);
   }
 
   // Launch interactive entry (the "Performance")

--- a/commands/mission.js
+++ b/commands/mission.js
@@ -727,7 +727,72 @@ function missionXpTaskTitle(objective) {
   return `${prefix}${shortClause || 'mission work'}`;
 }
 
+function normalizeMissionTaskMatchText(text) {
+  return String(text || '')
+    .replace(/^Mission XP:\s*/i, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function missionObjectiveTaskMatch(objective, title) {
+  const want = normalizeMissionTaskMatchText(objective);
+  const have = normalizeMissionTaskMatchText(title);
+  if (!want || !have) return false;
+  if (want === have) return true;
+  // First clause of a long objective often matches the claimed task title.
+  const wantClause = want.split(/:|[.!?](?=\s|$)/)[0].trim();
+  const haveClause = have.split(/:|[.!?](?=\s|$)/)[0].trim();
+  if (wantClause && haveClause && (wantClause === haveClause || want.startsWith(haveClause) || have.startsWith(wantClause))) {
+    return true;
+  }
+  return false;
+}
+
+function taskRowToMissionXpBinding(task, ownerResolution, outPath, { inserted = false, reused = true } = {}) {
+  return {
+    task_id: task.id,
+    ref: missionTaskRef(task) || task.id,
+    title: task.title,
+    operator_title_warning: warnIfTaskTitleNeedsOperatorWhy(task.title),
+    status: task.status || 'claimed',
+    assigned_to: task.claimed_by || ownerResolution.owner,
+    owner_resolution: ownerResolution.reason,
+    executed_by: ownerResolution.executed_by ? normalizeOwnerSlug(ownerResolution.executed_by) : null,
+    inserted,
+    reused,
+    projection_path: outPath,
+  };
+}
+
+function findOpenTaskMatchingMissionObjective(mission, root = process.cwd(), asJson = false) {
+  const taskDb = loadTaskDb(asJson);
+  const db = taskDb.open();
+  const workspaceRoot = taskDb.workspaceRoot(root);
+  const rows = taskDb.withTaskDisplayRefs(taskDb.listTasks(db, { workspaceRoot }));
+  const open = rows.filter((row) => row && ['open', 'claimed', 'review'].includes(row.status));
+  const explicitIds = Array.isArray(mission.task_ids) ? mission.task_ids.filter(Boolean) : [];
+  for (const id of explicitIds) {
+    const hit = open.find((row) => row.id === id || row.display_id === id || missionTaskRef(row) === id);
+    if (hit) return hit;
+  }
+  return open.find((row) => missionObjectiveTaskMatch(mission.objective, row.title)) || null;
+}
+
+function bindExistingMissionTask(mission, task, root = process.cwd(), asJson = false) {
+  const taskDb = loadTaskDb(asJson);
+  const db = taskDb.open();
+  const workspaceRoot = taskDb.workspaceRoot(root);
+  const ownerResolution = resolveMissionOwner(mission, workspaceRoot);
+  const { outPath } = writeMissionTaskProjection(taskDb, db, workspaceRoot);
+  return taskRowToMissionXpBinding(task, ownerResolution, outPath, { inserted: false, reused: true });
+}
+
 function createMissionXpTask(mission, root = process.cwd(), asJson = false) {
+  const existing = findOpenTaskMatchingMissionObjective(mission, root, asJson);
+  if (existing) {
+    return bindExistingMissionTask(mission, existing, root, asJson);
+  }
   const taskDb = loadTaskDb(asJson);
   const db = taskDb.open();
   const workspaceRoot = taskDb.workspaceRoot(root);
@@ -782,6 +847,7 @@ function createMissionXpTask(mission, root = process.cwd(), asJson = false) {
     owner_resolution: ownerResolution.reason,
     executed_by: ownerResolution.executed_by ? normalizeOwnerSlug(ownerResolution.executed_by) : null,
     inserted: result.inserted !== false,
+    reused: false,
     projection_path: outPath,
   };
 }
@@ -3972,8 +4038,22 @@ function startMission(args, options = {}) {
     const xpTask = createMissionXpTask(mission, process.cwd(), asJson);
     mission.xp_task = xpTask;
     mission.task_ids = Array.from(new Set([...(mission.task_ids || []), xpTask.task_id]));
+    mission.current_task_id = xpTask.task_id;
+    mission.task_ref = xpTask.ref;
     if (!mission.verifier && !mission.always_on) {
       mission.next_action = `work task then run: atris task current-step --goal-id ${mission.id} --as ${mission.owner} --proof "<proof>" --json`;
+    }
+  } else if (!(mission.task_ids && mission.task_ids.length)) {
+    // Bind a live open/claimed task with the same objective instead of leaving
+    // task_ids empty and forcing attach-task to spawn a Mission XP twin later.
+    const existing = findOpenTaskMatchingMissionObjective(mission, process.cwd(), asJson);
+    if (existing) {
+      const bound = bindExistingMissionTask(mission, existing, process.cwd(), asJson);
+      mission.task_ids = [bound.task_id];
+      mission.current_task_id = bound.task_id;
+      mission.task_ref = bound.ref;
+      mission.xp_task = bound;
+      mission.xp_task_enabled = true;
     }
   }
   if (typeof options.beforeMissionSave === 'function') {
@@ -4139,6 +4219,8 @@ async function startMissionFromRunObjective(objective, args) {
     const xpTask = createMissionXpTask(mission, process.cwd(), asJson);
     mission.xp_task = xpTask;
     mission.task_ids = Array.from(new Set([...(mission.task_ids || []), xpTask.task_id]));
+    mission.current_task_id = xpTask.task_id;
+    mission.task_ref = xpTask.ref;
   }
   if (landRun) {
     const repoPath = path.resolve(readFlag(args, '--repo', process.cwd()));
@@ -4265,14 +4347,16 @@ async function startMissionFromRunObjective(objective, args) {
 function attachMissionTask(args) {
   const asJson = wantsJson(args);
   if (hasFlag(args, '--help') || hasFlag(args, '-h') || String(args[0] || '').trim() === 'help') {
-    console.log('Usage: atris mission attach-task <id> [--json]');
+    console.log('Usage: atris mission attach-task <id> [--task <task-id>] [--json]');
+    console.log('Binds an open task with the same objective when one exists; pass --task to choose explicitly.');
     console.log('Run `atris mission --help` for the full option list.');
     process.exit(0);
   }
-  const ref = stripKnownFlags(args, [], ['--json'])[0] || '';
+  const ref = stripKnownFlags(args, ['--task'], ['--json'])[0] || '';
   if (!ref) {
-    exitMissionError('Usage: atris mission attach-task <id> [--json]', 1, asJson);
+    exitMissionError('Usage: atris mission attach-task <id> [--task <task-id>] [--json]', 1, asJson);
   }
+  const explicitTaskIds = readRepeatedFlag(args, '--task');
   let mission = resolveMission(ref);
   if (!mission) {
     exitMissingMission(ref, 1, asJson);
@@ -4288,6 +4372,13 @@ function attachMissionTask(args) {
     if (TERMINAL_STATUSES.has(mission.status)) {
       releaseMissionLock(lock);
       exitMissionError(`Mission "${ref}" is ${mission.status}; task spines attach only to active missions.`, 2, asJson);
+    }
+
+    if (explicitTaskIds.length) {
+      mission = {
+        ...mission,
+        task_ids: Array.from(new Set([...(mission.task_ids || []), ...explicitTaskIds])),
+      };
     }
 
     const existingSpine = missionTaskSpine(mission);
@@ -4365,6 +4456,8 @@ function attachMissionTask(args) {
       xp_task_enabled: true,
       xp_task: xpTask,
       task_ids: Array.from(new Set([...(baseMission.task_ids || []), xpTask.task_id])),
+      current_task_id: xpTask.task_id,
+      task_ref: xpTask.ref,
     };
     if (nextMission.status === 'ready' && nextMission.receipt_path) {
       nextMission.next_action = missionXpReadyAction(nextMission, nextMission.receipt_path) || nextMission.next_action;
@@ -4376,17 +4469,17 @@ function attachMissionTask(args) {
       nextMission.next_action = `work task then run: atris task current-step --goal-id ${nextMission.id} --as ${nextMission.owner} --proof "<proof>" --json`;
     }
 
-    const { mission: saved } = saveMission(nextMission, process.cwd(), 'mission_task_spine_attached', { task_id: xpTask.task_id, task_ref: xpTask.ref });
+    const { mission: saved } = saveMission(nextMission, process.cwd(), 'mission_task_spine_attached', { task_id: xpTask.task_id, task_ref: xpTask.ref, reused: xpTask.reused === true });
     const memberState = renderMemberMissionState(saved.owner);
-    const logPath = appendMemberLog(saved.owner, 'Mission task spine attached', {
+    const logPath = appendMemberLog(saved.owner, xpTask.reused ? 'Mission task spine bound to existing task' : 'Mission task spine attached', {
       mission: saved.objective,
       task: xpTask.ref,
     });
     const view = missionStatusView(saved);
     printJsonOrText(
-      { ok: true, action: 'mission_task_spine_attached', mission: view, task: xpTask, task_spine: view.task_spine, member_state: memberState, log_path: logPath },
+      { ok: true, action: xpTask.reused ? 'mission_task_spine_bound' : 'mission_task_spine_attached', mission: view, task: xpTask, task_spine: view.task_spine, member_state: memberState, log_path: logPath },
       [
-        `Attached task spine: ${saved.objective}`,
+        xpTask.reused ? `Bound existing task spine: ${saved.objective}` : `Attached task spine: ${saved.objective}`,
         `Task: ${xpTask.ref}`,
         `Next: ${view.task_spine.current_step_command}`,
       ],
@@ -5191,6 +5284,14 @@ function missionReportFor(mission, root = process.cwd()) {
     ? 'The last verifier passed; full-budget work is continuing.'
     : mission.operator_outcome
     || (verifierPassed ? 'Verifier passed.' : mission.status === 'complete' ? 'Mission is complete.' : mission.status === 'blocked' ? 'Mission is blocked.' : 'Mission is still in progress.');
+  // Keep summary aligned with outcome: never claim a Codex handoff when the
+  // same report also says no receipt / no live worker.
+  let workerSummary = missionWorkerSummary(mission, receipt);
+  if (awaitingFirstWorker || noLiveWorker) {
+    workerSummary = awaitingFirstWorker
+      ? 'Waiting for the first worker check-in; no receipt yet.'
+      : 'No worker receipt yet.';
+  }
   return {
     id: mission.id,
     objective: mission.objective,
@@ -5204,7 +5305,7 @@ function missionReportFor(mission, root = process.cwd()) {
     operator_outcome: operatorOutcome,
     verification: verificationDebt,
     worker: mission.worker || missionWorkerLabel(mission),
-    worker_summary: missionWorkerSummary(mission, receipt),
+    worker_summary: workerSummary,
     timeline,
     worker_receipt_path: workerReceiptPath,
     verifier_receipt_path: verifierReceiptPath,

--- a/commands/run-front.js
+++ b/commands/run-front.js
@@ -65,19 +65,27 @@ function runnerDrivableForFrontDoor(runner, options = {}) {
   return false;
 }
 
-// Most logical mission: a moving one beats a planned one, newer beats older.
-// ready is excluded — it waits for review, not for another worker pass.
+// Most logical mission: a moving one beats a planned one, ready waits for a
+// resume when nothing else is moving, and newer beats older.
 function pickRunnableMission(root = process.cwd(), missionMap = null, options = {}) {
   let map = missionMap;
   if (!map) {
     try { map = require('./mission').loadMissionMap(root); } catch { return null; }
   }
+  const rank = (status) => {
+    if (status === 'running') return 0;
+    if (status === 'planning') return 1;
+    if (status === 'ready') return 2;
+    return 9;
+  };
   const candidates = Array.from(map.values())
-    .filter((mission) => mission && (mission.status === 'running' || mission.status === 'planning'))
+    .filter((mission) => mission && (mission.status === 'running' || mission.status === 'planning' || mission.status === 'ready'))
     .filter((mission) => runnerDrivableForFrontDoor(mission?.runner, options))
     .filter((mission) => !/^decide and start the next useful mission after:/i.test(String(mission?.objective || '')))
     .sort((a, b) => {
-      if (a.status !== b.status) return a.status === 'running' ? -1 : 1;
+      const ra = rank(a.status);
+      const rb = rank(b.status);
+      if (ra !== rb) return ra - rb;
       return String(b.updated_at || b.created_at || '').localeCompare(String(a.updated_at || a.created_at || ''));
     });
   return candidates[0] || null;

--- a/commands/task.js
+++ b/commands/task.js
@@ -9,7 +9,10 @@ const { execSync } = require('node:child_process');
 const path = require('path');
 const os = require('os');
 const { hasFlag } = require('../lib/arg-parser');
-const { taskProofState } = require('../lib/task-proof');
+const {
+  taskProofState,
+  LOCAL_SUCCESS_PROOF_EXAMPLE,
+} = require('../lib/task-proof');
 const {
   candidatePolicyGate,
   evaluateAutoAccept,
@@ -163,7 +166,8 @@ atris task - durable local task state (SQLite, gitignored)
                                            Agent proof ready; native goal can complete
   atris task ready <id> --verify "<cmd>" --result "<sentence>"
                                            Run <cmd>; only ready if it exits 0 (executed proof)
-                                           Writes atris/runs/ receipt (pass or fail), folds path into proof
+                                           Writes atris/runs/ receipt (pass or fail); that local pass is enough proof
+                                           Optional CI URL only with --proof-url and --i-fetched
   atris task receipt <id> --verify "<cmd>" Run <cmd> and write an atris/runs/ receipt without going to ready
   atris task plan-preview "<purpose>" [--tag <tag>] [--owner <member>] [--task <id>]
                                            Show the plain Plan before work starts
@@ -472,8 +476,8 @@ function proofFlagValue(args) {
   return typeof proof === 'string' ? proof.trim() : '';
 }
 
-function resultSentenceIssue(value) {
-  const check = explainResult(value);
+function resultSentenceIssue(value, { allowCommandMention = false } = {}) {
+  const check = explainResult(value, { allowCommandMention });
   return check.ok ? null : check.reason;
 }
 
@@ -481,11 +485,28 @@ function readyResultDetail(reason) {
   return reason ? `${READY_RESULT_TEACHING}\n${reason}` : READY_RESULT_TEACHING;
 }
 
-function requireResultSentence(label, value, { ready = false } = {}) {
-  const issue = resultSentenceIssue(value);
+function requireResultSentence(label, value, { ready = false, allowCommandMention = false } = {}) {
+  const issue = resultSentenceIssue(value, { allowCommandMention });
   if (!issue) return String(value || '').replace(/\s+/g, ' ').trim();
   const detail = ready ? readyResultDetail(issue) : issue;
   failTask(label, 'weak_result', detail);
+}
+
+function weakProofDetail(issue) {
+  return `meaningful proof required: ${issue}\n${LOCAL_SUCCESS_PROOF_EXAMPLE}`;
+}
+
+function requireMeaningfulTaskProof(label, proof, { required = true } = {}) {
+  const issue = meaningfulTaskProofIssue(proof, { required });
+  if (issue) failTask(label, 'weak_proof', weakProofDetail(issue));
+}
+
+function sendProofIssue(res, proof, issue) {
+  return sendJson(res, 400, {
+    ok: false,
+    reason: String(proof || '').trim() ? 'weak_proof' : 'proof_required',
+    detail: weakProofDetail(issue),
+  });
 }
 
 function textFlag(args, names) {
@@ -656,19 +677,6 @@ function missionXpProofBoundaryEvaluation(task, proofOverride = null) {
     next_action: 'attach the zero-papercut end-to-end fresh-laptop receipt, then resubmit Mission XP proof',
     proof,
   };
-}
-
-function requireMeaningfulTaskProof(label, proof, { required = true } = {}) {
-  const issue = meaningfulTaskProofIssue(proof, { required });
-  if (issue) failTask(label, 'weak_proof', `meaningful proof required: ${issue}`);
-}
-
-function sendProofIssue(res, proof, issue) {
-  return sendJson(res, 400, {
-    ok: false,
-    reason: String(proof || '').trim() ? 'weak_proof' : 'proof_required',
-    detail: `meaningful proof required: ${issue}`,
-  });
 }
 
 function positional(args) {
@@ -8848,7 +8856,7 @@ function runTaskStep(taskDb, db, taskId, options = {}) {
     const proof = String(options.proof || '').trim();
     const proofIssue = meaningfulTaskProofIssue(proof);
     if (proofIssue) {
-      throw taskStepError(proof ? 'weak_proof' : 'proof_required', `meaningful proof required: ${proofIssue}`, { status: 400, exitCode: 2, page: actionPage });
+      throw taskStepError(proof ? 'weak_proof' : 'proof_required', weakProofDetail(proofIssue), { status: 400, exitCode: 2, page: actionPage });
     }
     const missionXpIssue = missionXpEndToEndProofIssue(task, proof, task.workspace_root || process.cwd());
     if (missionXpIssue) {
@@ -8895,7 +8903,7 @@ function runTaskStep(taskDb, db, taskId, options = {}) {
     const proof = String(options.proof || '').trim();
     const proofIssue = meaningfulTaskProofIssue(proof);
     if (proofIssue) {
-      throw taskStepError(proof ? 'weak_proof' : 'proof_required', `meaningful proof required: ${proofIssue}`, { status: 400, exitCode: 2, page: actionPage });
+      throw taskStepError(proof ? 'weak_proof' : 'proof_required', weakProofDetail(proofIssue), { status: 400, exitCode: 2, page: actionPage });
     }
     const parsedReward = parseStepReviewReward(options.reward);
     if (!parsedReward.ok) {
@@ -9615,9 +9623,32 @@ function cmdReady(args) {
   // turning a claim into executed evidence. --verify can carry an optional --proof note.
   const proofFlag = flag(args, '--proof');
   const verifyFlag = flag(args, '--verify');
-  const resultSentence = requireResultSentence('atris task ready', textFlag(args, ['--result']), { ready: true });
+  const proofUrl = textFlag(args, ['--proof-url']);
+  const iFetched = hasFlag(args, '--i-fetched');
+  if (proofUrl && !iFetched) {
+    failTask(
+      'atris task ready',
+      'unfetched_proof_url',
+      'CI run URLs only count after atris fetches them, or with --proof-url and --i-fetched',
+    );
+  }
+  if (iFetched && !proofUrl && !(typeof proofFlag === 'string' && /https?:\/\/github[.]com\//i.test(proofFlag))) {
+    failTask(
+      'atris task ready',
+      'proof_url_required',
+      '--i-fetched requires --proof-url <actions-run-url> (or a URL inside --proof)',
+    );
+  }
   const usedVerify = typeof verifyFlag === 'string' ? verifyFlag.trim() : '';
+  const resultSentence = requireResultSentence('atris task ready', textFlag(args, ['--result']), {
+    ready: true,
+    allowCommandMention: Boolean(usedVerify),
+  });
   let proof = typeof proofFlag === 'string' ? proofFlag : '';
+  if (proofUrl && iFetched) {
+    const attested = `[i-fetched] ${proofUrl}`;
+    proof = proof.trim() ? `${proof.trim()} ${attested}` : attested;
+  }
   const verifyAutoCertifyAllowed = !usedVerify || isAutoCertifyVerifyCommandAllowed(verifyFlag);
   if (usedVerify) {
     // Run the verifier once and write a receipt (pass or fail) so the review

--- a/lib/autoland.js
+++ b/lib/autoland.js
@@ -430,7 +430,7 @@ function hasAgentJargon(text) {
   return AGENT_JARGON.test(String(text || ''));
 }
 
-function explainResult(text) {
+function explainResult(text, options = {}) {
   const raw = String(text || '');
   const value = raw.replace(/\s+/g, ' ').trim();
   if (!value) return { ok: false, reason: 'result must say what someone can do now and why it matters.' };
@@ -443,7 +443,9 @@ function explainResult(text) {
   if (RESULT_ULID.test(value)) return { ok: false, reason: 'result should explain the gain, not include database ids.' };
   if (RESULT_TICKET.test(value)) return { ok: false, reason: 'result should not include ticket ids.' };
   if (RESULT_FILE_PATH.test(value)) return { ok: false, reason: 'result should not include file paths.' };
-  if (RESULT_COMMAND.test(value)) return { ok: false, reason: 'result should not include command syntax or flags.' };
+  if (!options.allowCommandMention && RESULT_COMMAND.test(value)) {
+    return { ok: false, reason: 'result should not include command syntax or flags.' };
+  }
   const finalWord = (value.replace(/[.!?]+$/g, '').match(/[A-Za-z]+$/) || [''])[0].toLowerCase();
   if (TRAILING_FRAGMENT_WORDS.has(finalWord) && !COMPLETE_TRAILING_PHRASE.test(value)) {
     return { ok: false, reason: 'result ends mid-thought; finish the sentence with the actual human gain.' };

--- a/lib/known-commands.js
+++ b/lib/known-commands.js
@@ -39,6 +39,15 @@ function suggestCommand(input, commands = knownCommands) {
   if (!input || typeof input !== 'string') return null;
   const word = input.toLowerCase().trim();
   if (!word) return null;
+  // Semantic near-misses that edit distance will not catch (context ≠ activate).
+  const ALIASES = {
+    context: 'activate',
+    ctx: 'activate',
+    info: 'status',
+    state: 'status',
+    whereami: 'status',
+  };
+  if (ALIASES[word] && commands.includes(ALIASES[word])) return ALIASES[word];
   // Ignore internal/private commands (leading underscore) as suggestions.
   const candidates = commands.filter((c) => !c.startsWith('_'));
   let best = null;
@@ -55,4 +64,21 @@ function suggestCommand(input, commands = knownCommands) {
   return best;
 }
 
-module.exports = { knownCommands, suggestCommand, editDistance };
+function suggestCommands(input, commands = knownCommands) {
+  const primary = suggestCommand(input, commands);
+  const word = String(input || '').toLowerCase().trim();
+  const extras = [];
+  if (word === 'context' || word === 'ctx') {
+    for (const name of ['activate', 'status']) {
+      if (commands.includes(name) && name !== primary) extras.push(name);
+    }
+  }
+  const out = [];
+  if (primary) out.push(primary);
+  for (const name of extras) {
+    if (!out.includes(name)) out.push(name);
+  }
+  return out;
+}
+
+module.exports = { knownCommands, suggestCommand, suggestCommands, editDistance };

--- a/lib/task-proof.js
+++ b/lib/task-proof.js
@@ -8,24 +8,41 @@ const PATH_ONLY_PROOF_RE = /(?:^|[\s'"`])(?:\.{0,2}\/|~\/|\/Users\/|\/private\/|
 const RECEIPT_OR_ARTIFACT_RE = /\b(?:receipt|artifact|screenshot|log|trace|path=|file=|bytes=|model=|opened=|https?:\/\/)\b/i;
 const RESULT_PAIR_RE = /\b(?:typecheck|build|smoke|test|pytest|verifier|validation|validated|verified|render|diff|sync|lineage|projection)\b.{0,80}\b(?:pass|passed|failed|green|ok|exit\s*0|reviewed)\b|\b(?:pass|passed|failed|green|ok|exit\s*0|reviewed)\b.{0,80}\b(?:typecheck|build|smoke|test|pytest|verifier|validation|validated|verified|render|diff|sync|lineage|projection)\b/i;
 const SUITE_GREEN_CLAIM_RE = /\b(?:tests|test\s+suite|suite)\s+(?:is|are|was|were)?\s*(?:all\s+)?(?:green|pass(?:es|ed)?|ok)\b|\b(?:all|full|whole|entire)\s+(?:tests?|test\s+suite|suite)\s+(?:is|are|was|were)?\s*(?:green|pass(?:es|ed)?|ok)\b|\ball\s+green\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?test\b\x60?(?:\s+(?:\d+\s*\/\s*\d+|all|suite))?\s+(?:is\s+)?(?:green|pass(?:es|ed)?|ok)\b/i;
-const CI_RUN_CITATION_RE = /https?:\/\/github[.]com\/[^/\s]+\/[^/\s]+\/actions\/runs\/\d+\b|\brun_id\s*=\s*\d+\b|\brun(?:\s+id)?\s*(?:=|:)?\s*\d+\b/i;
+const CI_RUN_URL_RE = /https?:\/\/github[.]com\/[^/\s]+\/[^/\s]+\/actions\/runs\/\d+\b/i;
+const CI_RUN_ID_RE = /\brun_id\s*=\s*\d+\b|\brun(?:\s+id)?\s*(?:=|:)?\s*\d+\b/i;
+const CI_RUN_CITATION_RE = new RegExp(`${CI_RUN_URL_RE.source}|${CI_RUN_ID_RE.source}`, 'i');
 const COMMIT_PINNED_LOCAL_VERIFY_RE = /\bcommit\s+[0-9a-f]{7,40}\b/i;
 const EXIT_ZERO_RE = /\bexit(?:ed)?(?:\s+code)?\s*0\b/i;
-const SUITE_GREEN_CITATION_REASON = 'cite the CI run URL, run id, or commit-pinned verify command with exit 0 before claiming the suite is green';
+const SUITE_GREEN_CITATION_REASON = 'cite a fetched CI run URL (--proof-url with --i-fetched), a run id, or a commit-pinned verify command with exit 0 before claiming the suite is green';
+const LOCAL_SUCCESS_PROOF_EXAMPLE = 'local success example: atris task ready <id> --verify "<cmd>" --result "<plain sentence>" (exit 0 plus the written atris/runs/ receipt path is enough; do not paste a CI URL unless atris fetched it or you pass --proof-url with --i-fetched)';
+const FETCHED_PROOF_URL_RE = /\[(?:fetched|i-fetched)\]\s*https?:\/\/github[.]com\/[^/\s]+\/[^/\s]+\/actions\/runs\/\d+\b/i;
 const HUMAN_PROOF_RE = /\b(?:team human approved|human approved|human approval|approved by|accepted by|reviewed by|customer replied|customer approved|customer accepted|replied)\b/i;
 const FILE_ACTION_RE = /\b(?:changed|updated|edited|created|deleted|saved|wrote|patched|reviewed|verified|validated|opened|read)\b/i;
-const VERIFIED_PROOF_RE = /^\[verified\]\s+`[^`]+`\s+passed\s+\(exit 0\)(?:\s|$)/i;
+const VERIFIED_PROOF_RE = /^\[verified\]\s+`[^`]+`\s+passed\s+\(exit 0\)(?:\s|$)/im;
+const LOCAL_RECEIPT_PATH_RE = /(?:^|[\s])(?:Receipt:\s*)?(?:atris\/runs\/|\.atris\/state\/)[^\s'"`,;)]+\.json\b/i;
 const SECOND_ACTOR_EXECUTED_PROOF_RE = /^Second-actor check:\s+`[^`]+`\s+re-run by [^,]+,\s+exited 0(?:[.\s]|$)/i;
 
 function compactWhitespace(text) {
   return String(text || '').replace(/\s+/g, ' ').trim();
 }
 
+function hasFetchedCiCitation(text) {
+  return FETCHED_PROOF_URL_RE.test(text);
+}
+
 function hasSuiteGreenCitation(text) {
-  return CI_RUN_CITATION_RE.test(text)
-    || (COMMIT_PINNED_LOCAL_VERIFY_RE.test(text)
-      && COMMAND_PROOF_RE.test(text)
-      && EXIT_ZERO_RE.test(text));
+  // A pasted actions URL is not proof unless atris fetched it (marked
+  // [fetched]/[i-fetched]) or the caller attested with --i-fetched.
+  if (hasFetchedCiCitation(text)) return true;
+  if (CI_RUN_URL_RE.test(text)) return false;
+  if (CI_RUN_ID_RE.test(text)) return true;
+  return COMMIT_PINNED_LOCAL_VERIFY_RE.test(text)
+    && COMMAND_PROOF_RE.test(text)
+    && EXIT_ZERO_RE.test(text);
+}
+
+function hasLocalVerifiedReceipt(text) {
+  return VERIFIED_PROOF_RE.test(text) && LOCAL_RECEIPT_PATH_RE.test(text);
 }
 
 function taskProofState(proof) {
@@ -33,6 +50,18 @@ function taskProofState(proof) {
   if (!text) return { ok: false, reason: 'proof required' };
   if (GENERIC_COMPLETION_PROOF_RE.test(text)) {
     return { ok: false, reason: 'proof must name what was verified, changed, approved, or produced' };
+  }
+  // An executed --verify that exited 0 and wrote an atris/runs receipt is
+  // meaningful proof on its own. Suite-green URL rules apply only to claims.
+  if (hasLocalVerifiedReceipt(text)) {
+    return { ok: true, reason: 'proof is a local verified command with receipt path' };
+  }
+  if (CI_RUN_URL_RE.test(text) && !hasFetchedCiCitation(text) && !SUITE_GREEN_CLAIM_RE.test(text)) {
+    return {
+      ok: false,
+      code: 'unfetched_proof_url',
+      reason: 'CI run URLs only count after atris fetches them, or with --proof-url and --i-fetched',
+    };
   }
   if (SUITE_GREEN_CLAIM_RE.test(text)) {
     if (!hasSuiteGreenCitation(text)) {
@@ -42,7 +71,7 @@ function taskProofState(proof) {
         reason: SUITE_GREEN_CITATION_REASON,
       };
     }
-    return { ok: true, reason: 'proof cites a CI run or commit-pinned local verify' };
+    return { ok: true, reason: 'proof cites a fetched CI run or commit-pinned local verify' };
   }
   if (COMMAND_PROOF_RE.test(text)) return { ok: true, reason: 'proof names a command' };
   if (HUMAN_PROOF_RE.test(text)) return { ok: true, reason: 'proof names human/customer approval' };
@@ -122,4 +151,7 @@ module.exports = {
   taskProofState,
   taskProofExecutionState,
   buildVerifiedProof,
+  LOCAL_SUCCESS_PROOF_EXAMPLE,
+  hasLocalVerifiedReceipt,
+  hasFetchedCiCitation,
 };

--- a/test/autoland.test.js
+++ b/test/autoland.test.js
@@ -905,7 +905,7 @@ test('tick blocks uncited suite-green proof and cites the needed run in its rece
     assert.deepEqual(receipt.landed, []);
     assert.deepEqual(receipt.citation_blocks, [{
       ref,
-      reason: 'cite the CI run URL, run id, or commit-pinned verify command with exit 0 before claiming the suite is green',
+      reason: 'cite a fetched CI run URL (--proof-url with --i-fetched), a run id, or a commit-pinned verify command with exit 0 before claiming the suite is green',
     }]);
     assert.equal(projectionByRef(repo)[ref].status, 'review');
   } finally {
@@ -913,12 +913,12 @@ test('tick blocks uncited suite-green proof and cites the needed run in its rece
   }
 });
 
-test('tick lands the same suite-green proof when it cites a CI run URL', () => {
+test('tick lands the same suite-green proof when it cites a fetched CI run URL', () => {
   const { base, repo } = makeTempRepo();
   try {
     const ref = certifiedVerifiedTask(repo, 'Land a cited green claim', {
       verify: 'git diff --check',
-      proof: 'suite green https://github.com/acme/repo/actions/runs/123456789',
+      proof: 'suite green [i-fetched] https://github.com/acme/repo/actions/runs/123456789',
     });
     autoland.writePolicy(repo, { enabled: true, enabled_by: 'keshav', strict_verify: false });
 

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -19539,14 +19539,22 @@ test('casual launch words route to the durable mission loop', () => {
   }
 });
 
-test('unknown single-word command shows warning', () => {
+test('unknown single-word command exits 2 without creating work', () => {
   const dir = makeTempDir();
   try {
     initWorkspace(dir);
     fs.writeFileSync(path.join(dir, 'atris', 'MAP.md'), '# MAP.md\n\n## By-Feature\n- example: bin/atris.js:1\n', 'utf8');
+    const beforeTodo = fs.existsSync(path.join(dir, 'atris', 'TODO.md'))
+      ? fs.readFileSync(path.join(dir, 'atris', 'TODO.md'), 'utf8')
+      : null;
     const res = runCli(['foobarxyz'], { cwd: dir });
-    assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /Unknown command.*foobarxyz/i);
+    assert.equal(res.status, 2, res.stderr || res.stdout);
+    assert.match(res.stderr + res.stdout, /Unknown command.*foobarxyz/i);
+    assert.doesNotMatch(res.stderr + res.stdout, /Treating as natural language/i);
+    const afterTodo = fs.existsSync(path.join(dir, 'atris', 'TODO.md'))
+      ? fs.readFileSync(path.join(dir, 'atris', 'TODO.md'), 'utf8')
+      : null;
+    assert.equal(afterTodo, beforeTodo);
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/dogfood-p0.test.js
+++ b/test/dogfood-p0.test.js
@@ -219,3 +219,154 @@ test('P0-4: plan/do/ingest start with PROMPT ONLY or ACTION TAKEN', () => {
     cleanupTempDir(dir);
   }
 });
+
+test('P0-13: local verify receipt is enough proof; unfetched actions URL is rejected', function () {
+  if (!hasNodeSqlite()) return;
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, 'tasks.db');
+  const env = { ATRIS_TASKS_DB: dbPath, NODE_NO_WARNINGS: '1', ATRIS_AGENT_ID: 'codex' };
+  try {
+    assert.equal(runCli(['init', '--yes'], { cwd: dir, env, timeout: 60000 }).status, 0);
+    const add = runCli(['task', 'add', 'Ship keyword search for operators', '--json'], { cwd: dir, env });
+    assert.equal(add.status, 0, add.stderr);
+    const ref = JSON.parse(add.stdout).task.display_id;
+
+    const receipt = runCli(['task', 'receipt', ref, '--verify', 'true', '--no-falsify-check', '--json'], { cwd: dir, env });
+    assert.equal(receipt.status, 0, receipt.stderr);
+    const receiptPayload = JSON.parse(receipt.stdout);
+    assert.equal(receiptPayload.passed, true);
+    assert.equal(receiptPayload.exit, 0);
+    assert.ok(receiptPayload.receipt_path);
+
+    const readyOk = runCli([
+      'task', 'ready', ref,
+      '--verify', 'true',
+      '--no-falsify-check',
+      '--result', 'Operators can now find tasks by keyword instead of scrolling the full list.',
+      '--json',
+    ], { cwd: dir, env });
+    assert.equal(readyOk.status, 0, readyOk.stderr || readyOk.stdout);
+    const readyPayload = JSON.parse(readyOk.stdout);
+    assert.match(readyPayload.task.review.proof, /\[verified\].*passed \(exit 0\)/);
+    assert.match(readyPayload.task.review.proof, /Receipt: atris\/runs\//);
+
+    const add2 = runCli(['task', 'add', 'Reject fabricated CI URL', '--json'], { cwd: dir, env });
+    assert.equal(add2.status, 0, add2.stderr);
+    const ref2 = JSON.parse(add2.stdout).task.display_id;
+    const fakeUrl = 'https://github.com/keshav/atris-dogfood-2/actions/runs/123456';
+    const readyFake = runCli([
+      'task', 'ready', ref2,
+      '--proof', `npm test passed ${fakeUrl}`,
+      '--result', 'Operators can now find tasks by keyword instead of scrolling the full list.',
+      '--json',
+    ], { cwd: dir, env });
+    assert.equal(readyFake.status, 2, readyFake.stderr || readyFake.stdout);
+    const fakePayload = JSON.parse(readyFake.stdout);
+    assert.equal(fakePayload.reason, 'weak_proof');
+    assert.match(fakePayload.detail, /local success example/i);
+    assert.match(fakePayload.detail, /fetched|i-fetched|receipt/i);
+
+    const readyMention = runCli([
+      'task', 'ready', ref2,
+      '--verify', 'true',
+      '--no-falsify-check',
+      '--result', 'Operators can find tasks by keyword after the npm test so they stop scrolling.',
+      '--json',
+    ], { cwd: dir, env });
+    assert.equal(readyMention.status, 0, readyMention.stderr || readyMention.stdout);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('P0-14: unknown verb atris context exits 2 and does not create a task', function () {
+  if (!hasNodeSqlite()) return;
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, 'tasks.db');
+  const env = { ATRIS_TASKS_DB: dbPath, NODE_NO_WARNINGS: '1' };
+  try {
+    assert.equal(runCli(['init', '--yes'], { cwd: dir, env, timeout: 60000 }).status, 0);
+    const beforeList = runCli(['task', 'list', '--json'], { cwd: dir, env });
+    assert.equal(beforeList.status, 0, beforeList.stderr);
+    const beforeCount = (JSON.parse(beforeList.stdout).tasks || []).length;
+    const beforeTodo = fs.existsSync(path.join(dir, 'atris', 'TODO.md'))
+      ? fs.readFileSync(path.join(dir, 'atris', 'TODO.md'), 'utf8')
+      : '';
+
+    const res = runCli(['context'], { cwd: dir, env });
+    assert.equal(res.status, 2, res.stderr || res.stdout);
+    assert.match(res.stderr + res.stdout, /Unknown command.*context/i);
+    assert.match(res.stderr + res.stdout, /activate|status/i);
+    assert.doesNotMatch(res.stderr + res.stdout, /Treating as natural language/i);
+
+    const afterList = runCli(['task', 'list', '--json'], { cwd: dir, env });
+    assert.equal(afterList.status, 0, afterList.stderr);
+    const afterCount = (JSON.parse(afterList.stdout).tasks || []).length;
+    assert.equal(afterCount, beforeCount);
+    const afterTodo = fs.existsSync(path.join(dir, 'atris', 'TODO.md'))
+      ? fs.readFileSync(path.join(dir, 'atris', 'TODO.md'), 'utf8')
+      : '';
+    assert.equal(afterTodo, beforeTodo);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('P0-15: mission attach-task binds the live claimed task instead of spawning a Mission XP twin', function () {
+  if (!hasNodeSqlite()) return;
+  const dir = makeTempDir();
+  const dbPath = path.join(dir, 'tasks.db');
+  const env = { ATRIS_TASKS_DB: dbPath, NODE_NO_WARNINGS: '1', ATRIS_AGENT_ID: 'cursor-agent' };
+  const objective = 'Add keyword search so operators can find tasks without scrolling';
+  try {
+    assert.equal(runCli(['init', '--yes'], { cwd: dir, env, timeout: 60000 }).status, 0);
+    const add = runCli(['task', 'add', objective, '--json'], { cwd: dir, env });
+    assert.equal(add.status, 0, add.stderr);
+    const task = JSON.parse(add.stdout).task;
+    const claim = runCli(['task', 'claim', task.display_id, '--as', 'cursor-agent', '--json'], { cwd: dir, env });
+    assert.equal(claim.status, 0, claim.stderr || claim.stdout);
+
+    const start = runCli([
+      'mission', 'start', objective,
+      '--owner', 'mission-lead',
+      '--runner', 'manual',
+      '--lane', 'code',
+      '--verify', 'true',
+      '--json',
+    ], { cwd: dir, env });
+    assert.equal(start.status, 0, start.stderr || start.stdout);
+    const started = JSON.parse(start.stdout);
+    assert.ok(started.mission.task_ids.includes(task.id) || started.mission.current_task_id === task.id
+      || (started.mission.xp_task && started.mission.xp_task.task_id === task.id),
+      `expected start to bind ${task.id}: ${start.stdout.slice(0, 500)}`);
+
+    const beforeList = JSON.parse(runCli(['task', 'list', '--json'], { cwd: dir, env }).stdout);
+    const beforeCount = (beforeList.tasks || []).length;
+
+    const attach = runCli(['mission', 'attach-task', started.mission.id, '--json'], { cwd: dir, env });
+    assert.equal(attach.status, 0, attach.stderr || attach.stdout);
+    const attached = JSON.parse(attach.stdout);
+    assert.ok(
+      attached.action === 'mission_task_spine_exists'
+      || attached.action === 'mission_task_spine_bound'
+      || (attached.task && attached.task.task_id === task.id),
+      `unexpected attach action: ${attached.action}`,
+    );
+    const spineId = attached.task_spine?.task_id
+      || attached.mission?.task_spine?.task_id
+      || attached.task?.task_id
+      || attached.mission?.current_task_id;
+    assert.equal(spineId, task.id);
+
+    const afterList = JSON.parse(runCli(['task', 'list', '--json'], { cwd: dir, env }).stdout);
+    const afterTasks = afterList.tasks || [];
+    assert.equal(afterTasks.length, beforeCount);
+    assert.equal(afterTasks.filter((row) => /^Mission XP:/i.test(row.title)).length, 0);
+
+    const { pickRunnableMission } = require('../commands/run-front');
+    const map = new Map([[started.mission.id, { ...started.mission, status: 'ready', runner: 'claude' }]]);
+    assert.equal(pickRunnableMission(dir, map).id, started.mission.id);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});

--- a/test/front-doors.test.js
+++ b/test/front-doors.test.js
@@ -54,7 +54,7 @@ test('runTickBudget: timed runs are loop contracts, untimed default small', () =
   assert.equal(runTickBudget(['--max-ticks', '2'], 3600), 2);
 });
 
-test('pickRunnableMission prefers running over planning, newest first, skips ready', () => {
+test('pickRunnableMission prefers running over planning, then ready', () => {
   const map = new Map([
     ['m1', { id: 'm1', status: 'planning', runner: 'atris2', objective: 'older plan', updated_at: '2026-07-01T01:00:00Z' }],
     ['m2', { id: 'm2', status: 'running', runner: 'atris2', objective: 'old run', updated_at: '2026-07-01T02:00:00Z' }],
@@ -62,6 +62,11 @@ test('pickRunnableMission prefers running over planning, newest first, skips rea
     ['m4', { id: 'm4', status: 'ready', runner: 'atris2', objective: 'waiting on review', updated_at: '2026-07-01T04:00:00Z' }],
   ]);
   assert.equal(pickRunnableMission(process.cwd(), map).id, 'm3');
+  map.delete('m2');
+  map.delete('m3');
+  assert.equal(pickRunnableMission(process.cwd(), map).id, 'm1');
+  map.delete('m1');
+  assert.equal(pickRunnableMission(process.cwd(), map).id, 'm4');
 });
 
 test('pickRunnableMission skips session-bound runners a headless loop cannot drive', () => {

--- a/test/status-gate-parity.test.js
+++ b/test/status-gate-parity.test.js
@@ -123,7 +123,7 @@ test('status never promises a landing the gate will statically refuse', (t) => {
         id: 'uncited-suite-green',
         review: { ...baseTask.review, proof: 'suite green' },
       },
-      expectedReason: 'cite the CI run URL, run id, or commit-pinned verify command with exit 0 before claiming the suite is green',
+      expectedReason: 'cite a fetched CI run URL (--proof-url with --i-fetched), a run id, or a commit-pinned verify command with exit 0 before claiming the suite is green',
     },
     {
       name: 'decision-tagged review',

--- a/test/suggest-command.test.js
+++ b/test/suggest-command.test.js
@@ -15,6 +15,7 @@ test('suggestCommand points a near-miss typo at the intended command', () => {
   assert.strictEqual(suggestCommand('missin'), 'mission');
   assert.strictEqual(suggestCommand('benc'), 'bench');
   assert.strictEqual(suggestCommand('stauts'), 'status');
+  assert.strictEqual(suggestCommand('context'), 'activate');
 });
 
 test('suggestCommand returns null for input that is not close to any command', () => {
@@ -45,7 +46,7 @@ test('every known command is its own closest match', () => {
 test('CLI prints a did-you-mean line for a typo', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-suggest-command-test-'));
   try {
-    let out;
+    let out = '';
     try {
       out = execFileSync('node', [CLI, 'taks'], {
         cwd: dir,
@@ -57,8 +58,8 @@ test('CLI prints a did-you-mean line for a typo', () => {
         },
       });
     } catch (err) {
-      // The natural-language fallthrough may exit nonzero; we only care about stdout.
-      out = err.stdout || '';
+      // Unknown single-word verbs exit 2; suggestion is on stderr.
+      out = `${err.stdout || ''}${err.stderr || ''}`;
     }
     assert.match(out, /Did you mean "atris task"\?/);
   } finally {

--- a/test/task-proof.test.js
+++ b/test/task-proof.test.js
@@ -114,15 +114,23 @@ test('task proof helper requires citations for suite-green claims', () => {
   const missing = taskProofState('suite green');
   assert.equal(missing.ok, false);
   assert.equal(missing.code, 'suite_green_citation_required');
-  assert.match(missing.reason, /cite the CI run/i);
+  assert.match(missing.reason, /fetched CI run|commit-pinned/i);
 
   for (const proof of [
-    'suite passes; https://github.com/acme/repo/actions/runs/123456789',
+    'suite passes; [i-fetched] https://github.com/acme/repo/actions/runs/123456789',
+    'all green; [fetched] https://github.com/acme/repo/actions/runs/123456789',
     'all green; run_id=123456789',
     'npm test passed; run 123456789',
     'commit abc1234; npm test passed (exit 0)',
   ]) {
     assert.equal(taskProofLooksMeaningful(proof), true, String(proof) + ' should cite the suite result');
+  }
+
+  for (const proof of [
+    'suite passes; https://github.com/acme/repo/actions/runs/123456789',
+    'npm test passed; https://github.com/keshav/atris-dogfood-2/actions/runs/123456',
+  ]) {
+    assert.equal(taskProofLooksMeaningful(proof), false, String(proof) + ' should reject an unfetched CI URL');
   }
 });
 
@@ -160,9 +168,12 @@ test('buildVerifiedProof turns a passing command into executed proof', () => {
   assert.equal(result.exit, 0);
   assert.match(result.proof, /^\[verified\] `npm test` passed \(exit 0\)/);
   assert.match(result.proof, /fixed the parser/);
-  // A locally verified full-suite command still needs an explicit citation.
+  // Without a receipt path, a suite-green local verify still needs a citation.
   assert.equal(taskProofLooksMeaningful(result.proof), false);
   assert.equal(taskProofState(result.proof).code, 'suite_green_citation_required');
+  // With the receipt path ready writes, the same local verify is meaningful.
+  const withReceipt = `${result.proof}\nReceipt: atris/runs/demo.json`;
+  assert.equal(taskProofLooksMeaningful(withReceipt), true);
   // It actually ran the command via bash.
   assert.deepEqual(calls[0][0], 'bash');
   assert.deepEqual(calls[0][1], ['-lc', 'npm test']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Dogfood pass-2 P0s from atris v3.54.0 on 2026-08-24.

**P0-13.** Local `--verify` exit 0 plus an `atris/runs/` receipt is meaningful proof. Fabricated GitHub Actions URLs without a fetch (or `--proof-url` + `--i-fetched`) are rejected. `weak_proof` prints the local-success example. Mentioning `npm` in `--result` is allowed when `--verify` already ran.

**P0-14.** Unknown single-token verbs (`atris context`) exit 2 with did-you-mean (`activate` / `status`) and do not create a task or rewrite TODO.md. Free-sentence work still needs `atris "<request>"`, `task new`, or `wish`.

**P0-15.** `mission start` / `attach-task` bind an open/claimed task with the same objective (or `--task <id>`) instead of spawning a Mission XP twin. `atris run` with no args can resume a ready mission. Report fields no longer claim a Codex handoff when there is no receipt.

## Test plan
- [x] `node --test test/dogfood-p0.test.js` (includes P0-13/14/15)
- [x] `node --test test/task-proof.test.js test/task-receipt.test.js test/front-doors.test.js test/suggest-command.test.js`
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ece608fc-f3fc-4aa6-b30f-baf07e6e9cea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ece608fc-f3fc-4aa6-b30f-baf07e6e9cea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

