### PR TITLE
fix(cli): land verify/hygiene follow-up for dogfood #674

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -58,7 +58,7 @@ rg "logAtris|logsDigest|addInboxIdea|--repl" commands/log.js bin/atris.js test/l
 rg "logSyncAtris" commands/log-sync.js      # Log sync command
 rg "experimentsCommand" commands/experiments.js  # Experiments CLI command
 rg "loginAtris|switchAccount|useAccount|accountsCmd|showAuthHelp|--global|scope" bin/atris.js commands/auth.js lib/cli-scope.js test/dogfood-p1.test.js # Auth/account commands + workspace vs --global account list
-rg "doctorCommand|collectDoctor|task_support|public bin shim" commands/doctor.js bin/atris.js package.json test/dogfood-p1.test.js # atris doctor --json: node, task-support 22+, auth, workspace, tiny POSIX bin shim
+rg "doctorCommand|task_support|public bin shim" commands/doctor.js bin/atris.js package.json test/dogfood-p1.test.js # atris doctor --json: node, task-support 22+, auth, workspace, tiny POSIX bin shim (helpers stay internal)
 rg "agentDoctor|inspectAgentCliWiring|agent dogfood|agentDogfoodCommand|agentSpawnCommand|agent_spawns" bin/atris.js commands/agent-spawn.js test/commands.test.js test/agent-spawn.test.js commands/init.js # Local AI CLI wiring doctor, Devin/Droid GLM 5.2 dogfood smoke, durable worker spawn requests, and Devin init scaffold
 rg "activateAtris|showActivateHelp|activate and next --help" bin/atris.js commands/activate.js test/commands.test.js # Activate command + wiki status + non-mutating help
 rg "autopilotAtris|buildAutopilotGlassLog|writeAutopilotGlassLog|glassLogPath" commands/autopilot.js test/autopilot-glass-logging.test.js  # Autopilot command + glass phase receipt (plan -> review -> action -> result -> proof)

--- a/commands/doctor.js
+++ b/commands/doctor.js
@@ -124,9 +124,5 @@ function doctorCommand(args = [], options = {}) {
 }
 
 module.exports = {
-  TASK_NODE_MAJOR,
-  collectDoctor,
   doctorCommand,
-  parseNodeVersion,
-  renderDoctor,
 };

--- a/lib/workspace-scaffold.js
+++ b/lib/workspace-scaffold.js
@@ -267,8 +267,4 @@ function seedInitTaskPlane(projectRoot, { todoFile, journalFile } = {}) {
 module.exports = {
   ensureWorkspaceBrain,
   workspaceBrainPresent,
-  mapPlaceholder,
-  todoPlaceholder,
-  firstJournalMarkdown,
-  seedInitTaskPlane,
 };

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -17856,9 +17856,9 @@ test('verify detects placeholder MAP.md', () => {
   const dir = makeTempDir();
   try {
     initWorkspace(dir);
-    // init creates a placeholder MAP.md
+    // init creates a placeholder MAP.md; verify correctly fails when MAP has issues
     const res = runCli(['verify'], { cwd: dir });
-    assert.equal(res.status, 0, res.stderr);
+    assert.equal(res.status, 1, res.stderr);
     // Should mention MAP issues since it's a placeholder
     assert.match(res.stdout, /MAP\.md/);
   } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#674 was squash-merged before the CI hygiene follow-up landed on the branch. Master still had orphaned exports and a verify test that expected exit 0 on placeholder MAP.

## Fix

- Export only `doctorCommand` from `commands/doctor.js`
- Stop exporting unused scaffold helpers from `lib/workspace-scaffold.js`
- Expect `atris verify` exit 1 when MAP is a placeholder

## Proof

```bash
node --test test/auto-accept-certified.test.js test/repo-hygiene.test.js test/dogfood-p1.test.js
```

49/49 pass locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad5fb7f6-eb11-4ddf-a1e3-c84048a5d2cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad5fb7f6-eb11-4ddf-a1e3-c84048a5d2cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

