### PR TITLE
fix(cli): dogfood pass-2 T6-T10 papercuts

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -912,15 +912,15 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 - **Routing:** `bin/atris.js:1327-1331` routes `code-review` and `cr` to `commands/review.js`
 - **Engine discovery:** `commands/review.js:14-30` searches for `review_engine.py`
-- **Missing-engine JSON:** `commands/review.js:32-50` returns `{ ok:false }` under `--json` while preserving human stderr instructions
-- **JSON error helper:** `commands/review.js:53-60` keeps wrapper-owned setup failures parseable
-- **Handler:** `commands/review.js:62-187` parses file/diff/all/json args and delegates to the Python engine when present
-- **All-mode setup:** `commands/review.js:98-106` returns `{ ok:false }` for missing `backend/services/` under `--all --json`, before auditing services
-- **All-mode JSON success:** `commands/review.js:132-145` returns one parseable `{ ok:true, action:"code_review_all" }` summary instead of human `AUDIT:` prose
-- **All-mode human success:** `commands/review.js:147-156` keeps the existing audit banner and table for non-JSON callers
-- **Regression:** `test/code-review.test.js:22-144` covers JSON missing-engine output, JSON missing-services output, JSON success summaries, and unchanged human paths
+- **Missing-engine JSON:** `commands/review.js:32-46` returns `{ ok:false, error:"not installed" }` under `--json` and prints `not installed; atris skill install code-review` on stderr for humans, both exit 2 (no stack trace)
+- **JSON error helper:** `commands/review.js:48-55` keeps wrapper-owned setup failures parseable
+- **Handler:** `commands/review.js:57-182` parses file/diff/all/json args and delegates to the Python engine when present
+- **All-mode setup:** `commands/review.js:93-101` returns `{ ok:false }` for missing `backend/services/` under `--all --json`, before auditing services
+- **All-mode JSON success:** `commands/review.js:127-140` returns one parseable `{ ok:true, action:"code_review_all" }` summary instead of human `AUDIT:` prose
+- **All-mode human success:** `commands/review.js:142-151` keeps the existing audit banner and table for non-JSON callers
+- **Regression:** `test/code-review.test.js` and `test/dogfood-t6-t10.test.js` cover not-installed exit 2, JSON missing-services, and JSON success summaries
 
-**Search:** `rg "reviewCommand|printMissingReviewEngine|exitReviewError|code_review_all|code-review --json|missing services" commands/review.js test/code-review.test.js bin/atris.js`
+**Search:** `rg "reviewCommand|printMissingReviewEngine|exitReviewError|code_review_all|code-review --json|not installed" commands/review.js test/code-review.test.js test/dogfood-t6-t10.test.js bin/atris.js`
 
 ### Feature: Release (`atris release`)
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -590,7 +590,7 @@ function showHelpAll() {
   console.log('  meet       - onboard a stranger in one sitting and print their /book link');
   console.log('  avail      - Booking availability (/book/{username} weekly windows)');
   console.log('  brain      - Compile MAP/TODO/wiki/state into a loadable agent brain');
-  console.log('  lesson     - Append a one-line lesson to atris/lessons.md (add --detector validates the falsifier at write time; ledger/revert audit every mutation; mine: distill receipts/episodes/scorecards into policy lessons)');
+  console.log('  lesson     - atris lesson add <slug> <pass|fail> "<text>" (mine/sweep/resolve/revert/ledger; --detector validates the falsifier at write time)');
   console.log('  taste      - Record the operator\'s keep, kill, and more creative verdicts');
   console.log('  teach      - Turn a bad turn into a failing benchmark, then a permanent guard (red gate: no promotion without a proven failure)');
   console.log('  ingest     - Local-first wiki ingest into atris/wiki/');

--- a/commands/founder.js
+++ b/commands/founder.js
@@ -41,11 +41,17 @@ function parseArgs(args = []) {
   let index = args[0] === 'score' ? 1 : 0;
   let root = null;
   let days = DEFAULT_DAYS;
+  let json = false;
 
   while (index < args.length) {
     const arg = String(args[index]);
     if (arg === '--help' || arg === '-h' || arg === 'help') {
-      return { help: true, root, days };
+      return { help: true, root, days, json };
+    }
+    if (arg === '--json') {
+      json = true;
+      index += 1;
+      continue;
     }
     if (arg === '--root' || arg.startsWith('--root=')) {
       const value = arg.startsWith('--root=') ? arg.slice('--root='.length) : args[++index];
@@ -65,7 +71,7 @@ function parseArgs(args = []) {
     throw new Error(`unknown founder option: ${arg}`);
   }
 
-  return { help: false, root, days };
+  return { help: false, root, days, json };
 }
 
 function founderNow(env = process.env) {
@@ -272,9 +278,9 @@ function renderFounderScorecard(scorecard) {
 }
 
 function showFounderHelp() {
-  console.log('usage: atris founder [score] [--days n] [--root dir]');
+  console.log('usage: atris founder [score] [--days n] [--root dir] [--json]');
   console.log('shows the last 7 days against the prior 7 days from git and task receipts.');
-  console.log('supported flags: --days, --root, --help, -h');
+  console.log('supported flags: --days, --root, --json, --help, -h');
 }
 
 function founderCommand(args = [], options = {}) {
@@ -283,7 +289,7 @@ function founderCommand(args = [], options = {}) {
     parsed = parseArgs(args);
   } catch (error) {
     console.error(`error: ${error.message}`);
-    console.error('supported flags: --days, --root, --help, -h');
+    console.error('supported flags: --days, --root, --json, --help, -h');
     return 2;
   }
   if (parsed.help) {
@@ -299,7 +305,11 @@ function founderCommand(args = [], options = {}) {
   const now = founderNow(options.env || process.env);
   const scorecard = buildFounderScorecard(root, { days: parsed.days, now });
   appendFounderScorecard(currentWorkspace, scorecard);
-  console.log(renderFounderScorecard(scorecard));
+  if (parsed.json) {
+    console.log(JSON.stringify(scorecard, null, 2));
+  } else {
+    console.log(renderFounderScorecard(scorecard));
+  }
   return 0;
 }
 

--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -228,7 +228,8 @@ function formatCalendarTimeRange(event) {
 
 function formatCalendarEvents(label, events) {
   if (events.length === 0) {
-    console.log(`No events ${label}. 🎉`);
+    // label is already a phrase like "today's events" or "events on 2026-08-24"
+    console.log(`No ${label}.`);
     return;
   }
 
@@ -1665,6 +1666,7 @@ module.exports = {
   integrationsStatus,
   parseCalendarSearchArgs,
   filterCalendarEventsForSearch,
+  formatCalendarEvents,
   formatCalendarSearchResults,
   formatCalendarSearchError,
 };

--- a/commands/review.js
+++ b/commands/review.js
@@ -30,24 +30,19 @@ function findReviewEngine() {
 }
 
 function printMissingReviewEngine(jsonMode) {
+  const install = 'atris skill install code-review';
   if (jsonMode) {
     console.log(JSON.stringify({
       ok: false,
-      error: 'Review engine not found.',
+      error: 'not installed',
       expected: 'atris/business/claude-code-review/workspace/review_engine.py',
       specialists: ['Security', 'Testing', 'Performance', 'Maintainability', 'Database', 'Async'],
-      install: 'copy review_engine.py to your project',
+      install,
     }, null, 2));
   } else {
-    console.error('Review engine not found.');
-    console.error('Expected at: atris/business/claude-code-review/workspace/review_engine.py');
-    console.error('');
-    console.error('The review engine runs 6 specialists:');
-    console.error('  Security, Testing, Performance, Maintainability, Database, Async');
-    console.error('');
-    console.error('Install: copy review_engine.py to your project');
+    console.error(`not installed; ${install}`);
   }
-  process.exit(1);
+  process.exit(2);
 }
 
 function exitReviewError(message, jsonMode, extra = {}) {

--- a/commands/task.js
+++ b/commands/task.js
@@ -10,17 +10,14 @@ const path = require('path');
 const os = require('os');
 const { hasFlag } = require('../lib/arg-parser');
 const {
-<<<<<<< HEAD
-  taskProofState,
-  LOCAL_SUCCESS_PROOF_EXAMPLE,
-} = require('../lib/task-proof');
-=======
   compactErrorPayload,
   compactSuccessPayload,
   printCliJson,
 } = require('../lib/cli-json');
-const { taskProofState } = require('../lib/task-proof');
->>>>>>> e99f5d93 (fix(cli): dogfood pass-2 items 16-19 for headless agents)
+const {
+  taskProofState,
+  LOCAL_SUCCESS_PROOF_EXAMPLE,
+} = require('../lib/task-proof');
 const {
   candidatePolicyGate,
   evaluateAutoAccept,

--- a/commands/xp.js
+++ b/commands/xp.js
@@ -112,6 +112,7 @@ function showHelp() {
   console.log('       atris xp [--json] [--local] [--workspace <path>] [--operator <name>]');
   console.log('');
   console.log('Show your AgentXP graph for the active Atris account.');
+  console.log('With no bound business (.atris/business.json), defaults to --local workspace receipts.');
   console.log('Use status to show account-level AgentXP across verified local ledgers.');
   console.log('Use collect or status --local to project accepted task proof in the current workspace.');
   console.log('Use session to encapsulate the current work window into a local XP capsule.');
@@ -2327,7 +2328,10 @@ async function xpCommand(...args) {
   }
 
   const jsonMode = args.includes('--json');
-  const localMode = hasFlagOrValue(args, '--local') || hasFlagOrValue(args, '--workspace') || hasFlagOrValue(args, '--operator');
+  const explicitLocal = hasFlagOrValue(args, '--local') || hasFlagOrValue(args, '--workspace') || hasFlagOrValue(args, '--operator');
+  // No bound business means cloud graph has nothing useful; default to local receipts.
+  const boundBusiness = publicWorkspaceBinding(defaultXpWorkspace());
+  const localMode = explicitLocal || !boundBusiness;
   if (localMode) {
     let payload;
     try {

--- a/test/code-review.test.js
+++ b/test/code-review.test.js
@@ -23,14 +23,14 @@ test('code-review --json missing engine returns JSON error', () => {
   const dir = makeTempDir();
   try {
     const result = runCli(['code-review', '--json'], dir);
-    assert.equal(result.status, 1);
+    assert.equal(result.status, 2);
     assert.equal(result.stderr, '');
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: false,
-      error: 'Review engine not found.',
+      error: 'not installed',
       expected: 'atris/business/claude-code-review/workspace/review_engine.py',
       specialists: ['Security', 'Testing', 'Performance', 'Maintainability', 'Database', 'Async'],
-      install: 'copy review_engine.py to your project',
+      install: 'atris skill install code-review',
     });
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -41,10 +41,10 @@ test('code-review missing engine keeps human stderr', () => {
   const dir = makeTempDir();
   try {
     const result = runCli(['code-review', 'example.py'], dir);
-    assert.equal(result.status, 1);
+    assert.equal(result.status, 2);
     assert.equal(result.stdout, '');
-    assert.match(result.stderr, /Review engine not found/);
-    assert.match(result.stderr, /copy review_engine\.py to your project/);
+    assert.match(result.stderr, /not installed; atris skill install code-review/);
+    assert.doesNotMatch(result.stderr, /Traceback|Error:/);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/dogfood-pass2.test.js
+++ b/test/dogfood-pass2.test.js
@@ -204,8 +204,11 @@ test('18: close with no args exits 2; sign status when off exits 0', () => {
     assert.match(sign.stdout, /co-author is off/i);
 
     const founder = runCli(['founder', '--json'], { cwd: dir });
-    assert.equal(founder.status, 2, founder.stdout + founder.stderr);
-    assert.match(founder.stderr, /supported flags/i);
+    assert.equal(founder.status, 0, founder.stdout + founder.stderr);
+    const founderBody = JSON.parse(founder.stdout);
+    assert.equal(typeof founderBody.commitsThisWeek, 'number');
+    assert.equal(typeof founderBody.slopePct, 'number');
+    assert.ok(Array.isArray(founderBody.perRepo));
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/dogfood-t6-t10.test.js
+++ b/test/dogfood-t6-t10.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { scrubAgentEnv } = require('./helpers/agent-env');
+const { formatCalendarEvents } = require('../commands/integrations');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+const TIMEOUT_MS = 20000;
+
+function makeTempDir(prefix = 'atris-dogfood-t6-t10-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupTempDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function runCli(args, { cwd, env, timeout = TIMEOUT_MS } = {}) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout,
+    env: {
+      ...scrubAgentEnv(),
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ...(env || {}),
+    },
+  });
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    assert.fail(`cli hung past ${timeout}ms (args: ${args.join(' ')})`);
+  }
+  if (result.error) throw result.error;
+  return result;
+}
+
+test('T6: code-review missing engine says not installed and exits 2', () => {
+  const dir = makeTempDir();
+  try {
+    const human = runCli(['code-review', 'example.py'], { cwd: dir });
+    assert.equal(human.status, 2);
+    assert.match(human.stderr, /not installed; atris skill install code-review/);
+    assert.doesNotMatch(human.stderr + human.stdout, /Traceback/);
+
+    const json = runCli(['code-review', '--json'], { cwd: dir });
+    assert.equal(json.status, 2);
+    const body = JSON.parse(json.stdout);
+    assert.equal(body.ok, false);
+    assert.equal(body.error, 'not installed');
+    assert.match(body.install, /atris skill install code-review/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('T7: xp defaults to --local when no bound business', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, '.atris', 'state'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.atris', 'state', 'task_episodes.jsonl'), '');
+    // Fake login so the old cloud path would otherwise try the network.
+    const home = path.join(dir, 'home');
+    fs.mkdirSync(path.join(home, '.atris'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.atris', 'credentials.json'), JSON.stringify({
+      token: 'fake-token',
+      email: 'dogfood@example.com',
+    }));
+
+    const result = runCli(['xp', '--json'], {
+      cwd: dir,
+      env: { HOME: home, ATRIS_HOME: home },
+    });
+    assert.equal(result.status, 0, result.stderr + result.stdout);
+    const body = JSON.parse(result.stdout);
+    assert.equal(body.schema, 'atris.career_xp_projection.v1');
+    assert.doesNotMatch(result.stderr, /Failed to load XP graph|404/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('T7: xp still uses cloud path when business is bound and --local is absent', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, '.atris'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.atris', 'business.json'), JSON.stringify({
+      business_id: 'biz_dogfood',
+      slug: 'dogfood-co',
+    }));
+    const result = runCli(['xp'], { cwd: dir });
+    // No credentials + bound business -> login hint (cloud path), not silent local.
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Not logged in|login|--local/i);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('T8: calendar empty-day copy is a real sentence', () => {
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    formatCalendarEvents("today's events", []);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.deepEqual(lines, ["No today's events."]);
+  assert.doesNotMatch(lines.join('\n'), /No events today's events/);
+});
+
+test('T9: top-level lesson help matches real argv; lesson --help prints schema', () => {
+  const help = runCli(['help', '--all']);
+  assert.equal(help.status, 0, help.stderr);
+  assert.match(help.stdout, /lesson\s+- atris lesson add <slug> <pass\|fail>/);
+  assert.doesNotMatch(help.stdout, /Append a one-line lesson/);
+
+  const lessonHelp = runCli(['lesson', '--help']);
+  assert.equal(lessonHelp.status, 0, lessonHelp.stderr);
+  assert.match(lessonHelp.stdout, /Usage: atris lesson add <slug> <pass\|fail>/);
+  assert.match(lessonHelp.stdout, /lesson mine/);
+  assert.match(lessonHelp.stdout, /lesson ledger/);
+});
+
+test('T10: founder --json emits JSON scorecard', () => {
+  const dir = makeTempDir();
+  try {
+    const run = runCli(['founder', '--json', '--root', dir], {
+      cwd: dir,
+      env: { ATRIS_FOUNDER_NOW: '2026-08-10T08:00:00.000Z' },
+    });
+    assert.equal(run.status, 0, run.stderr + run.stdout);
+    const body = JSON.parse(run.stdout);
+    assert.equal(typeof body.commitsThisWeek, 'number');
+    assert.equal(typeof body.commitsLastWeek, 'number');
+    assert.equal(typeof body.slopePct, 'number');
+    assert.ok(Array.isArray(body.perRepo));
+  } finally {
+    cleanupTempDir(dir);
+  }
+});

--- a/test/founder.test.js
+++ b/test/founder.test.js
@@ -169,3 +169,18 @@ test('malformed task data is treated as unavailable', () => {
     fs.rmSync(fixtureRoot, { recursive: true, force: true });
   }
 });
+
+test('founder --json emits a parseable scorecard', () => {
+  const { fixtureRoot, scanRoot } = makeFixture();
+  try {
+    const alpha = initRepo(scanRoot, 'alpha');
+    commitAt(alpha, '2026-08-06T12:00:00Z', 'one current commit');
+    const run = runFounder(alpha, ['--json', '--root', scanRoot], '2026-08-07T12:00:00Z');
+    assert.equal(run.status, 0, run.stderr);
+    const body = JSON.parse(run.stdout);
+    assert.equal(body.commitsThisWeek, 1);
+    assert.ok(Array.isArray(body.perRepo));
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Five small dogfood papercuts from pass 2 (2026-08-24), plus a merge-marker unblock in `commands/task.js` that broke `atris task` on master.

| Item | Fix |
|------|-----|
| T6 `code-review` | Missing Python engine prints `not installed; atris skill install code-review` and exits 2 (no stack). JSON path matches. |
| T7 `xp` | Defaults to `--local` when `.atris/business.json` has no bound business. Bound workspaces still try cloud. |
| T8 `calendar today` | Empty day prints `No today's events.` instead of `No events today's events.` Exit 0 unchanged. |
| T9 `lesson` help | Top-level help one-liner matches `lesson add <slug> <pass\|fail>`. `lesson --help` already prints the schema. |
| T10 `founder --json` | Honors `--json` with a scorecard payload (was unknown option / then reject). |

Also resolves leftover `<<<<<<<` conflict markers in `commands/task.js` from the prior pass-2 merge so the CLI can load again.

## Proof

```bash
node --test test/dogfood-t6-t10.test.js test/code-review.test.js test/founder.test.js test/dogfood-pass2.test.js test/calendar-search.test.js
```

28/28 pass.

Ready to squash-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-172f7329-afc7-492d-8e20-52fcb67f3637?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-172f7329-afc7-492d-8e20-52fcb67f3637&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

