### PR TITLE
fix(cli): dogfood pass-3 items 27-28 truth/study and social leaks

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -132,6 +132,10 @@ rg "addTask|claimTask|doneTask|appendTaskCompletionLogs|listTasks|workspaceRoot"
 rg "missionBlockerTitle|missionXpTaskTitle|Mission XP" lib/self-drive.js commands/mission.js commands/task.js test/self-drive.test.js test/mission-xp.test.js  # Mission-generated task titles stay short and plain while full context remains in task metadata and dialogue
 rg "codexGoalCommand|completed_task_closed|thread_goals" commands/codex-goal.js commands/mission.js test/codex-goal.test.js test/mission-status.test.js  # Native Codex goal boundary: read-only status, completed-task reset refusal, and scheduled-loop stop
 rg "integrationsStatus|--global|scope: 'workspace'" bin/atris.js commands/integrations.js test/dogfood-p1.test.js # Integrations default workspace; --global for account hosts
+rg "requireAccountBound|refuseAccountGlobal|ACCOUNT_GLOBAL_MESSAGE|isBoundBusinessWorkspace" lib/account-bound.js bin/atris.js test/dogfood-pass3-27-28.test.js # Unbound folders refuse account-global inbox/gmail/slack/errors; pass --account
+rg "truthCommand|loadWorkspaceLoops|loadHeartbeats|--global" commands/truth.js lib/cli-scope.js test/dogfood-pass3-27-28.test.js test/truth.test.js # truth loops from atris/loops; --global for machine heartbeats
+rg "resolveStudyRoot|ATRIS_STUDY_ROOT|not installed" commands/study.js test/dogfood-pass3-27-28.test.js # study resolves via env / atris/study / not installed (no personal path)
+rg "wantsLocal|errors --account|--approved|twitter post|slack send" commands/errors.js commands/integrations.js test/dogfood-pass3-27-28.test.js # errors --local by default; twitter/slack send need --approved
 rg "ciCommand|runnerAssetName|buildJitConfigRequest|parseRunnerMarker|runJobLoop|runCiRunner|summarizeUsage" bin/atris.js commands/ci.js lib/ci-runner.js lib/known-commands.js test/ci.test.js # Self-hosted GitHub Actions runner: offline argument and asset selection, per-version local cache, concurrent per-repo job loops with isolated warm work folders, marker-based job-time and result metering, and a per-repo build-minute view
 rg "githubCommand|createOfficialCliCommand|github cli wrapper|github help is workspace-free" bin/atris.js commands/github.js lib/official-cli-integration.js test/official-cli-integrations.test.js # github official cli wrapper: gh binary/auth detection plus pr list/create/checks/view passthrough
 rg "vercelCommand|vercel cli wrapper|vercel help is workspace-free" bin/atris.js commands/vercel.js test/official-cli-integrations.test.js # vercel official cli wrapper: vercel binary/auth detection plus deploy/ls/logs/inspect passthrough
@@ -1460,7 +1464,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - **Regression:** `test/commands.test.js:4279-4294` covers integrations help without login errors or `.atris` creation
 - **Value:** Manage external services without leaving the CLI
 
-**Search:** `rg "gmailCommand|calendarCommand|twitterCommand|slackCommand|integrationsStatus|showIntegrationsHelp|integrations --help" bin/atris.js commands/integrations.js test/commands.test.js`
+**Search:** `rg "gmailCommand|calendarCommand|twitterCommand|slackCommand|integrationsStatus|showIntegrationsHelp|integrations --help|--approved|requireAccountBound" bin/atris.js commands/integrations.js lib/account-bound.js test/commands.test.js test/dogfood-pass3-27-28.test.js`
 
 ### Feature: State Detection
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -46,6 +46,10 @@ const {
 // State detection for smart default
 const { detectWorkspaceState, loadContext } = require('../lib/state-detection');
 const {
+  requireAccountBound,
+  refuseAccountGlobal,
+} = require('../lib/account-bound');
+const {
   saveContextProfile,
   createStarterTask,
   shouldGatherContext,
@@ -2041,7 +2045,7 @@ if (command === 'init') {
 } else if (command === 'truth') {
   // Truth: one table rolling up mission state, tasks, feature proof receipts, and loop heartbeats.
   Promise.resolve(require('../commands/truth').truthCommand(process.argv.slice(3)))
-    .then((code) => process.exit(code || 0))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'codex-goal') {
   Promise.resolve(require('../commands/codex-goal').codexGoalCommand(process.argv.slice(3)))
@@ -2752,12 +2756,18 @@ if (command === 'init') {
   const status = require('../commands/stripe').stripeCommand(process.argv.slice(3));
   process.exit(status);
 } else if (command === 'gmail') {
-  const { gmailCommand } = require('../commands/integrations');
-  const subcommand = process.argv[3];
-  const args = process.argv.slice(4);
-  gmailCommand(subcommand, ...args)
-    .then(() => process.exit(0))
-    .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  {
+    const raw = process.argv.slice(3);
+    const helpOnly = raw.length === 0 || raw.includes('--help') || raw.includes('-h') || raw[0] === 'help';
+    const gate = helpOnly ? { ok: true, args: raw } : requireAccountBound(raw);
+    if (!gate.ok) process.exit(refuseAccountGlobal());
+    const { gmailCommand } = require('../commands/integrations');
+    const subcommand = gate.args[0];
+    const args = gate.args.slice(1);
+    gmailCommand(subcommand, ...args)
+      .then(() => process.exit(0))
+      .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  }
 } else if (command === 'calendar') {
   const { calendarCommand } = require('../commands/integrations');
   const subcommand = process.argv[3];
@@ -2766,19 +2776,31 @@ if (command === 'init') {
     .then(() => process.exit(0))
     .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'twitter') {
-  const { twitterCommand } = require('../commands/integrations');
-  const subcommand = process.argv[3];
-  const args = process.argv.slice(4);
-  twitterCommand(subcommand, ...args)
-    .then(() => process.exit(0))
-    .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  {
+    const raw = process.argv.slice(3);
+    const helpOnly = raw.length === 0 || raw.includes('--help') || raw.includes('-h') || raw[0] === 'help';
+    const gate = helpOnly ? { ok: true, args: raw } : requireAccountBound(raw);
+    if (!gate.ok) process.exit(refuseAccountGlobal());
+    const { twitterCommand } = require('../commands/integrations');
+    const subcommand = gate.args[0];
+    const args = gate.args.slice(1);
+    twitterCommand(subcommand, ...args)
+      .then(() => process.exit(0))
+      .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  }
 } else if (command === 'slack') {
-  const { slackCommand } = require('../commands/integrations');
-  const subcommand = process.argv[3];
-  const args = process.argv.slice(4);
-  slackCommand(subcommand, ...args)
-    .then(() => process.exit(0))
-    .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  {
+    const raw = process.argv.slice(3);
+    const helpOnly = raw.length === 0 || raw.includes('--help') || raw.includes('-h') || raw[0] === 'help';
+    const gate = helpOnly ? { ok: true, args: raw } : requireAccountBound(raw);
+    if (!gate.ok) process.exit(refuseAccountGlobal());
+    const { slackCommand } = require('../commands/integrations');
+    const subcommand = gate.args[0];
+    const args = gate.args.slice(1);
+    slackCommand(subcommand, ...args)
+      .then(() => process.exit(0))
+      .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  }
 } else if (command === 'imessage') {
   const { imessageCommand } = require('../commands/integrations');
   const subcommand = process.argv[3];
@@ -3113,9 +3135,16 @@ if (command === 'init') {
     .then(() => process.exit(0))
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'errors') {
-  require('../commands/errors').errorsCommand()
-    .then(() => process.exit(0))
-    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+  {
+    const gate = requireAccountBound(process.argv.slice(3));
+    if (!gate.ok) process.exit(refuseAccountGlobal());
+    // Keep --account so errors can default to --local inside bound workspaces.
+    const errorArgs = gate.account ? ['--account', ...gate.args] : gate.args;
+    process.argv = [process.argv[0], process.argv[1], 'errors', ...errorArgs];
+    require('../commands/errors').errorsCommand()
+      .then(() => process.exit(0))
+      .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  }
 } else if (command === 'social') {
   require('../commands/social').socialCommand()
     .then(() => process.exit(0))
@@ -3141,9 +3170,14 @@ if (command === 'init') {
     .then(() => process.exit(0))
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'inbox') {
-  require('../commands/social').inboxCommand()
-    .then(() => process.exit(0))
-    .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
+  {
+    const gate = requireAccountBound(process.argv.slice(3));
+    if (!gate.ok) process.exit(refuseAccountGlobal());
+    process.argv = [process.argv[0], process.argv[1], 'inbox', ...gate.args];
+    require('../commands/social').inboxCommand()
+      .then(() => process.exit(0))
+      .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
+  }
 } else if (command === 'join') {
   require('../commands/social').joinCommand()
     .then(() => process.exit(0))

--- a/commands/errors.js
+++ b/commands/errors.js
@@ -2,14 +2,18 @@
  * Errors command for Atris CLI — admin dashboard over atris_error_events.
  *
  * Usage:
- *   atris errors                      List errors from last 24h, grouped by signature
+ *   atris errors                      Local-only by default (no cloud dump)
+ *   atris errors --account            List cloud errors from last 24h
  *   atris errors --hours 72           Widen the window (max 720h / 30d)
  *   atris errors --limit 1000         Raise the raw-event cap for grouping
  *   atris errors show <id>            Full detail (stack trace, message) for one event
  *
- * Requires admin role on the user row.
+ * Requires admin role on the user row for cloud reads.
+ * Account gate: unbound folders need --account (see lib/account-bound.js).
  */
 
+const fs = require('fs');
+const path = require('path');
 const { loadCredentials } = require('../utils/auth');
 const { apiRequestJson } = require('../utils/api');
 
@@ -38,12 +42,55 @@ function extractFlag(args, ...names) {
   return [value, remaining];
 }
 
+function wantsLocal(args) {
+  if (args.includes('--account') || args.includes('--cloud')) return false;
+  // --local is the default; keep the flag recognized for explicit callers.
+  return true;
+}
+
+function listLocalErrors(json) {
+  const localPath = path.join(process.cwd(), '.atris', 'state', 'errors.jsonl');
+  const rows = [];
+  if (fs.existsSync(localPath)) {
+    for (const line of fs.readFileSync(localPath, 'utf8').split('\n')) {
+      if (!line.trim()) continue;
+      try { rows.push(JSON.parse(line)); } catch { /* skip */ }
+    }
+  }
+
+  if (json) {
+    console.log(JSON.stringify({
+      ok: true,
+      scope: 'local',
+      total_events: rows.length,
+      groups: [],
+      note: 'local scope. pass --account for cloud error events.',
+    }, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log('No local errors. Pass --account for cloud error events.');
+    return;
+  }
+
+  console.log(`Local errors (${rows.length}). Pass --account for cloud error events.\n`);
+  for (const row of rows.slice(0, 20)) {
+    console.log(`  ${row.message || row.error || JSON.stringify(row)}`);
+  }
+}
+
 async function listErrors(args) {
   const [hoursArg, r1] = extractFlag(args, '--hours', '-H');
   const [limitArg, r2] = extractFlag(r1, '--limit', '-L');
   const json = r2.includes('--json');
   const hours = hoursArg ? parseInt(hoursArg, 10) : 24;
   const limit = limitArg ? parseInt(limitArg, 10) : 500;
+
+  if (wantsLocal(r2)) {
+    listLocalErrors(json);
+    return;
+  }
 
   const token = getToken();
   const result = await apiRequestJson(`/errors?hours=${hours}&limit=${limit}`, {
@@ -64,7 +111,7 @@ async function listErrors(args) {
   const groups = data.groups || [];
 
   if (json) {
-    console.log(JSON.stringify({ ok: true, ...data }, null, 2));
+    console.log(JSON.stringify({ ok: true, scope: 'account', ...data }, null, 2));
     return;
   }
 
@@ -136,12 +183,13 @@ async function showError(errorId) {
 function printHelp() {
   console.log('');
   console.log('Usage:');
-  console.log('  atris errors                         List errors from last 24h, grouped');
-  console.log('  atris errors --hours 72              Widen the window (max 720h / 30d)');
-  console.log('  atris errors --limit 1000            Raise the raw-event cap');
-  console.log('  atris errors show <full-uuid>        Full detail for one event');
+  console.log('  atris errors                         Local errors (default; no cloud dump)');
+  console.log('  atris errors --account               List cloud errors from last 24h');
+  console.log('  atris errors --account --hours 72    Widen the cloud window (max 720h / 30d)');
+  console.log('  atris errors --account --limit 1000  Raise the raw-event cap');
+  console.log('  atris errors show <full-uuid>        Full detail for one cloud event');
   console.log('');
-  console.log('Admin role required.');
+  console.log('Admin role required for cloud reads. Unbound folders need --account.');
   console.log('');
 }
 
@@ -155,6 +203,8 @@ async function errorsCommand() {
   }
 
   if (sub === 'show') {
+    // show is account-scoped detail; require explicit --account in the remaining args
+    // or that the caller already passed the account gate from a bound workspace.
     await showError(args[1]);
     return;
   }

--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -600,7 +600,15 @@ async function calendarCommand(subcommand, ...args) {
 // ============================================================================
 
 async function twitterPost(args = []) {
-  const outbound = prepareOutboundSendTextOrExit('twitter', args);
+  const approved = args.includes('--approved') || args.includes('--confirm-approved');
+  const cleaned = args.filter((a) => a !== '--approved' && a !== '--confirm-approved');
+  if (!approved) {
+    console.error('Refusing to post without --approved after the exact text is confirmed.');
+    console.error('Usage: atris twitter post "<text>" --approved');
+    process.exit(2);
+  }
+
+  const outbound = prepareOutboundSendTextOrExit('twitter', cleaned);
   let text = outbound.body;
   if (!text) {
     const readline = require('readline');
@@ -659,7 +667,7 @@ async function twitterCommand(subcommand, ...args) {
       break;
     default:
       console.log('Twitter commands:');
-      console.log('  atris twitter post [text]  - Post a tweet');
+      console.log('  atris twitter post "<text>" --approved  - Post a tweet');
   }
 }
 
@@ -835,9 +843,16 @@ async function slackSearch(query, args = []) {
 
 async function slackSend(channel, textParts) {
   const target = String(channel || '').trim();
-  const text = prepareOutboundSendTextOrExit('slack', textParts).body;
+  const approved = (textParts || []).includes('--approved') || (textParts || []).includes('--confirm-approved');
+  const cleaned = (textParts || []).filter((a) => a !== '--approved' && a !== '--confirm-approved');
+  if (!approved) {
+    console.error('Refusing to send without --approved after the exact channel and exact text are confirmed.');
+    console.error('Usage: atris slack send <channel> "<message>" --approved');
+    process.exit(2);
+  }
+  const text = prepareOutboundSendTextOrExit('slack', cleaned).body;
   if (!target || !text) {
-    console.error('Usage: atris slack send <channel> "<message>"');
+    console.error('Usage: atris slack send <channel> "<message>" --approved');
     process.exit(1);
   }
 
@@ -861,9 +876,16 @@ async function slackSend(channel, textParts) {
 
 async function slackDm(userId, textParts) {
   const target = String(userId || '').trim();
-  const text = prepareOutboundSendTextOrExit('slack', textParts).body;
+  const approved = (textParts || []).includes('--approved') || (textParts || []).includes('--confirm-approved');
+  const cleaned = (textParts || []).filter((a) => a !== '--approved' && a !== '--confirm-approved');
+  if (!approved) {
+    console.error('Refusing to send without --approved after the exact recipient and exact text are confirmed.');
+    console.error('Usage: atris slack dm <slack_user_id> "<message>" --approved');
+    process.exit(2);
+  }
+  const text = prepareOutboundSendTextOrExit('slack', cleaned).body;
   if (!target || !text) {
-    console.error('Usage: atris slack dm <slack_user_id> "<message>"');
+    console.error('Usage: atris slack dm <slack_user_id> "<message>" --approved');
     process.exit(1);
   }
 
@@ -913,8 +935,8 @@ async function slackCommand(subcommand, ...args) {
       console.log('  atris slack dms                  - List Slack DMs');
       console.log('  atris slack messages <channel>   - Read recent messages');
       console.log('  atris slack search <query>       - Search Slack messages');
-      console.log('  atris slack send <channel> "<message>" - Send a message as you');
-      console.log('  atris slack dm <user_id> "<message>"   - DM someone as you');
+      console.log('  atris slack send <channel> "<message>" --approved - Send a message as you');
+      console.log('  atris slack dm <user_id> "<message>" --approved   - DM someone as you');
   }
 }
 

--- a/commands/study.js
+++ b/commands/study.js
@@ -16,7 +16,6 @@ const path = require('path');
 const http = require('http');
 const { spawn, spawnSync } = require('child_process');
 
-const BACKEND_ROOT = '/Users/keshavrao/arena/atrisos-backend';
 const FEED_URL = 'http://localhost:8777';
 const FEED_STATS_URL = `${FEED_URL}/api/stats`;
 const FEED_NEXT_URL = `${FEED_URL}/api/next`;
@@ -91,18 +90,31 @@ function parseArgs(argv = []) {
   return opts;
 }
 
+function resolveStudyRoot(cwd = process.cwd()) {
+  const candidates = [
+    process.env.ATRIS_STUDY_ROOT,
+    process.env.ATRIS_BACKEND_ROOT,
+    path.join(path.resolve(cwd), 'atris', 'study'),
+  ].filter(Boolean);
+  for (const root of candidates) {
+    const resolved = path.resolve(String(root));
+    if (fs.existsSync(resolved)) return resolved;
+  }
+  return null;
+}
+
 function requireBackend() {
-  if (!fs.existsSync(BACKEND_ROOT)) {
-    console.error(`✗ Backend repo not found: ${BACKEND_ROOT}`);
-    process.exit(1);
+  const backendRoot = resolveStudyRoot();
+  if (!backendRoot) {
+    console.error('not installed');
+    process.exit(2);
   }
-  const venvPython = path.join(BACKEND_ROOT, 'venv/bin/python');
+  const venvPython = path.join(backendRoot, 'venv/bin/python');
   if (!fs.existsSync(venvPython)) {
-    console.error(`✗ Backend venv not found: ${venvPython}`);
-    console.error('  Create the venv in atrisos-backend before running atris study.');
-    process.exit(1);
+    console.error('not installed');
+    process.exit(2);
   }
-  return venvPython;
+  return { venvPython, backendRoot };
 }
 
 function detectLanguage(topic) {
@@ -608,11 +620,11 @@ async function runWhileMode(opts) {
   const topic = opts.topic;
 
   if (topic) {
-    const venvPython = requireBackend();
+    const { venvPython, backendRoot } = requireBackend();
     const language = detectLanguage(topic);
-    if (language) printTutorLoopBlock(BACKEND_ROOT, language);
+    if (language) printTutorLoopBlock(backendRoot, language);
     try {
-      await runIngest(venvPython, BACKEND_ROOT, topic, opts.personal);
+      await runIngest(venvPython, backendRoot, topic, opts.personal);
     } catch (err) {
       console.error(`\n✗ ${err.message || err}`);
     }
@@ -625,9 +637,10 @@ async function runWhileMode(opts) {
   let statsAvailable = false;
   let useCards = false;
 
-  if (fs.existsSync(BACKEND_ROOT) && fs.existsSync(path.join(BACKEND_ROOT, 'venv/bin/python'))) {
-    const venvPython = path.join(BACKEND_ROOT, 'venv/bin/python');
-    statsAvailable = await tryEnsureFeedServerSilent(venvPython, BACKEND_ROOT);
+  const studyRoot = resolveStudyRoot();
+  if (studyRoot && fs.existsSync(path.join(studyRoot, 'venv/bin/python'))) {
+    const venvPython = path.join(studyRoot, 'venv/bin/python');
+    statsAvailable = await tryEnsureFeedServerSilent(venvPython, studyRoot);
     useCards = statsAvailable;
   }
 
@@ -663,21 +676,21 @@ async function run(argv = []) {
     return 0;
   }
 
-  const venvPython = requireBackend();
+  const { venvPython, backendRoot } = requireBackend();
   const language = detectLanguage(opts.topic);
 
   if (language) {
-    printTutorLoopBlock(BACKEND_ROOT, language);
+    printTutorLoopBlock(backendRoot, language);
   }
 
   try {
-    await runIngest(venvPython, BACKEND_ROOT, opts.topic, opts.personal);
+    await runIngest(venvPython, backendRoot, opts.topic, opts.personal);
   } catch (err) {
     console.error(`\n✗ ${err.message || err}`);
     return 1;
   }
 
-  await ensureFeedServer(venvPython, BACKEND_ROOT);
+  await ensureFeedServer(venvPython, backendRoot);
   openFeed();
   return 0;
 }
@@ -687,4 +700,5 @@ module.exports = {
   parseArgs,
   showHelp,
   wrapText,
+  resolveStudyRoot,
 };

--- a/commands/truth.js
+++ b/commands/truth.js
@@ -3,13 +3,18 @@
 //   1. .atris/state/missions.jsonl        — mission states (dedupe by id, latest wins)
 //   2. ~/.atris/tasks.db                  — task counts by status, scoped to this workspace unless --all is passed
 //   3. atris/features/*/                  — validate.md frontmatter + newest proof/ receipt age
-//   4. ~/.atris/heartbeat/{registry,state}.json — declared loops vs last_run / fails
+//   4. atris/loops/*.md                   — workspace loops by default; pass --global for ~/.atris/heartbeat
 
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
 const taskDb = require('../lib/task-db');
+const { parseScopeFlag } = require('../lib/cli-scope');
+const {
+  requireAccountBound,
+  refuseAccountGlobal,
+} = require('../lib/account-bound');
 
 const STALE_DAYS = 7;
 
@@ -186,20 +191,61 @@ function loadHeartbeats() {
   });
 }
 
+// Workspace loops live in atris/loops/*.md (not ~/.atris/heartbeat).
+function loadWorkspaceLoops(cwd) {
+  const dir = path.join(cwd, 'atris', 'loops');
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const name of fs.readdirSync(dir).sort()) {
+    if (!name.endsWith('.md') || name === 'LOOPS.md' || name === 'TICK.md') continue;
+    const filePath = path.join(dir, name);
+    let text = '';
+    try { text = fs.readFileSync(filePath, 'utf8'); } catch { continue; }
+    const logDates = [...text.matchAll(/^- (\d{4}-\d{2}-\d{2}):/gm)].map((m) => m[1]).sort();
+    let verdict;
+    let lastRunAgeDays = null;
+    if (logDates.length === 0) {
+      verdict = 'never-ran';
+    } else {
+      const newest = logDates[logDates.length - 1];
+      lastRunAgeDays = daysAgo(Date.parse(`${newest}T00:00:00Z`));
+      if (lastRunAgeDays != null && lastRunAgeDays > STALE_DAYS) verdict = 'stale';
+      else verdict = 'proven';
+    }
+    out.push({
+      id: name.replace(/\.md$/, ''),
+      verdict,
+      lastRunAgeDays,
+      fails: 0,
+    });
+  }
+  return out;
+}
+
 function truthCommand(args = []) {
   const cwd = process.cwd();
-  const json = args.includes('--json');
-  const summary = args.includes('--summary');
-  const all = args.includes('--all');
+  const scopeFlag = parseScopeFlag(args);
+  const rest = scopeFlag.args;
+  const json = rest.includes('--json') || args.includes('--json');
+  const summary = rest.includes('--summary') || args.includes('--summary');
+  const all = rest.includes('--all') || args.includes('--all');
+  const hasAtris = fs.existsSync(path.join(cwd, 'atris'));
+
+  // Unbound scratch folders must not dump machine-global heartbeats.
+  // A local atris/ tree (or --global / --account) is enough to continue.
+  if (!hasAtris && !scopeFlag.global) {
+    const gate = requireAccountBound(rest);
+    if (!gate.ok) return refuseAccountGlobal();
+  }
 
   const missions = loadMissions(cwd);
   const taskCounts = loadTaskCounts({ cwd, all });
-  const scope = all
+  const scope = all || scopeFlag.global
     ? { kind: 'global' }
     : { kind: 'workspace', workspace_root: taskCounts.workspaceRoot };
   const tasks = taskCounts.counts;
   const features = loadFeatures(cwd);
-  const heartbeats = loadHeartbeats();
+  const heartbeats = scopeFlag.global ? loadHeartbeats() : loadWorkspaceLoops(cwd);
 
   const featureTally = {};
   for (const f of features) featureTally[f.verdict] = (featureTally[f.verdict] || 0) + 1;

--- a/lib/account-bound.js
+++ b/lib/account-bound.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ACCOUNT_GLOBAL_MESSAGE = 'account-global; pass --account to continue';
+
+function isBoundBusinessWorkspace(cwd = process.cwd()) {
+  const root = path.resolve(cwd);
+  return fs.existsSync(path.join(root, '.atris', 'business.json'))
+    && fs.existsSync(path.join(root, 'atris'));
+}
+
+function isHelpArg(arg) {
+  return arg === '--help' || arg === '-h' || arg === 'help';
+}
+
+/**
+ * Account-scoped verbs dump live CRM/cloud state. Outside a bound business
+ * workspace they must opt in with --account. Help always passes.
+ * Returns { ok, args } where args has --account stripped when continuing.
+ */
+function requireAccountBound(args = [], options = {}) {
+  const list = Array.isArray(args) ? [...args] : [];
+  const cwd = options.cwd || process.cwd();
+  if (list.some(isHelpArg)) {
+    return { ok: true, args: list, help: true };
+  }
+  if (isBoundBusinessWorkspace(cwd)) {
+    return { ok: true, args: list.filter((arg) => arg !== '--account'), bound: true };
+  }
+  if (list.includes('--account')) {
+    return { ok: true, args: list.filter((arg) => arg !== '--account'), account: true };
+  }
+  return { ok: false, args: list, message: ACCOUNT_GLOBAL_MESSAGE };
+}
+
+function refuseAccountGlobal(write = console.error) {
+  write(ACCOUNT_GLOBAL_MESSAGE);
+  return 2;
+}
+
+module.exports = {
+  ACCOUNT_GLOBAL_MESSAGE,
+  isBoundBusinessWorkspace,
+  requireAccountBound,
+  refuseAccountGlobal,
+};

--- a/test/dogfood-pass3-27-28.test.js
+++ b/test/dogfood-pass3-27-28.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { scrubAgentEnv } = require('./helpers/agent-env');
+const { ACCOUNT_GLOBAL_MESSAGE } = require('../lib/account-bound');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+const TIMEOUT_MS = 20000;
+
+function makeTempDir(prefix = 'atris-dogfood-27-28-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupTempDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function runCli(args, { cwd, env, timeout = TIMEOUT_MS } = {}) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout,
+    env: {
+      ...scrubAgentEnv(),
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ...(env || {}),
+    },
+  });
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    assert.fail(`cli hung past ${timeout}ms (args: ${args.join(' ')})`);
+  }
+  if (result.error) throw result.error;
+  return result;
+}
+
+test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumping account data', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(path.join(home, '.atris', 'heartbeat'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.atris', 'heartbeat', 'registry.json'), JSON.stringify({
+    jobs: [{ id: 'web-guardian', cadence_minutes: 60 }],
+  }));
+  fs.writeFileSync(path.join(home, '.atris', 'heartbeat', 'state.json'), JSON.stringify({
+    'web-guardian': { last_run: new Date().toISOString(), consecutive_fails: 0 },
+  }));
+  fs.writeFileSync(path.join(home, '.atris', 'credentials.json'), JSON.stringify({
+    token: 'fake-token',
+    email: 'dogfood@example.com',
+  }));
+
+  try {
+    for (const args of [
+      ['inbox'],
+      ['gmail', 'inbox'],
+      ['slack', 'channels'],
+      ['errors', '--json'],
+      ['truth'],
+    ]) {
+      const result = runCli(args, {
+        cwd: dir,
+        env: { HOME: home, ATRIS_HOME: home },
+      });
+      assert.equal(result.status, 2, `${args.join(' ')} status=${result.status}`);
+      const out = `${result.stderr}${result.stdout}`;
+      assert.match(out, /account-global; pass --account to continue/);
+      assert.doesNotMatch(out, /web-guardian|dogfood@example|Conversations|Channels|payroll|502/);
+      assert.equal(out.includes(ACCOUNT_GLOBAL_MESSAGE), true);
+    }
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('27: truth reads atris/loops only; --global unlocks machine heartbeats', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(path.join(dir, 'atris', 'loops'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'atris', 'loops', 'quality.md'), [
+    '# Loop - Quality',
+    '',
+    '**Owner:** `team/validator`',
+    '**Wiki:** [systems/loops.md](../wiki/systems/loops.md)',
+    '**Runner:** `node --test`',
+    '**Protects:** trust',
+    '**Signal (green =):** tests pass',
+    '**Cadence:** per commit',
+    '',
+    '## Log',
+    '',
+    `- ${new Date().toISOString().slice(0, 10)}: workspace loop only`,
+    '',
+  ].join('\n'));
+  fs.mkdirSync(path.join(home, '.atris', 'heartbeat'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.atris', 'heartbeat', 'registry.json'), JSON.stringify({
+    jobs: [{ id: 'youtube-watch-feeder', cadence_minutes: 60 }],
+  }));
+  fs.writeFileSync(path.join(home, '.atris', 'heartbeat', 'state.json'), JSON.stringify({
+    'youtube-watch-feeder': { last_run: new Date().toISOString(), consecutive_fails: 0 },
+  }));
+
+  try {
+    const scoped = runCli(['truth', '--json'], {
+      cwd: dir,
+      env: { HOME: home, ATRIS_HOME: home },
+    });
+    assert.equal(scoped.status, 0, scoped.stderr + scoped.stdout);
+    const scopedBody = JSON.parse(scoped.stdout);
+    assert.equal(scopedBody.scope.kind, 'workspace');
+    const scopedIds = (scopedBody.loop_rows || []).map((row) => row.id);
+    assert.ok(scopedIds.includes('quality'), `expected quality loop, got ${scopedIds}`);
+    assert.ok(!scopedIds.includes('youtube-watch-feeder'), 'machine loop leaked into workspace truth');
+
+    const global = runCli(['truth', '--global', '--json'], {
+      cwd: dir,
+      env: { HOME: home, ATRIS_HOME: home },
+    });
+    assert.equal(global.status, 0, global.stderr + global.stdout);
+    const globalBody = JSON.parse(global.stdout);
+    const globalIds = (globalBody.loop_rows || []).map((row) => row.id);
+    assert.ok(globalIds.includes('youtube-watch-feeder'), `expected machine loop, got ${globalIds}`);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('27: study has no hardcoded personal path and says not installed', () => {
+  const studySrc = fs.readFileSync(path.join(repoRoot, 'commands', 'study.js'), 'utf8');
+  assert.doesNotMatch(studySrc, /\/Users\/keshavrao/);
+
+  const dir = makeTempDir();
+  try {
+    const result = runCli(['study', 'spanish'], { cwd: dir });
+    assert.equal(result.status, 2);
+    assert.match(`${result.stderr}${result.stdout}`, /not installed/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('28: errors defaults to local and does not dump cloud json', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, '.atris'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.atris', 'business.json'), JSON.stringify({
+      business_id: 'biz_dogfood',
+      slug: 'dogfood-co',
+    }));
+
+    const result = runCli(['errors', '--json'], { cwd: dir });
+    assert.equal(result.status, 0, result.stderr + result.stdout);
+    const body = JSON.parse(result.stdout);
+    assert.equal(body.ok, true);
+    assert.equal(body.scope, 'local');
+    assert.doesNotMatch(result.stdout, /business_id|502|uuid/i);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('28: twitter post and slack send require --approved', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, '.atris'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.atris', 'business.json'), JSON.stringify({
+      business_id: 'biz_dogfood',
+      slug: 'dogfood-co',
+    }));
+
+    const twitter = runCli(['twitter', 'post', 'hello world'], { cwd: dir });
+    assert.equal(twitter.status, 2);
+    assert.match(`${twitter.stderr}${twitter.stdout}`, /--approved/);
+
+    const slack = runCli(['slack', 'send', '#general', 'hello'], { cwd: dir });
+    assert.equal(slack.status, 2);
+    assert.match(`${slack.stderr}${slack.stdout}`, /--approved/);
+
+    const help = runCli(['twitter'], { cwd: dir });
+    assert.equal(help.status, 0);
+    assert.match(help.stdout, /--approved/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dogfood pass-3 safety items **27** and **28** (2026-08-24). Stays off items 23-26.

### 27. truth + study no longer leak the operator machine
- `atris truth` reads **this workspace** `atris/loops` by default
- `--global` unlocks machine heartbeats under `~/.atris/heartbeat`
- Unbound scratch folders (no `atris/`) exit 2 with `account-global; pass --account to continue` instead of dumping machine loops
- `atris study` resolves via `$ATRIS_STUDY_ROOT` / `$ATRIS_BACKEND_ROOT` / `./atris/study`, else `not installed` (exit 2). No hardcoded personal path.

### 28. Social + mail + chat refuse in unbound folders
- `inbox` / `gmail` / `slack` / `errors` use the same unbound refuse as the account-global work (`lib/account-bound.js`): exit 2, `account-global; pass --account to continue`
- `errors` is **--local by default** (no cloud dump); pass `--account` for cloud
- `twitter post` and `slack send`/`dm` require `--approved` like imessage

## Proof

```bash
node --test test/dogfood-pass3-27-28.test.js
node --test test/truth.test.js
```

Both green (5 + 3).

## Note

Shares `lib/account-bound.js` with the parallel T1-T5 dogfood PR so either can land first (identical helper).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbb16a50-1844-4c66-9520-c14f92b1873e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbb16a50-1844-4c66-9520-c14f92b1873e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

