### PR TITLE
dogfood: first-minute atris names the next move

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -28,7 +28,7 @@ For details, read `atris/wiki/concepts/owner-computer-model.md` before changing 
 
 ```bash
 # Core CLI logic
-rg "async function interactiveEntry|shouldGatherContext|renderContextGathererPrompt" bin/atris.js lib/context-gatherer.js    # Main entry points: cold-start dispatcher, first-contact context gatherer, legacy natural-language mode
+rg "async function interactiveEntry|shouldGatherContext|renderContextGathererPrompt|buildFirstMinute|shouldAutoInitFresh" bin/atris.js lib/context-gatherer.js lib/first-minute.js    # Main entry points: cold-start dispatcher, first-minute bare atris screen, first-contact context gatherer, legacy natural-language mode
 rg "pickLane|loadOverrides|routerCommand|promotionCandidates|autoLaneForMessage|appendAutoOutcome|modelForMode|buildPayload|connectorTurnPolicy|formatApprovalReceipt|formatTaskPreviewRows|resolveRoute|formatUsage|normalizeChatCommandArgs|CHAT_COMMANDS|filterChatCommands|attachSlashMenu|attachChatCtrlC|runChatSlash|async function chat|postTurn|runAxSpawnCommand|runAxYoutubeCommand|runChatDogfood|extractYoutubeUrl|AX Cloud-First Standard|verify-ax-cloud-standard" ax lib/ax-auto-lane.js commands/router.js test/ax-auto-lane.test.js test/router-promote.test.js test/cli-smoke.test.js test/ax.test.js scripts/verify-ax-cloud-standard.js atris/team/codex-executor/MEMBER.md  # ax Atris2 local coding-agent CLI: deterministic explainable auto lane selection, local outcome traces, reflex overrides, gated promotion, cloud-first by default, explicit --local workspace opt-in, Fast/Pro/Max/Code Fast modes, SSE streaming, workspace_path, readline slash menu and Ctrl-C conventions, chat history, connector turn isolation, Gmail approval previews, doctor/help, durable worker spawn aliases, local YouTube URL routing, and safe 25-loop --dogfood-chat checklist
 rg "atrisFastChat|atrisFastOnce|streamProChat|text_delta|Usage: atris fast" bin/atris.js utils/api.js test/commands.test.js test/api-stream.test.js  # Atris2 Fast one-shot chat CLI and SSE text_delta streaming
 rg "brainstormAtris|Usage: atris brainstorm|brainstorm help|isNonInteractive" commands/brainstorm.js lib/noninteractive.js test/commands.test.js test/dogfood-p0.test.js  # Brainstorm command + workspace-free help; headless captures idea args without prompting
@@ -1506,11 +1506,12 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
-- **Entry point:** `bin/atris.js:1182` (`interactiveEntry`)
+- **Entry point:** `bin/atris.js:1344` (`interactiveEntry`)
+- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`; empty folders name `atris init --minimal`
 - **Helper:** `lib/context-gatherer.js`
 - **State:** `.atris/state/context_profile.json`
-- **Regression:** `test/context-gatherer.test.js`, `test/cli-smoke.test.js`
-- **Search:** `rg "shouldGatherContext|saveContextProfile|createStarterTask|Context gatherer" bin/atris.js lib/context-gatherer.js test`
+- **Regression:** `test/first-minute.test.js`, `test/context-gatherer.test.js`, `test/cli-smoke.test.js`
+- **Search:** `rg "shouldGatherContext|saveContextProfile|createStarterTask|buildFirstMinute|Context gatherer" bin/atris.js lib/context-gatherer.js lib/first-minute.js test`
 
 ---
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -58,6 +58,11 @@ const {
   isAtrisMetaQuestion,
   renderPrompt: renderContextGathererPrompt,
 } = require('../lib/context-gatherer');
+const {
+  buildFirstMinute,
+  isBareAtrisFlag,
+  shouldAutoInitFresh,
+} = require('../lib/first-minute');
 
 // Journal & config utilities (canonical modules)
 const { getLogPath, ensureLogDirectory, createLogFile } = require('../lib/file-ops');
@@ -157,6 +162,9 @@ function parseNaturalEntryArgs(args = []) {
     const value = String(args[i] || '');
     if (value === '--json') {
       asJson = true;
+      continue;
+    }
+    if (value === '--yes' || value === '-y' || value === '--verbose') {
       continue;
     }
     if (isHelpToken(value)) {
@@ -1188,6 +1196,9 @@ if (!command || !knownCommands.includes(command)) {
 if (!command || !knownCommands.includes(command)) {
   const rawNaturalArgs = process.argv.slice(2);
   const natural = parseNaturalEntryArgs(rawNaturalArgs);
+  if (command && isBareAtrisFlag(command)) {
+    command = '';
+  }
   const userInput = natural.input;
   const directSingleWordNatural = !natural.multiword
     && SINGLE_WORD_NATURAL_INTENTS.has(userInput.toLowerCase());
@@ -1307,9 +1318,47 @@ function printStarterTaskNext(starter) {
   console.log('Next: atris task next --as ' + localOwnerName());
 }
 
+function runMinimalInit() {
+  const script = process.argv[1] || path.join(__dirname, 'atris.js');
+  const result = spawnSync(process.execPath, [script, 'init', '--minimal', '--yes'], {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: 'utf8',
+    stdio: 'inherit',
+  });
+  return Number.isInteger(result.status) ? result.status : 1;
+}
+
+function printFirstMinuteScreen(options) {
+  const screen = buildFirstMinute(options);
+  console.log('');
+  console.log(screen.text);
+  return screen;
+}
+
 async function interactiveEntry(userInput, options = {}) {
   const workspaceDir = process.cwd();
   const state = detectWorkspaceState(workspaceDir);
+
+  // Fresh folder is the first-minute product: one next command, no menu.
+  if (state.state === 'fresh') {
+    if (options.asJson) {
+      console.log(JSON.stringify({
+        schema: 'atris.one_lap.v1',
+        ok: false,
+        status: 'stuck',
+        reason: 'this workspace is not initialized',
+        next_action: 'atris init --minimal --yes',
+      }, null, 2));
+      return 2;
+    }
+    printFirstMinuteScreen({ root: workspaceDir, fresh: true });
+    if (shouldAutoInitFresh(process.argv.slice(2))) {
+      return runMinimalInit();
+    }
+    return 0;
+  }
+
   const context = loadContext(workspaceDir);
 
   if (options.asJson && !String(userInput || '').trim()) {
@@ -1335,25 +1384,6 @@ async function interactiveEntry(userInput, options = {}) {
       return 0;
     }
     printAtrisOverview();
-    return;
-  }
-
-  // Fresh install - offer init
-  if (state.state === 'fresh') {
-    if (options.asJson) {
-      console.log(JSON.stringify({
-        schema: 'atris.one_lap.v1',
-        ok: false,
-        status: 'stuck',
-        reason: 'this workspace is not initialized',
-        next_action: 'atris init --yes',
-      }, null, 2));
-      return 2;
-    }
-    console.log('\nNo atris/ folder found.');
-    console.log('');
-    console.log('Next: atris init');
-    console.log('Local project install instead? Run: npx atris init');
     return;
   }
 
@@ -1430,70 +1460,12 @@ async function interactiveEntry(userInput, options = {}) {
     }, null, 2));
     return 2;
   }
-  // Mission needs a tick when: it has a verifier configured AND that verifier
-  // hasn't passed yet. Planning-state missions count too — first tick is what
-  // moves them to running.
-  const needsTickMission = activeMissions.find(
-    (m) => m.verifier && !m.verifier_passed
-  );
+  const hasRequest = Boolean(String(userInput || '').trim());
 
-  // Build status line
-  const parts = [];
-  if (wipCount > 0) {
-    parts.push(`work in progress: ${wipCount}`);
-  }
-  if (liveMissionsCount > 0) {
-    parts.push(`missions: ${liveMissionsCount}`);
-  }
-  if (inboxCount > 0) {
-    parts.push(`inbox: ${inboxCount}`);
-  }
-  if (backlogCount > 0) {
-    parts.push(`backlog: ${backlogCount}`);
-  }
-  if (completedTasksCount > 0) {
-    parts.push(`done: ${completedTasksCount}`);
-  }
-  const statusLine = parts.length > 0 ? parts.join('  |  ') : 'clean slate';
-
-  console.log('');
-  const contextRow = (label, value) => `  ${label.padEnd(9)}${value}`;
-  console.log(contextRow('context', 'loaded'));
-  console.log(contextRow('status', statusLine));
-
-  if (gatherContext) {
-    const hotAnswer = String(userInput || '').trim();
-    if (hotAnswer) {
-      const answer = hotAnswer;
-      if (isAtrisMetaQuestion(answer)) {
-        printAtrisOverview();
-        return;
-      }
-      const profile = saveContextProfile(workspaceDir, answer, { source: 'hot_start' });
-      const starter = createStarterTask(workspaceDir, answer);
-      console.log('');
-      console.log('Got it. I saved your first direction.');
-      console.log(`Focus: ${profile.first_answer}`);
-      if (starter && starter.display_id) {
-        console.log(`First task: ${starter.display_id} — ${starter.title}`);
-      } else if (starter && starter.title) {
-        console.log(`First task: ${starter.title}`);
-      }
-      if (mapStatus !== 'ready') {
-        printStarterTaskNext(starter);
-        return;
-      }
-      await planCmd(answer);
-      return;
-    }
-    if (shouldSkipContextGatherer()) {
-      console.log('');
-      if (process.argv.includes('--verbose')) {
-        console.log('context gatherer skipped (non-interactive).');
-      }
-      printFirstUseNext();
-      return;
-    } else {
+  // Bare `atris` is the first-minute screen: one win, one next command.
+  // Interactive first-contact still asks once when the folder has no work yet.
+  if (!hasRequest) {
+    if (gatherContext && !shouldSkipContextGatherer()) {
       const answer = await askContextGatherer(workspaceDir);
       if (isAtrisMetaQuestion(answer)) {
         printAtrisOverview();
@@ -1522,6 +1494,36 @@ async function interactiveEntry(userInput, options = {}) {
       await planCmd(answer);
       return;
     }
+    printFirstMinuteScreen({
+      root: workspaceDir,
+      context,
+      missions: activeMissions,
+    });
+    return 0;
+  }
+
+  if (gatherContext) {
+    const answer = String(userInput || '').trim();
+    if (isAtrisMetaQuestion(answer)) {
+      printAtrisOverview();
+      return;
+    }
+    const profile = saveContextProfile(workspaceDir, answer, { source: 'hot_start' });
+    const starter = createStarterTask(workspaceDir, answer);
+    console.log('');
+    console.log('Got it. I saved your first direction.');
+    console.log(`Focus: ${profile.first_answer}`);
+    if (starter && starter.display_id) {
+      console.log(`First task: ${starter.display_id} — ${starter.title}`);
+    } else if (starter && starter.title) {
+      console.log(`First task: ${starter.title}`);
+    }
+    if (mapStatus !== 'ready') {
+      printStarterTaskNext(starter);
+      return;
+    }
+    await planCmd(answer);
+    return;
   }
 
   if (mapStatus !== 'ready') {
@@ -1529,91 +1531,8 @@ async function interactiveEntry(userInput, options = {}) {
     return;
   }
 
-  // Hot start - user provided input directly
-  if (userInput) {
-    console.log(`\n> ${userInput}`);
-    await planCmd(userInput);
-    return;
-  }
-
-  // Surface live missions so the operator sees durable goals alongside dev WIP.
-  if (liveMissionsCount > 0) {
-    console.log('\nLive missions:');
-    for (const m of activeMissions.slice(0, 5)) {
-      const tickGate = m.verifier && !m.verifier_passed ? ' [needs tick]' : '';
-      const obj = m.objective.length > 70 ? `${m.objective.slice(0, 67)}...` : m.objective;
-      console.log(`- [${m.owner}] ${obj} (${m.status})${tickGate}`);
-    }
-  }
-
-  // Cold start auto-advance.
-  // ORDER MATTERS: missions outrank pipeline state because a mission's verifier
-  // is the contract that gates the Stop hook. Closing it unblocks everything else.
-  if (needsTickMission) {
-    console.log(`\nNext: atris mission tick (${needsTickMission.owner} mission has unverified verifier)`);
-    console.log(`Run: atris mission tick ${needsTickMission.id} --verify --complete-on-pass`);
-    return;
-  }
-
-  if (completedTasksCount > 0) {
-    const preview = context.completedTasks.slice(0, 3).map((t) => (t.length > 70 ? `${t.slice(0, 67)}...` : t));
-    if (preview.length > 0) {
-      console.log('\nCompleted (history):');
-      preview.forEach((t) => console.log(`- ${t}`));
-      console.log('Completed tasks are history, not pending review.');
-    }
-  }
-
-  if (wipCount > 0 || backlogCount > 0) {
-    const featurePreview = Array.isArray(context.inProgressFeatures) ? context.inProgressFeatures : [];
-    const inProgressPreview = context.inProgressTasks.slice(0, 2).map((t) => (t.length > 70 ? `${t.slice(0, 67)}...` : t));
-    const backlogPreview = context.backlogTasks.slice(0, 2).map((t) => (t.length > 70 ? `${t.slice(0, 67)}...` : t));
-    if (featurePreview.length > 0) {
-      console.log(`\nIn-progress features: ${featurePreview.join(', ')}`);
-    }
-    if (inProgressPreview.length > 0) {
-      console.log('\nIn Progress (preview):');
-      inProgressPreview.forEach((t) => console.log(`- ${t}`));
-    }
-    if (backlogPreview.length > 0) {
-      console.log('\nBacklog (preview):');
-      backlogPreview.forEach((t) => console.log(`- ${t}`));
-    }
-    console.log('\nNext: atris do (work ready to execute)');
-    await doCmd();
-    return;
-  }
-
-  if (inboxCount > 0) {
-    const preview = context.inboxItems.slice(0, 3).map((t) => (t.length > 70 ? `${t.slice(0, 67)}...` : t));
-    if (preview.length > 0) {
-      console.log('\nInbox (preview):');
-      preview.forEach((t) => console.log(`- ${t}`));
-    }
-    console.log('\nNext: atris plan (Inbox has ideas)');
-    await planCmd();
-    return;
-  }
-
-  if (completedTasksCount > 0) {
-    console.log('Next: atris plan (new work)');
-    return;
-  }
-
-  // No obvious next step - prompt for input
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-  });
-
-  const request = await new Promise(r => rl.question('\nWhat do you want to build?\n> ', r));
-  rl.close();
-
-  if (!request.trim()) {
-    return;
-  }
-
-  await planCmd(request);
+  console.log(`\n> ${userInput}`);
+  await planCmd(userInput);
 }
 
 async function askContextGatherer(workspaceDir) {

--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -1,0 +1,275 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const FIRST_USE_COMMAND = 'atris "help me choose the first useful step for this project"';
+const INIT_COMMAND = 'atris init --minimal';
+const BARE_ATRIS_FLAGS = new Set(['--yes', '-y', '--json', '--verbose']);
+
+function clip(value, max = 72) {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+  if (text.length <= max) return text;
+  const slice = text.slice(0, Math.max(0, max - 3));
+  const lastSpace = slice.lastIndexOf(' ');
+  const body = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
+  return `${body.replace(/[\s,;:.!?-]+$/, '')}...`;
+}
+
+function isBareAtrisFlag(token) {
+  return BARE_ATRIS_FLAGS.has(String(token || ''));
+}
+
+function personName(env = process.env) {
+  const raw = String(env.ATRIS_OPERATOR || env.USER || env.LOGNAME || '').trim();
+  let name = raw.split(/[\\/]/).pop();
+  if (!name) {
+    try {
+      name = String(os.userInfo().username || '').trim();
+    } catch {
+      name = '';
+    }
+  }
+  if (!name || name === 'root' || name === 'node') return '';
+  return name;
+}
+
+function folderName(root = process.cwd()) {
+  const name = path.basename(path.resolve(root || '.'));
+  if (!name || name === '.' || name === path.sep) return 'this folder';
+  if (/^(tmp|temp|atris-.*test)/i.test(name)) return 'this folder';
+  return name;
+}
+
+function greet(person) {
+  return person ? `hey ${person}, ` : '';
+}
+
+function taskRef(task) {
+  const ref = task && (task.display_id || task.legacy_ref || '');
+  return String(ref || '').trim();
+}
+
+function newest(tasks) {
+  return [...(Array.isArray(tasks) ? tasks : [])].sort((a, b) => (
+    Number(b && (b.updated_at || b.created_at) || 0)
+    - Number(a && (a.updated_at || a.created_at) || 0)
+  ))[0] || null;
+}
+
+function isCertifiedReview(task) {
+  const review = task && task.review || {};
+  const metadata = task && task.metadata || {};
+  if (review.agent_certified === true || metadata.agent_certified === true) return true;
+  return Number(review.agent_review_pass_count || metadata.agent_review_pass_count || 0) >= 2;
+}
+
+function loadLocalTasks(root = process.cwd()) {
+  try {
+    const taskDb = require('./task-db');
+    const db = taskDb.open();
+    const workspaceRoot = taskDb.workspaceRoot(root);
+    const rows = taskDb.listTasks(db, { workspaceRoot, limit: 200 });
+    if (Array.isArray(rows) && rows.length) return taskDb.withTaskDisplayRefs(rows);
+  } catch {
+    // Fall through to the local projection. Tests and fresh folders often have no db.
+  }
+  const projectionPath = path.join(root, '.atris', 'state', 'tasks.projection.json');
+  try {
+    const parsed = JSON.parse(fs.readFileSync(projectionPath, 'utf8'));
+    return Array.isArray(parsed.tasks) ? parsed.tasks : [];
+  } catch {
+    return [];
+  }
+}
+
+function loadLatestRecap(root = process.cwd()) {
+  const dir = path.join(root, 'atris', 'reports');
+  if (!fs.existsSync(dir)) return null;
+  let names = [];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return null;
+  }
+  const recaps = names
+    .filter((name) => /\.md$/i.test(name) && /recap/i.test(name))
+    .map((name) => {
+      const file = path.join(dir, name);
+      let mtime = 0;
+      try {
+        mtime = fs.statSync(file).mtimeMs;
+      } catch {
+        mtime = 0;
+      }
+      return { file, name, mtime };
+    })
+    .sort((a, b) => b.mtime - a.mtime || a.name.localeCompare(b.name));
+  const hit = recaps[0];
+  if (!hit) return null;
+  let title = path.basename(hit.name, '.md').replace(/[-_]+/g, ' ');
+  try {
+    const head = fs.readFileSync(hit.file, 'utf8').slice(0, 2000);
+    const h1 = head.split('\n').find((line) => line.startsWith('# '));
+    if (h1) title = h1.slice(2).trim();
+  } catch {
+    // Keep the filename title.
+  }
+  title = clip(title, 72);
+  return title ? { title, file: hit.file } : null;
+}
+
+function taskCommand(task, person) {
+  const ref = taskRef(task);
+  const who = person || 'operator';
+  if (!task) return FIRST_USE_COMMAND;
+  if (task.status === 'claimed') return ref ? `atris task step ${ref}` : 'atris do';
+  if (task.status === 'review') {
+    if (isCertifiedReview(task)) return 'atris task reviews --limit 5';
+    return ref ? `atris task review-chat ${ref} --as codex-review` : 'atris task reviews --limit 5';
+  }
+  if (task.status === 'open') {
+    return ref ? `atris task claim ${ref} --as ${who}` : 'atris task next';
+  }
+  return 'atris do';
+}
+
+function pickNext({
+  tasks = [],
+  missions = [],
+  person = '',
+  completedTitles = [],
+  backlogCount = 0,
+  inboxCount = 0,
+  wipCount = 0,
+} = {}) {
+  const claimed = newest(tasks.filter((task) => task && task.status === 'claimed'));
+  if (claimed) return { task: claimed, command: taskCommand(claimed, person) };
+  const review = newest(tasks.filter((task) => task && task.status === 'review'));
+  if (review) return { task: review, command: taskCommand(review, person) };
+  const needTick = (missions || []).find((mission) => mission && mission.verifier && !mission.verifier_passed);
+  if (needTick) {
+    const id = String(needTick.id || '').trim();
+    return {
+      mission: needTick,
+      command: id
+        ? `atris mission tick ${id} --verify --complete-on-pass`
+        : 'atris mission status --status active',
+    };
+  }
+  const open = newest(tasks.filter((task) => task && task.status === 'open'));
+  if (open) return { task: open, command: taskCommand(open, person) };
+  if (wipCount > 0 || backlogCount > 0) return { command: 'atris do' };
+  if (inboxCount > 0) return { command: 'atris plan' };
+  if (completedTitles.length > 0) return { command: 'atris plan' };
+  return { command: FIRST_USE_COMMAND };
+}
+
+function renderFresh({ person = '', folder = 'this folder' } = {}) {
+  const room = folder || 'this folder';
+  return [
+    `${greet(person)}${room} is a clean start.`,
+    '',
+    `next: ${INIT_COMMAND}`,
+  ].join('\n');
+}
+
+function renderWorkspace({
+  person = '',
+  folder = 'this folder',
+  task = null,
+  recap = null,
+  completedTitle = '',
+  nextCommand = FIRST_USE_COMMAND,
+} = {}) {
+  const who = greet(person);
+  const title = task && clip(task.title, 68);
+  let win = `${who}${folder || 'this folder'} is set up.`;
+  if (task && task.status === 'review' && title) {
+    win = `${who}you already shipped ${title}.`;
+  } else if (task && task.status === 'claimed' && title) {
+    win = `${who}${title} is already yours.`;
+  } else if (task && task.status === 'open' && title) {
+    win = `${who}${title} is ready to claim.`;
+  } else if (completedTitle) {
+    win = `${who}you already shipped ${clip(completedTitle, 68)}.`;
+  } else if (recap && recap.title) {
+    win = `${who}you already have a recap in ${folder || 'this folder'}: ${recap.title}.`;
+  }
+  const lines = [win];
+  if (recap && recap.title && task) lines.push(`last recap: ${recap.title}.`);
+  lines.push('');
+  lines.push(`next: ${nextCommand}`);
+  return lines.join('\n');
+}
+
+function buildFirstMinute({
+  root = process.cwd(),
+  fresh = false,
+  person,
+  folder,
+  context = {},
+  missions = [],
+} = {}) {
+  const who = person != null ? person : personName();
+  const room = folder != null ? folder : folderName(root);
+  if (fresh) {
+    return {
+      kind: 'fresh',
+      text: renderFresh({ person: who, folder: room }),
+      nextCommand: INIT_COMMAND,
+    };
+  }
+  const tasks = loadLocalTasks(root);
+  const picked = pickNext({
+    tasks,
+    missions,
+    person: who,
+    completedTitles: Array.isArray(context.completedTasks) ? context.completedTasks : [],
+    backlogCount: Array.isArray(context.backlogTasks) ? context.backlogTasks.length : 0,
+    inboxCount: typeof context.inboxCount === 'number' ? context.inboxCount : 0,
+    wipCount: Array.isArray(context.inProgressTasks) ? context.inProgressTasks.length : 0,
+  });
+  const recap = loadLatestRecap(root);
+  const completedTitle = Array.isArray(context.completedTasks) ? context.completedTasks[0] : '';
+  return {
+    kind: 'workspace',
+    text: renderWorkspace({
+      person: who,
+      folder: room,
+      task: picked.task || null,
+      recap,
+      completedTitle,
+      nextCommand: picked.command,
+    }),
+    nextCommand: picked.command,
+    task: picked.task || null,
+    recap,
+  };
+}
+
+function shouldAutoInitFresh(args = process.argv.slice(2), env = process.env) {
+  const list = Array.isArray(args) ? args : [];
+  if (list.includes('--json')) return false;
+  if (env.ATRIS_NO_INTERACTIVE || env.ATRIS_NONINTERACTIVE === '1') return false;
+  return list.includes('--yes') || list.includes('-y');
+}
+
+function spokenLineCount(text) {
+  return String(text || '')
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean).length;
+}
+
+module.exports = {
+  buildFirstMinute,
+  isBareAtrisFlag,
+  personName,
+  renderFresh,
+  renderWorkspace,
+  shouldAutoInitFresh,
+  spokenLineCount,
+};

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -582,7 +582,8 @@ test('default entry auto-advances to plan when inbox has items', () => {
 
     const res = runCli([], { cwd: dir });
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /Atris Plan — Navigator Agent Activated/);
+    assert.match(res.stdout, /^next: atris plan$/m);
+    assert.doesNotMatch(res.stdout, /What do you want to build|Atris Plan/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -602,7 +603,8 @@ test('default entry gathers first-contact context before MAP bootstrap', () => {
     const bare = runCli([], { cwd: dir, input: '\n', env });
     assert.equal(bare.status, 0, bare.stderr);
     assert.doesNotMatch(bare.stdout, /context gatherer skipped \(non-interactive\)/);
-    assert.match(bare.stdout, /next\s+run `atris` and describe what you want in plain words\./);
+    assert.match(bare.stdout, /^next: atris /m);
+    assert.doesNotMatch(bare.stdout, /What do you want to build/);
 
     // the hot-start path (answer passed as argv) still gathers context
     const res = runCli(['help me organize college applications'], { cwd: dir, env });
@@ -634,7 +636,8 @@ test('default entry auto-advances to do when backlog tasks exist', () => {
 
     const res = runCli([], { cwd: dir });
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /Atris Do — Executor Agent Activated/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.doesNotMatch(res.stdout, /What do you want to build|Atris Do/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -663,9 +666,9 @@ test('default entry treats completed-only TODO rows as history', () => {
 
     const res = runCli([], { cwd: dir });
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /Completed \(history\):/);
-    assert.match(res.stdout, /Completed tasks are history, not pending review\./);
-    assert.doesNotMatch(res.stdout, /Next: atris review|I checked the review setup\./);
+    assert.match(res.stdout, /validate thing|already shipped|set up/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.doesNotMatch(res.stdout, /Next: atris review|I checked the review setup\.|What do you want to build/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -687,10 +690,9 @@ test('default entry routes active work before completed history', () => {
 
     const res = runCli([], { cwd: dir });
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /Completed \(history\):/);
-    assert.match(res.stdout, /Backlog \(preview\):/);
-    assert.match(res.stdout, /Next: atris do \(work ready to execute\)/);
-    assert.doesNotMatch(res.stdout, /Next: atris review|I checked the review setup\./);
+    assert.match(res.stdout, /validate old thing|build the useful thing|already/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.doesNotMatch(res.stdout, /Next: atris review|I checked the review setup\.|What do you want to build/);
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -16988,9 +16988,9 @@ test('fresh workspace prompt gives one primary first command plus local fallback
     const home = path.join(dir, 'home');
     const res = runCli([], { cwd: dir, env: { HOME: home } });
     assert.equal(res.status, 0, res.stderr || res.stdout);
-    assert.match(res.stdout, /No atris\/ folder found/);
-    assert.match(res.stdout, /^Next: atris init$/m);
-    assert.match(res.stdout, /^Local project install instead\? Run: npx atris init$/m);
+    assert.match(res.stdout, /init/);
+    assert.match(res.stdout, /^next: atris init --minimal$/m);
+    assert.ok(res.stdout.trim().split('\n').filter(Boolean).length <= 6);
     assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
     assert.equal(fs.existsSync(path.join(home, '.atris')), false);
   } finally {

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -1,0 +1,242 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+  buildFirstMinute,
+  personName,
+  renderFresh,
+  renderWorkspace,
+  shouldAutoInitFresh,
+  spokenLineCount,
+} = require('../lib/first-minute');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-first-minute-'));
+}
+
+function cleanupTempDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function runCli(args, { cwd, env, timeout = 15000 } = {}) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout,
+    env: {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ATRIS_NO_INTERACTIVE: '1',
+      ...(env || {}),
+    },
+  });
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    assert.fail(`cli hung past ${timeout}ms (args: ${args.join(' ') || '(none)'})`);
+  }
+  if (result.error) throw result.error;
+  return result;
+}
+
+function writeReadyWorkspace(dir, tasks) {
+  fs.mkdirSync(path.join(dir, 'atris', 'reports'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.atris', 'state'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'atris', 'MAP.md'), '# MAP.md\n\n## By-Feature\n- example: bin/atris.js:1\n', 'utf8');
+  fs.writeFileSync(path.join(dir, 'atris', 'TODO.md'), '# TODO.md\n\n## Backlog\n\n(Empty)\n', 'utf8');
+  fs.writeFileSync(path.join(dir, '.atris', 'state', 'tasks.projection.json'), JSON.stringify({
+    schema: 'atris.task_projection.v1',
+    tasks,
+  }, null, 2), 'utf8');
+}
+
+test('fresh first-minute copy names init and stays short', () => {
+  const text = renderFresh({ person: 'keshav', folder: 'this folder' });
+  assert.match(text, /hey keshav, this folder is a clean start\./);
+  assert.match(text, /^next: atris init --minimal$/m);
+  assert.ok(spokenLineCount(text) <= 4);
+  assert.ok(text.length < 200);
+});
+
+test('claimed task first-minute names the person or title and one next command', () => {
+  const text = renderWorkspace({
+    person: 'keshav',
+    folder: 'atris',
+    task: { title: 'Ship the landing page', status: 'claimed', display_id: 'CLI-9' },
+    nextCommand: 'atris task step CLI-9',
+  });
+  assert.match(text, /hey keshav, Ship the landing page is already yours\./);
+  assert.match(text, /^next: atris task step CLI-9$/m);
+  assert.equal(text.match(/^next:/mg).length, 1);
+  assert.ok(spokenLineCount(text) <= 4);
+});
+
+test('ready review task first-minute leads with a win', () => {
+  const text = renderWorkspace({
+    person: 'keshav',
+    folder: 'atris',
+    task: { title: 'Ship the landing page', status: 'review', display_id: 'CLI-9' },
+    recap: { title: 'week one loop' },
+    nextCommand: 'atris task reviews --limit 5',
+  });
+  assert.match(text, /you already shipped Ship the landing page/);
+  assert.match(text, /last recap: week one loop/);
+  assert.match(text, /^next: atris task reviews --limit 5$/m);
+  assert.ok(spokenLineCount(text) <= 4);
+});
+
+test('headless flags never auto-init without an explicit yes', () => {
+  assert.equal(shouldAutoInitFresh([], { ATRIS_NO_INTERACTIVE: '1' }), false);
+  assert.equal(shouldAutoInitFresh(['--yes'], { ATRIS_NO_INTERACTIVE: '1' }), false);
+  assert.equal(shouldAutoInitFresh(['--json', '--yes'], {}), false);
+  assert.equal(shouldAutoInitFresh(['--yes'], {}), true);
+});
+
+test('personName prefers the local user', () => {
+  assert.equal(personName({ USER: 'keshav' }), 'keshav');
+});
+
+test('buildFirstMinute reads a claimed task from the local projection', () => {
+  const dir = makeTempDir();
+  try {
+    writeReadyWorkspace(dir, [{
+      id: 'task-1',
+      display_id: 'CLI-9',
+      title: 'Ship the landing page',
+      status: 'claimed',
+      claimed_by: 'keshav',
+      updated_at: 20,
+    }]);
+    const screen = buildFirstMinute({
+      root: dir,
+      person: 'keshav',
+      folder: 'atris',
+    });
+    assert.match(screen.text, /Ship the landing page/);
+    assert.equal(screen.nextCommand, 'atris task step CLI-9');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('empty dir bare atris names init, stays short, and does not hang', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  try {
+    const res = runCli([], {
+      cwd: dir,
+      env: { HOME: home, USER: 'keshav', ATRIS_TASKS_DB: path.join(dir, 'tasks.db') },
+    });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /init/);
+    assert.match(res.stdout, /atris init --minimal/);
+    assert.match(res.stdout, /keshav|this folder|clean start/);
+    assert.ok(spokenLineCount(res.stdout) <= 6);
+    assert.ok(res.stdout.length < 400);
+    assert.doesNotMatch(res.stdout, /operating system|What do you want to build/i);
+    assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('empty dir --json and no-interactive --yes never init', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  try {
+    const json = runCli(['--json'], {
+      cwd: dir,
+      env: { HOME: home, USER: 'keshav', ATRIS_TASKS_DB: path.join(dir, 'tasks.db') },
+    });
+    assert.equal(json.status, 2, json.stderr || json.stdout);
+    const payload = JSON.parse(json.stdout);
+    assert.equal(payload.next_action, 'atris init --minimal --yes');
+    assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+
+    const blocked = runCli(['--yes'], {
+      cwd: dir,
+      env: {
+        HOME: home,
+        USER: 'keshav',
+        ATRIS_NO_INTERACTIVE: '1',
+        ATRIS_TASKS_DB: path.join(dir, 'tasks.db'),
+      },
+    });
+    assert.equal(blocked.status, 0, blocked.stderr || blocked.stdout);
+    assert.match(blocked.stdout, /atris init --minimal/);
+    assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('workspace with a claimed task names the person or title and one next command', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  try {
+    writeReadyWorkspace(dir, [{
+      id: 'task-1',
+      display_id: 'CLI-9',
+      title: 'Ship the landing page',
+      status: 'claimed',
+      claimed_by: 'keshav',
+      updated_at: 30,
+    }]);
+    const res = runCli([], {
+      cwd: dir,
+      env: {
+        HOME: home,
+        USER: 'keshav',
+        ATRIS_TASKS_DB: path.join(dir, 'claimed.db'),
+      },
+    });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /keshav|Ship the landing page/);
+    assert.match(res.stdout, /^next: atris task step CLI-9$/m);
+    assert.equal(res.stdout.match(/^next:/mg).length, 1);
+    assert.doesNotMatch(res.stdout, /What do you want to build|context   loaded|Atris Do/);
+    assert.ok(spokenLineCount(res.stdout) <= 6);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('workspace with a ready task names the win and one next command', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  try {
+    writeReadyWorkspace(dir, [{
+      id: 'task-2',
+      display_id: 'CLI-8',
+      title: 'Ship the landing page',
+      status: 'review',
+      claimed_by: 'keshav',
+      updated_at: 40,
+      review: { agent_certified: true, agent_review_pass_count: 2 },
+    }]);
+    const res = runCli([], {
+      cwd: dir,
+      env: {
+        HOME: home,
+        USER: 'keshav',
+        ATRIS_TASKS_DB: path.join(dir, 'ready.db'),
+      },
+    });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /keshav|Ship the landing page/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.equal(res.stdout.match(/^next:/mg).length, 1);
+    assert.doesNotMatch(res.stdout, /What do you want to build/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});

--- a/test/init-non-interactive.test.js
+++ b/test/init-non-interactive.test.js
@@ -12,8 +12,6 @@ const cliPath = path.join(repoRoot, 'bin', 'atris.js');
 // 60s keeps the real-hang guard (interactive prompt waiting on stdin blocks
 // forever) while clearing the load-induced slowdown.
 const INIT_TIMEOUT_MS = 60000;
-const FIRST_USE_NEXT = 'Next: atris "help me choose the first useful step for this project"';
-const FIRST_MISSION = 'atris mission start "Verify this Atris workspace is ready" --owner validator --runner manual --lane workspace --verify "node -e \\"require(\'fs\').accessSync(\'atris/atris.md\')\\"" --stop "workspace readiness is verified"';
 const STARTER_MEMBERS = ['customer-lead', 'executor', 'improver', 'mission-lead', 'navigator', 'validator'];
 
 function makeTempDir() {
@@ -67,10 +65,8 @@ test('init --yes exits without hanging and skips context gatherer', () => {
     const res = runInit(['--yes'], { cwd: dir });
     assert.equal(res.status, 0, `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`);
     assert.doesNotMatch(res.stdout, /context gatherer skipped/);
-    assert.ok(res.stdout.includes('  next     run `atris` and describe what you want in plain words.'));
-    assert.ok(res.stdout.includes(`agents: ${FIRST_MISSION}`));
-    assert.ok(res.stdout.includes(`Then: ${FIRST_USE_NEXT.slice('Next: '.length)}`));
-    assert.doesNotMatch(res.stdout, /BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.doesNotMatch(res.stdout, /What do you want to build|BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
     assert.ok(fs.existsSync(path.join(dir, 'atris', 'atris.md')));
   } finally {
     cleanupTempDir(dir);
@@ -83,10 +79,8 @@ test('init -y exits without hanging and skips context gatherer', () => {
     const res = runInit(['-y'], { cwd: dir });
     assert.equal(res.status, 0, `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`);
     assert.doesNotMatch(res.stdout, /context gatherer skipped/);
-    assert.ok(res.stdout.includes('  next     run `atris` and describe what you want in plain words.'));
-    assert.ok(res.stdout.includes(`agents: ${FIRST_MISSION}`));
-    assert.ok(res.stdout.includes(`Then: ${FIRST_USE_NEXT.slice('Next: '.length)}`));
-    assert.doesNotMatch(res.stdout, /BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.doesNotMatch(res.stdout, /What do you want to build|BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
     assert.ok(fs.existsSync(path.join(dir, 'atris', 'atris.md')));
   } finally {
     cleanupTempDir(dir);
@@ -99,10 +93,8 @@ test('init with piped stdin exits without hanging', () => {
     const res = runInit([], { cwd: dir, input: '' });
     assert.equal(res.status, 0, `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`);
     assert.doesNotMatch(res.stdout, /context gatherer skipped/);
-    assert.ok(res.stdout.includes('  next     run `atris` and describe what you want in plain words.'));
-    assert.ok(res.stdout.includes(`agents: ${FIRST_MISSION}`));
-    assert.ok(res.stdout.includes(`Then: ${FIRST_USE_NEXT.slice('Next: '.length)}`));
-    assert.doesNotMatch(res.stdout, /BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.doesNotMatch(res.stdout, /What do you want to build|BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
     assert.ok(fs.existsSync(path.join(dir, 'atris', 'atris.md')));
   } finally {
     cleanupTempDir(dir);
@@ -115,10 +107,8 @@ test('init with ATRIS_NO_INTERACTIVE skips context gatherer', () => {
     const res = runInit([], { cwd: dir, env: { ATRIS_NO_INTERACTIVE: '1' } });
     assert.equal(res.status, 0, `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`);
     assert.doesNotMatch(res.stdout, /context gatherer skipped/);
-    assert.ok(res.stdout.includes('  next     run `atris` and describe what you want in plain words.'));
-    assert.ok(res.stdout.includes(`agents: ${FIRST_MISSION}`));
-    assert.ok(res.stdout.includes(`Then: ${FIRST_USE_NEXT.slice('Next: '.length)}`));
-    assert.doesNotMatch(res.stdout, /BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
+    assert.match(res.stdout, /^next: atris /m);
+    assert.doesNotMatch(res.stdout, /What do you want to build|BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -142,7 +132,8 @@ test('init keeps default output grouped and restores file details with --verbose
     assert.equal(verbose.status, 0, `stdout:\n${verbose.stdout}\nstderr:\n${verbose.stderr}`);
     assert.match(verbose.stdout, /✓ Created GETTING_STARTED\.md/);
     assert.match(verbose.stdout, /✓ Copied skill:/);
-    assert.match(verbose.stdout, /context gatherer skipped \(non-interactive\)\./);
+    assert.match(verbose.stdout, /^next: atris /m);
+    assert.doesNotMatch(verbose.stdout, /What do you want to build/);
   } finally {
     cleanupTempDir(quietDir);
     cleanupTempDir(verboseDir);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bare `atris` is now the first-minute product screen, not a status dump.

Empty folders lead with a clean start and print `atris init --minimal`. `--yes` can run that init. `ATRIS_NO_INTERACTIVE` and `--json` never prompt and never init without `--yes`.

In a workspace, the screen speaks to this person in this folder. If a claimed or ready task exists, it names that win and one next command. Help is unchanged.

Verify:
```
node --test test/first-minute.test.js test/context-gatherer.test.js test/init-non-interactive.test.js
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dffb995-142d-48e1-a7a8-d304388b2cbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dffb995-142d-48e1-a7a8-d304388b2cbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

