### PR TITLE
dogfood: first-minute tells one truth

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1507,7 +1507,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
 - **Entry point:** `bin/atris.js:1344` (`interactiveEntry`)
-- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`; empty folders name `atris init --minimal`
+- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`; empty folders name `atris init --minimal`; certified review names `atris task accept <id>`; scratch `/tmp` folders stay "this folder"; person name prefers the saved account first name
 - **Helper:** `lib/context-gatherer.js`
 - **State:** `.atris/state/context_profile.json`
 - **Regression:** `test/first-minute.test.js`, `test/context-gatherer.test.js`, `test/cli-smoke.test.js`

--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -7,6 +7,10 @@ const path = require('path');
 const FIRST_USE_COMMAND = 'atris "help me choose the first useful step for this project"';
 const INIT_COMMAND = 'atris init --minimal';
 const BARE_ATRIS_FLAGS = new Set(['--yes', '-y', '--json', '--verbose']);
+const NOT_A_PERSON = new Set([
+  'root', 'node', 'ubuntu', 'admin', 'nobody', 'www', 'daemon', 'guest',
+  'test', 'user', 'operator', 'tmp', 'temp', 'atris',
+]);
 
 function clip(value, max = 72) {
   const text = String(value || '').replace(/\s+/g, ' ').trim();
@@ -22,8 +26,19 @@ function isBareAtrisFlag(token) {
   return BARE_ATRIS_FLAGS.has(String(token || ''));
 }
 
-function personName(env = process.env) {
-  const raw = String(env.ATRIS_OPERATOR || env.USER || env.LOGNAME || '').trim();
+function givenNameFrom(raw) {
+  const text = String(raw || '').replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+  const handle = text.includes('@') ? text.split('@')[0] : text;
+  const first = handle.split(/[._+\s/-]/)[0].replace(/\d+$/g, '');
+  if (!/^[A-Za-z][A-Za-z'-]{1,15}$/.test(first)) return '';
+  const name = first.toLowerCase();
+  if (NOT_A_PERSON.has(name)) return '';
+  return name;
+}
+
+function unixUser(env = process.env) {
+  const raw = String(env.USER || env.LOGNAME || '').trim();
   let name = raw.split(/[\\/]/).pop();
   if (!name) {
     try {
@@ -32,19 +47,64 @@ function personName(env = process.env) {
       name = '';
     }
   }
-  if (!name || name === 'root' || name === 'node') return '';
+  if (!name || NOT_A_PERSON.has(name.toLowerCase())) return '';
   return name;
+}
+
+function loadSavedAccount() {
+  try {
+    const home = process.env.HOME || os.homedir();
+    const file = path.join(home, '.atris', 'credentials.json');
+    if (!fs.existsSync(file)) return null;
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function personName(env = process.env, account) {
+  const fromOperator = givenNameFrom(env.ATRIS_OPERATOR);
+  if (fromOperator) return fromOperator;
+  const saved = account !== undefined ? account : loadSavedAccount();
+  if (saved) {
+    const fromAccount = givenNameFrom(saved.name || saved.display_name || saved.username || saved.handle)
+      || givenNameFrom(saved.email);
+    if (fromAccount) return fromAccount;
+  }
+  return givenNameFrom(env.USER || env.LOGNAME) || unixUser(env);
+}
+
+function isScratchFolder(root = process.cwd()) {
+  const resolved = path.resolve(root || '.');
+  const name = path.basename(resolved);
+  const unix = resolved.replace(/\\/g, '/');
+  if (/(?:^|\/)(?:tmp|temp|var\/folders)(?:\/|$)/i.test(unix)) return true;
+  try {
+    const tmp = path.resolve(os.tmpdir()).replace(/\\/g, '/');
+    if (unix === tmp || unix.startsWith(`${tmp}/`)) return true;
+  } catch {
+    // Keep the path regex above.
+  }
+  return /^(tmp|temp|atris-)/i.test(name);
 }
 
 function folderName(root = process.cwd()) {
   const name = path.basename(path.resolve(root || '.'));
   if (!name || name === '.' || name === path.sep) return 'this folder';
-  if (/^(tmp|temp|atris-.*test)/i.test(name)) return 'this folder';
+  if (isScratchFolder(root)) return 'this folder';
   return name;
 }
 
 function greet(person) {
   return person ? `hey ${person}, ` : '';
+}
+
+function softTitle(title, maxWords = 5) {
+  const words = String(title || '').replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  if (!words.length) return '';
+  const text = words.slice(0, maxWords).join(' ').replace(/[.,;:!?]+$/g, '');
+  return `"${text.toLowerCase()}"`;
 }
 
 function taskRef(task) {
@@ -125,11 +185,11 @@ function taskCommand(task, person) {
   const ref = taskRef(task);
   const who = person || 'operator';
   if (!task) return FIRST_USE_COMMAND;
-  if (task.status === 'claimed') return ref ? `atris task step ${ref}` : 'atris do';
   if (task.status === 'review') {
-    if (isCertifiedReview(task)) return 'atris task reviews --limit 5';
+    if (isCertifiedReview(task)) return ref ? `atris task accept ${ref}` : 'atris task reviews --limit 5';
     return ref ? `atris task review-chat ${ref} --as codex-review` : 'atris task reviews --limit 5';
   }
+  if (task.status === 'claimed') return ref ? `atris task step ${ref}` : 'atris do';
   if (task.status === 'open') {
     return ref ? `atris task claim ${ref} --as ${who}` : 'atris task next';
   }
@@ -145,9 +205,12 @@ function pickNext({
   inboxCount = 0,
   wipCount = 0,
 } = {}) {
+  const reviews = (Array.isArray(tasks) ? tasks : []).filter((task) => task && task.status === 'review');
+  const certified = newest(reviews.filter(isCertifiedReview));
+  if (certified) return { task: certified, command: taskCommand(certified, person) };
   const claimed = newest(tasks.filter((task) => task && task.status === 'claimed'));
   if (claimed) return { task: claimed, command: taskCommand(claimed, person) };
-  const review = newest(tasks.filter((task) => task && task.status === 'review'));
+  const review = newest(reviews);
   if (review) return { task: review, command: taskCommand(review, person) };
   const needTick = (missions || []).find((mission) => mission && mission.verifier && !mission.verifier_passed);
   if (needTick) {
@@ -171,6 +234,7 @@ function renderFresh({ person = '', folder = 'this folder' } = {}) {
   const room = folder || 'this folder';
   return [
     `${greet(person)}${room} is a clean start.`,
+    "I'll set this up when you want.",
     '',
     `next: ${INIT_COMMAND}`,
   ].join('\n');
@@ -185,16 +249,20 @@ function renderWorkspace({
   nextCommand = FIRST_USE_COMMAND,
 } = {}) {
   const who = greet(person);
-  const title = task && clip(task.title, 68);
+  const title = task && softTitle(task.title);
   let win = `${who}${folder || 'this folder'} is set up.`;
-  if (task && task.status === 'review' && title) {
+  if (task && task.status === 'done' && title) {
     win = `${who}you already shipped ${title}.`;
+  } else if (task && task.status === 'review' && title) {
+    win = isCertifiedReview(task)
+      ? `${who}${title} is waiting for your ok.`
+      : `${who}${title} is ready to look at.`;
   } else if (task && task.status === 'claimed' && title) {
     win = `${who}${title} is already yours.`;
   } else if (task && task.status === 'open' && title) {
     win = `${who}${title} is ready to claim.`;
   } else if (completedTitle) {
-    win = `${who}you already shipped ${clip(completedTitle, 68)}.`;
+    win = `${who}you already shipped ${softTitle(completedTitle)}.`;
   } else if (recap && recap.title) {
     win = `${who}you already have a recap in ${folder || 'this folder'}: ${recap.title}.`;
   }
@@ -266,6 +334,7 @@ function spokenLineCount(text) {
 
 module.exports = {
   buildFirstMinute,
+  folderName,
   isBareAtrisFlag,
   personName,
   renderFresh,

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -7,6 +7,7 @@ const { spawnSync } = require('node:child_process');
 
 const {
   buildFirstMinute,
+  folderName,
   personName,
   renderFresh,
   renderWorkspace,
@@ -23,6 +24,11 @@ function makeTempDir() {
 
 function cleanupTempDir(dir) {
   fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeAccount(home, account) {
+  fs.mkdirSync(path.join(home, '.atris'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.atris', 'credentials.json'), JSON.stringify(account, null, 2), 'utf8');
 }
 
 function runCli(args, { cwd, env, timeout = 15000 } = {}) {
@@ -58,6 +64,7 @@ function writeReadyWorkspace(dir, tasks) {
 test('fresh first-minute copy names init and stays short', () => {
   const text = renderFresh({ person: 'keshav', folder: 'this folder' });
   assert.match(text, /hey keshav, this folder is a clean start\./);
+  assert.match(text, /I'll set this up when you want\./);
   assert.match(text, /^next: atris init --minimal$/m);
   assert.ok(spokenLineCount(text) <= 4);
   assert.ok(text.length < 200);
@@ -70,24 +77,48 @@ test('claimed task first-minute names the person or title and one next command',
     task: { title: 'Ship the landing page', status: 'claimed', display_id: 'CLI-9' },
     nextCommand: 'atris task step CLI-9',
   });
-  assert.match(text, /hey keshav, Ship the landing page is already yours\./);
+  assert.match(text, /hey keshav, "ship the landing page" is already yours\./);
   assert.match(text, /^next: atris task step CLI-9$/m);
   assert.equal(text.match(/^next:/mg).length, 1);
   assert.ok(spokenLineCount(text) <= 4);
 });
 
-test('ready review task first-minute leads with a win', () => {
+test('ready review task first-minute waits for a human ok', () => {
   const text = renderWorkspace({
     person: 'keshav',
     folder: 'atris',
-    task: { title: 'Ship the landing page', status: 'review', display_id: 'CLI-9' },
+    task: {
+      title: 'Print a human line like 4 words so the count is easy to read.',
+      status: 'review',
+      display_id: 'UNW-2',
+      review: { agent_certified: true, agent_review_pass_count: 2 },
+    },
     recap: { title: 'week one loop' },
-    nextCommand: 'atris task reviews --limit 5',
+    nextCommand: 'atris task accept UNW-2',
   });
-  assert.match(text, /you already shipped Ship the landing page/);
+  assert.match(text, /"print a human line like" is waiting for your ok\./);
+  assert.doesNotMatch(text, /you already shipped/);
+  assert.doesNotMatch(text, /so the count is easy to read/);
   assert.match(text, /last recap: week one loop/);
-  assert.match(text, /^next: atris task reviews --limit 5$/m);
+  assert.match(text, /^next: atris task accept UNW-2$/m);
   assert.ok(spokenLineCount(text) <= 4);
+});
+
+test('uncertified review task first-minute is ready to look at', () => {
+  const text = renderWorkspace({
+    person: 'keshav',
+    folder: 'atris',
+    task: {
+      title: 'Print a human line like 4 words so the count is easy to read.',
+      status: 'review',
+      display_id: 'UNW-4',
+      review: { agent_review_pass_count: 1 },
+    },
+    nextCommand: 'atris task review-chat UNW-4 --as codex-review',
+  });
+  assert.match(text, /"print a human line like" is ready to look at\./);
+  assert.doesNotMatch(text, /you already shipped/);
+  assert.match(text, /^next: atris task review-chat UNW-4 --as codex-review$/m);
 });
 
 test('headless flags never auto-init without an explicit yes', () => {
@@ -97,8 +128,20 @@ test('headless flags never auto-init without an explicit yes', () => {
   assert.equal(shouldAutoInitFresh(['--yes'], {}), true);
 });
 
-test('personName prefers the local user', () => {
-  assert.equal(personName({ USER: 'keshav' }), 'keshav');
+test('personName prefers a given name from the saved account', () => {
+  assert.equal(personName({ USER: 'keshavrao' }, { email: 'keshav@atrislabs.com' }), 'keshav');
+  assert.equal(personName({ USER: 'keshavrao' }, { name: 'Keshav Rao' }), 'keshav');
+  assert.equal(personName({ USER: 'keshavrao' }, null), 'keshavrao');
+  assert.equal(personName({ ATRIS_OPERATOR: 'keshav', USER: 'keshavrao' }, null), 'keshav');
+  assert.equal(personName({ USER: 'keshav' }, null), 'keshav');
+});
+
+test('scratch folders stay this folder and real names stay', () => {
+  assert.equal(folderName('/tmp/atris-use-now'), 'this folder');
+  assert.equal(folderName('/tmp/atris-first-min-try'), 'this folder');
+  assert.equal(folderName('/var/folders/xx/yy/T/launch'), 'this folder');
+  assert.equal(folderName('/Users/keshav/launch-day'), 'launch-day');
+  assert.equal(folderName('/Users/keshav/atris'), 'atris');
 });
 
 test('buildFirstMinute reads a claimed task from the local projection', () => {
@@ -117,8 +160,58 @@ test('buildFirstMinute reads a claimed task from the local projection', () => {
       person: 'keshav',
       folder: 'atris',
     });
-    assert.match(screen.text, /Ship the landing page/);
+    assert.match(screen.text, /"ship the landing page"/);
     assert.equal(screen.nextCommand, 'atris task step CLI-9');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('buildFirstMinute prefers a certified review over a newer uncertified one', () => {
+  const dir = makeTempDir();
+  try {
+    writeReadyWorkspace(dir, [
+      {
+        id: 'task-1',
+        display_id: 'UNW-1',
+        title: 'Open follow-up',
+        status: 'open',
+        updated_at: 10,
+      },
+      {
+        id: 'task-2',
+        display_id: 'UNW-2',
+        title: 'Print a human line like 4 words so the count is easy to read.',
+        status: 'review',
+        updated_at: 20,
+        review: { agent_certified: true, agent_review_pass_count: 2 },
+      },
+      {
+        id: 'task-3',
+        display_id: 'UNW-3',
+        title: 'Second check still open',
+        status: 'review',
+        updated_at: 30,
+        review: { agent_review_pass_count: 1 },
+      },
+      {
+        id: 'task-4',
+        display_id: 'UNW-4',
+        title: 'Newer review still waiting',
+        status: 'review',
+        updated_at: 40,
+        review: { agent_review_pass_count: 1 },
+      },
+    ]);
+    const screen = buildFirstMinute({
+      root: dir,
+      person: 'keshav',
+      folder: 'this folder',
+    });
+    assert.equal(screen.nextCommand, 'atris task accept UNW-2');
+    assert.match(screen.text, /waiting for your ok/);
+    assert.doesNotMatch(screen.text, /you already shipped/);
+    assert.doesNotMatch(screen.text, /review-chat/);
   } finally {
     cleanupTempDir(dir);
   }
@@ -140,6 +233,7 @@ test('empty dir bare atris names init, stays short, and does not hang', () => {
     assert.ok(spokenLineCount(res.stdout) <= 6);
     assert.ok(res.stdout.length < 400);
     assert.doesNotMatch(res.stdout, /operating system|What do you want to build/i);
+    assert.doesNotMatch(res.stdout, /mission run|help me choose the first useful step/i);
     assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
   } finally {
     cleanupTempDir(dir);
@@ -199,7 +293,7 @@ test('workspace with a claimed task names the person or title and one next comma
       },
     });
     assert.equal(res.status, 0, res.stderr || res.stdout);
-    assert.match(res.stdout, /keshav|Ship the landing page/);
+    assert.match(res.stdout, /keshav|ship the landing page/i);
     assert.match(res.stdout, /^next: atris task step CLI-9$/m);
     assert.equal(res.stdout.match(/^next:/mg).length, 1);
     assert.doesNotMatch(res.stdout, /What do you want to build|context   loaded|Atris Do/);
@@ -209,33 +303,70 @@ test('workspace with a claimed task names the person or title and one next comma
   }
 });
 
-test('workspace with a ready task names the win and one next command', () => {
+test('workspace with a ready task names the win and points at accept', () => {
   const dir = makeTempDir();
   const home = path.join(dir, 'home');
   fs.mkdirSync(home, { recursive: true });
+  writeAccount(home, {
+    token: 'test-token',
+    email: 'keshav@atrislabs.com',
+    name: 'Keshav Rao',
+    user_id: 'u-1',
+  });
   try {
-    writeReadyWorkspace(dir, [{
-      id: 'task-2',
-      display_id: 'CLI-8',
-      title: 'Ship the landing page',
-      status: 'review',
-      claimed_by: 'keshav',
-      updated_at: 40,
-      review: { agent_certified: true, agent_review_pass_count: 2 },
-    }]);
+    writeReadyWorkspace(dir, [
+      {
+        id: 'task-1',
+        display_id: 'UNW-1',
+        title: 'Open follow-up',
+        status: 'open',
+        updated_at: 10,
+      },
+      {
+        id: 'task-2',
+        display_id: 'UNW-2',
+        title: 'Print a human line like 4 words so the count is easy to read.',
+        status: 'review',
+        claimed_by: 'keshav',
+        updated_at: 20,
+        review: { agent_certified: true, agent_review_pass_count: 2 },
+      },
+      {
+        id: 'task-3',
+        display_id: 'UNW-3',
+        title: 'Second check still open',
+        status: 'review',
+        updated_at: 30,
+        review: { agent_review_pass_count: 1 },
+      },
+      {
+        id: 'task-4',
+        display_id: 'UNW-4',
+        title: 'Newer review still waiting',
+        status: 'review',
+        updated_at: 40,
+        review: { agent_review_pass_count: 1 },
+      },
+    ]);
     const res = runCli([], {
       cwd: dir,
       env: {
         HOME: home,
-        USER: 'keshav',
+        USER: 'keshavrao',
         ATRIS_TASKS_DB: path.join(dir, 'ready.db'),
       },
     });
     assert.equal(res.status, 0, res.stderr || res.stdout);
-    assert.match(res.stdout, /keshav|Ship the landing page/);
-    assert.match(res.stdout, /^next: atris /m);
+    assert.match(res.stdout, /hey keshav,/);
+    assert.doesNotMatch(res.stdout, /keshavrao/);
+    assert.match(res.stdout, /"print a human line like"/);
+    assert.match(res.stdout, /waiting for your ok/);
+    assert.match(res.stdout, /^next: atris task accept UNW-2$/m);
     assert.equal(res.stdout.match(/^next:/mg).length, 1);
+    assert.doesNotMatch(res.stdout, /you already shipped/);
+    assert.doesNotMatch(res.stdout, /review-chat/);
     assert.doesNotMatch(res.stdout, /What do you want to build/);
+    assert.ok(spokenLineCount(res.stdout) <= 6);
   } finally {
     cleanupTempDir(dir);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bare `atris` was saying three different things at once: a unix username, a ticket dump, and `review-chat` on work that already passed both checks.

This keeps the same screen and the same verbs. It just tells one truth.

- Name comes from the saved account first name or email local-part (`keshav`), not `keshavrao`. `$USER` is last resort.
- Scratch paths under `/tmp`, `/var/folders`, and `atris-*` names print as `this folder`. A real folder like `launch-day` stays.
- Review work is never “shipped”. Certified / two-pass review says it is waiting for your ok. Uncertified review says it is ready to look at. Titles are a short quoted clip.
- If any review task is certified, next is `atris task accept <id>`. A newer uncertified review does not win. `review-chat` only appears when nothing is ready to accept.
- Empty folder still prints `next: atris init --minimal`. `--json` and `ATRIS_NO_INTERACTIVE` never init. `--yes` still runs `init --minimal`. Headless never prompts. Help is unchanged.

Verify: `node --test test/first-minute.test.js`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-657e3a6c-e0ec-496b-96bb-c0919a2c3fc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-657e3a6c-e0ec-496b-96bb-c0919a2c3fc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

