### PR TITLE
feat(cli): mint scoped agent tokens with atris login --agent

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -64,7 +64,7 @@ rg "syncCheckoutCommand|checkoutBehindMessage|trackedTreeIsClean" commands/sync-
 rg "logAtris|logsDigest|addInboxIdea|--repl" commands/log.js bin/atris.js test/logs-digest.test.js test/dogfood-papercuts.test.js test/dogfood-p0.test.js  # `atris log \"note\"` inbox write, optional --repl editor, and read-only daily digest
 rg "logSyncAtris" commands/log-sync.js      # Log sync command
 rg "experimentsCommand" commands/experiments.js  # Experiments CLI command
-rg "loginAtris|switchAccount|useAccount|accountsCmd|showAuthHelp|--global|scope" bin/atris.js commands/auth.js lib/cli-scope.js test/dogfood-p1.test.js # Auth/account commands + workspace vs --global account list
+rg "loginAtris|mintAgentToken|parseAgentTokenArgs|--agent|agent-token|showAuthHelp|--global|scope" bin/atris.js commands/auth.js lib/cli-scope.js test/auth-agent-token.test.js test/dogfood-p1.test.js # Auth/account commands, scoped agent-token mint from stored JWT (`atris login --agent`), and workspace vs --global account list
 rg "doctorCommand|task_support|public bin shim" commands/doctor.js bin/atris.js package.json test/dogfood-p1.test.js # atris doctor --json: node, task-support 22+, auth, workspace, tiny POSIX bin shim (helpers stay internal)
 rg "agentDoctor|inspectAgentCliWiring|agent dogfood|agentDogfoodCommand|agentSpawnCommand|agent_spawns" bin/atris.js commands/agent-spawn.js test/commands.test.js test/agent-spawn.test.js commands/init.js # Local AI CLI wiring doctor, Devin/Droid GLM 5.2 dogfood smoke, durable worker spawn requests, and Devin init scaffold
 rg "activateAtris|showActivateHelp|activate and next --help" bin/atris.js commands/activate.js test/commands.test.js # Activate command + wiki status + non-mutating help

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -709,7 +709,7 @@ function showHelpAll() {
   console.log('  agent      - Select cloud agent, spawn worker requests, or run `agent doctor`');
   console.log('  chat       - Chat with Atris 2 Fast in this workspace (--agent for cloud agent; or: atris chat scan)');
   console.log('  fast       - Chat with Atris2 Fast');
-  console.log('  login      - Sign in or add another account');
+  console.log('  login      - Sign in, add an account, or mint a scoped agent token (--agent)');
   console.log('  logout     - Sign out of current account');
   console.log('  whoami     - Show active account');
   console.log('  switch     - Switch account globally (atris switch <name>)');
@@ -957,7 +957,7 @@ function showReleaseHelp() {
 
 function showAuthHelp(commandName) {
   const usage = {
-    login: 'Usage: atris login [--token <token>] [--force]',
+    login: 'Usage: atris login [--token <token>] [--force] [--agent]',
     logout: 'Usage: atris logout',
     whoami: 'Usage: atris whoami [--json]',
     switch: 'Usage: atris switch [account] [--global]',
@@ -970,6 +970,7 @@ function showAuthHelp(commandName) {
   console.log('Description:');
   if (commandName === 'login') {
     console.log('  Sign in with browser OAuth or a pasted API token.');
+    console.log('  --agent mints a scoped agent token from stored credentials. No browser.');
   } else if (commandName === 'logout') {
     console.log('  Sign out of the current Atris account.');
   } else if (commandName === 'whoami') {
@@ -984,8 +985,11 @@ function showAuthHelp(commandName) {
   console.log('');
   console.log('Options:');
   if (commandName === 'login') {
-    console.log('  --token <token>  Save an API token without prompting.');
-    console.log('  --force, -f      Re-run login even if credentials already exist.');
+    console.log('  --token <token>           Save an API token without prompting.');
+    console.log('  --force, -f               Re-run login even if credentials already exist.');
+    console.log('  --agent                   Mint a scoped agent token from the stored login.');
+    console.log('  --scopes <list>           Comma-separated scopes (default: x-search,youtube).');
+    console.log('  --daily-credit-cap <n>    Daily credit cap (default: 50).');
   } else if (commandName === 'switch') {
     console.log('  --global, -g     Switch the account for all terminals.');
   }

--- a/commands/auth.js
+++ b/commands/auth.js
@@ -1,8 +1,220 @@
-const { loadCredentials, saveCredentials, deleteCredentials, getCredentialsPath, openBrowser, promptUser, displayAccountSummary, ensureValidCredentials, loadProfile, listProfiles, profileNameFromEmail, deleteProfile, getTerminalSessionId, setSessionProfile, getSessionProfile, clearSessionProfile, cleanStaleSessions, getSessionsDir } = require('../utils/auth');
+const { loadCredentials, saveCredentials, deleteCredentials, getCredentialsPath, openBrowser, promptUser, displayAccountSummary, ensureValidCredentials, loadProfile, listProfiles, profileNameFromEmail, deleteProfile, saveProfile, getTokenExpiryEpochSeconds, getTerminalSessionId, setSessionProfile, getSessionProfile, clearSessionProfile, cleanStaleSessions, getSessionsDir } = require('../utils/auth');
 const { getAppBaseUrl, apiRequestJson } = require('../utils/api');
 const { isNonInteractive, wantsJson } = require('../lib/noninteractive');
+const { hasFlag, readFlag } = require('../lib/arg-parser');
 const fs = require('fs');
 const path = require('path');
+
+const AGENT_TOKEN_PATH = '/auth/agent-token';
+const DEFAULT_AGENT_SCOPES = ['x-search', 'youtube'];
+const DEFAULT_DAILY_CREDIT_CAP = 50;
+
+function firstNonEmptyString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function wantsAgentToken(args = []) {
+  if (hasFlag(args, '--agent')) return true;
+  const first = args.find((arg) => arg && !String(arg).startsWith('-'));
+  return first === 'agent-token';
+}
+
+function parseScopeList(raw) {
+  if (!raw) return [...DEFAULT_AGENT_SCOPES];
+  const scopes = String(raw).split(',').map((part) => part.trim()).filter(Boolean);
+  if (scopes.length === 0) {
+    throw new Error('scopes must list at least one value');
+  }
+  return scopes;
+}
+
+function parseDailyCreditCap(args) {
+  const present = args.some((arg) => arg === '--daily-credit-cap' || String(arg).startsWith('--daily-credit-cap='));
+  const raw = readFlag(args, '--daily-credit-cap', '');
+  if (!present) return DEFAULT_DAILY_CREDIT_CAP;
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error('daily credit cap must be a positive integer');
+  }
+  return value;
+}
+
+function parseAgentTokenArgs(args = []) {
+  return {
+    agent: wantsAgentToken(args),
+    scopes: parseScopeList(readFlag(args, '--scopes', '')),
+    dailyCreditCap: parseDailyCreditCap(args),
+    json: wantsJson(args),
+    help: hasFlag(args, '--help') || hasFlag(args, '-h') || args[0] === 'help',
+  };
+}
+
+function extractAgentAccessToken(data) {
+  if (!data || typeof data !== 'object') return null;
+  return firstNonEmptyString(
+    data.access_token,
+    data.token,
+    data.agent_access,
+    data.agent_token,
+    data.agent_access_token,
+  );
+}
+
+function expiryFromValue(value) {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const ms = value > 1e12 ? value : value * 1000;
+    return new Date(ms).toISOString();
+  }
+  return null;
+}
+
+function extractAgentTokenMeta(data, requested, token) {
+  const payload = data && typeof data === 'object' ? data : {};
+  const scopes = Array.isArray(payload.scopes) && payload.scopes.length
+    ? payload.scopes.map(String)
+    : requested.scopes;
+  const rawCap = payload.daily_credit_cap;
+  const dailyCreditCap = Number.isFinite(Number(rawCap)) ? Number(rawCap) : requested.dailyCreditCap;
+  const expiresAt = expiryFromValue(payload.expires_at ?? payload.expiry ?? payload.expires ?? payload.exp)
+    || expiryFromValue(getTokenExpiryEpochSeconds(token));
+  return { scopes, dailyCreditCap, expiresAt };
+}
+
+function persistMintedAgentToken(credentials, token, extras = {}) {
+  const next = {
+    token,
+    refresh_token: extras.refresh_token || credentials.refresh_token || null,
+    email: credentials.email || null,
+    user_id: credentials.user_id || null,
+    provider: credentials.provider || null,
+    saved_at: extras.saved_at || new Date().toISOString(),
+  };
+  if (credentials.source_profile) {
+    saveProfile(credentials.source_profile, next);
+    return next;
+  }
+  saveCredentials(next.token, next.refresh_token, next.email, next.user_id, next.provider);
+  return next;
+}
+
+function printAgentTokenMint(meta, output) {
+  output('minted scoped agent token');
+  output(`scopes: ${meta.scopes.join(', ')}`);
+  output(`daily credit cap: ${meta.dailyCreditCap}`);
+  if (meta.expiresAt) output(`expires: ${meta.expiresAt}`);
+}
+
+function redactSecret(text, secret) {
+  if (!secret || !text) return text;
+  return String(text).split(secret).join('[redacted]');
+}
+
+async function postAgentToken(api, token, body) {
+  return api(AGENT_TOKEN_PATH, {
+    method: 'POST',
+    token,
+    body,
+    retries: 0,
+  });
+}
+
+async function mintAgentToken(args = [], deps = {}) {
+  const output = deps.output || console.log;
+  const outputError = deps.outputError || console.error;
+  const api = deps.apiRequestJson || apiRequestJson;
+  const load = deps.loadCredentials || loadCredentials;
+  const persist = deps.persistMintedAgentToken || persistMintedAgentToken;
+  const now = deps.now || (() => new Date().toISOString());
+
+  let options;
+  try {
+    options = parseAgentTokenArgs(args);
+  } catch (error) {
+    const message = error.message || String(error);
+    if (wantsJson(args)) {
+      output(JSON.stringify({ ok: false, error: message }, null, 2));
+    } else {
+      outputError(message);
+    }
+    return 1;
+  }
+
+  const credentials = load() || {};
+  const accessToken = firstNonEmptyString(credentials.token);
+  const refreshToken = firstNonEmptyString(credentials.refresh_token);
+  if (!accessToken && !refreshToken) {
+    if (options.json) {
+      output(JSON.stringify({
+        ok: false,
+        error: 'not_logged_in',
+        next: 'atris login',
+      }, null, 2));
+    } else {
+      output('not signed in. run atris login first, then atris login --agent.');
+    }
+    return 1;
+  }
+
+  const body = {
+    scopes: options.scopes,
+    daily_credit_cap: options.dailyCreditCap,
+  };
+  let authToken = accessToken || refreshToken;
+  let result = await postAgentToken(api, authToken, body);
+  if (!result.ok && result.status === 401 && refreshToken && authToken !== refreshToken) {
+    authToken = refreshToken;
+    result = await postAgentToken(api, authToken, body);
+  }
+
+  if (!result.ok) {
+    const detail = redactSecret(result.error || 'agent token request failed', accessToken);
+    if (options.json) {
+      output(JSON.stringify({
+        ok: false,
+        error: redactSecret(detail, refreshToken),
+        status: result.status || 0,
+      }, null, 2));
+    } else {
+      outputError(redactSecret(detail, refreshToken));
+    }
+    return 1;
+  }
+
+  const minted = extractAgentAccessToken(result.data);
+  if (!minted) {
+    const message = 'backend did not return an agent token';
+    if (options.json) {
+      output(JSON.stringify({ ok: false, error: message }, null, 2));
+    } else {
+      outputError(message);
+    }
+    return 1;
+  }
+
+  persist(credentials, minted, {
+    refresh_token: firstNonEmptyString(result.data && result.data.refresh_token) || refreshToken,
+    saved_at: now(),
+  });
+
+  const meta = extractAgentTokenMeta(result.data, options, minted);
+  if (options.json) {
+    output(JSON.stringify({
+      ok: true,
+      minted: true,
+      scopes: meta.scopes,
+      daily_credit_cap: meta.dailyCreditCap,
+      expires_at: meta.expiresAt,
+    }, null, 2));
+    return 0;
+  }
+
+  printAgentTokenMint(meta, output);
+  return 0;
+}
 
 async function printWhoamiPayload(asJson) {
   const ensured = await ensureValidCredentials(apiRequestJson);
@@ -60,6 +272,20 @@ async function loginAtris(options = {}) {
 
   try {
     const existing = loadCredentials();
+
+    if (wantsAgentToken(args)) {
+      if (directToken) {
+        saveCredentials(
+          String(directToken).trim(),
+          existing?.refresh_token || null,
+          existing?.email || null,
+          existing?.user_id || null,
+          existing?.provider || 'manual',
+        );
+      }
+      const code = await mintAgentToken(args);
+      process.exit(code);
+    }
 
     // Direct token mode (non-interactive)
     if (directToken) {
@@ -675,4 +901,19 @@ function shellInit() {
   console.log(lines.join('\n'));
 }
 
-module.exports = { loginAtris, logoutAtris, whoamiAtris, switchAccount, useAccount, accountsCmd, listAccountsCmd, resolveProfile, profileEmail, activateGlobal, switchSession, shellInit };
+module.exports = {
+  loginAtris,
+  logoutAtris,
+  whoamiAtris,
+  switchAccount,
+  useAccount,
+  accountsCmd,
+  resolveProfile,
+  profileEmail,
+  activateGlobal,
+  switchSession,
+  shellInit,
+  parseAgentTokenArgs,
+  mintAgentToken,
+  wantsAgentToken,
+};

--- a/test/auth-agent-token.test.js
+++ b/test/auth-agent-token.test.js
@@ -1,0 +1,401 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+
+const {
+  parseAgentTokenArgs,
+  mintAgentToken,
+  wantsAgentToken,
+} = require('../commands/auth');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+const SECRET = 'minted-agent-access-token-secret';
+
+function jwtWithExp(exp) {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-agent-token-'));
+}
+
+function writeCredentials(home, creds) {
+  const dir = path.join(home, '.atris');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'credentials.json'), JSON.stringify(creds, null, 2));
+}
+
+function readCredentials(home) {
+  return JSON.parse(fs.readFileSync(path.join(home, '.atris', 'credentials.json'), 'utf8'));
+}
+
+function cliEnv(extra = {}) {
+  return {
+    ...process.env,
+    ATRIS_SKIP_UPDATE_CHECK: '1',
+    ATRIS_NONINTERACTIVE: '1',
+    ATRIS_TOKEN: '',
+    ATRIS_PROFILE: '',
+    ...extra,
+  };
+}
+
+function runCli(args, { cwd, env, timeout = 15000 } = {}) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout,
+    env: cliEnv(env),
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function runCliAsync(args, { cwd, env, timeout = 8000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd,
+      env: cliEnv(env),
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`cli hung past ${timeout}ms (args: ${args.join(' ')})`));
+    }, timeout);
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('close', (status) => {
+      clearTimeout(timer);
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+function startHttpMock(handler) {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      const text = Buffer.concat(chunks).toString('utf8');
+      let body = null;
+      if (text) {
+        try { body = JSON.parse(text); } catch { body = text; }
+      }
+      const request = {
+        method: req.method,
+        url: req.url,
+        authorization: req.headers.authorization,
+        body,
+      };
+      requests.push(request);
+      Promise.resolve()
+        .then(() => handler(request))
+        .catch((error) => ({ status: 500, body: { error: String(error.message || error) } }))
+        .then((response) => {
+          res.statusCode = response?.status || 200;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(response?.body || {}));
+        });
+    });
+  });
+  return new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: server.address().port, requests });
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test('parseAgentTokenArgs defaults scopes and cap, and accepts overrides', () => {
+  assert.equal(wantsAgentToken(['--agent']), true);
+  assert.equal(wantsAgentToken(['agent-token']), true);
+  assert.equal(wantsAgentToken(['--force']), false);
+
+  const defaults = parseAgentTokenArgs(['--agent']);
+  assert.equal(defaults.agent, true);
+  assert.deepEqual(defaults.scopes, ['x-search', 'youtube']);
+  assert.equal(defaults.dailyCreditCap, 50);
+
+  const youtubeOnly = parseAgentTokenArgs(['--agent', '--scopes', 'youtube', '--daily-credit-cap', '25']);
+  assert.deepEqual(youtubeOnly.scopes, ['youtube']);
+  assert.equal(youtubeOnly.dailyCreditCap, 25);
+
+  const inline = parseAgentTokenArgs(['agent-token', '--scopes=x-search, youtube', '--daily-credit-cap=10']);
+  assert.deepEqual(inline.scopes, ['x-search', 'youtube']);
+  assert.equal(inline.dailyCreditCap, 10);
+});
+
+test('mintAgentToken writes the store and prints scopes, cap, and expiry without the token', async () => {
+  const calls = [];
+  const output = [];
+  const errors = [];
+  const persisted = [];
+  const expiresAt = '2026-08-26T12:00:00.000Z';
+
+  const code = await mintAgentToken(['--agent'], {
+    output: (line) => output.push(line),
+    outputError: (line) => errors.push(line),
+    loadCredentials: () => ({
+      token: 'user-jwt',
+      refresh_token: 'refresh-jwt',
+      email: 'agent@example.com',
+      user_id: 'u-1',
+      provider: 'atris',
+    }),
+    persistMintedAgentToken: (credentials, token, extras) => {
+      persisted.push({ credentials, token, extras });
+    },
+    apiRequestJson: async (pathname, options) => {
+      calls.push({ pathname, options });
+      return {
+        ok: true,
+        status: 200,
+        data: {
+          access_token: SECRET,
+          token_type: 'agent_access',
+          scopes: ['x-search', 'youtube'],
+          daily_credit_cap: 50,
+          expires_at: expiresAt,
+        },
+      };
+    },
+  });
+
+  assert.equal(code, 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pathname, '/auth/agent-token');
+  assert.equal(calls[0].options.method, 'POST');
+  assert.equal(calls[0].options.token, 'user-jwt');
+  assert.deepEqual(calls[0].options.body, {
+    scopes: ['x-search', 'youtube'],
+    daily_credit_cap: 50,
+  });
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0].token, SECRET);
+  assert.equal(persisted[0].credentials.email, 'agent@example.com');
+
+  const text = output.join('\n');
+  assert.match(text, /minted scoped agent token/);
+  assert.match(text, /scopes: x-search, youtube/);
+  assert.match(text, /daily credit cap: 50/);
+  assert.match(text, /expires: 2026-08-26T12:00:00.000Z/);
+  assert.doesNotMatch(text, new RegExp(SECRET));
+  assert.equal(errors.length, 0);
+});
+
+test('mintAgentToken youtube-only request omits x-search from the body', async () => {
+  const calls = [];
+  const output = [];
+  const code = await mintAgentToken(['--agent', '--scopes', 'youtube'], {
+    output: (line) => output.push(line),
+    outputError: () => {},
+    loadCredentials: () => ({ token: 'user-jwt' }),
+    persistMintedAgentToken: () => {},
+    apiRequestJson: async (pathname, options) => {
+      calls.push({ pathname, options });
+      return {
+        ok: true,
+        status: 200,
+        data: {
+          token: SECRET,
+          scopes: ['youtube'],
+          daily_credit_cap: 50,
+        },
+      };
+    },
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(calls[0].options.body.scopes, ['youtube']);
+  assert.doesNotMatch(output.join('\n'), /x-search/);
+  assert.doesNotMatch(output.join('\n'), new RegExp(SECRET));
+});
+
+test('mintAgentToken --json omits the token and still records the mint', async () => {
+  const output = [];
+  const persisted = [];
+  const exp = Math.floor(Date.now() / 1000) + 3600;
+  const minted = jwtWithExp(exp);
+
+  const code = await mintAgentToken(['--agent', '--json'], {
+    output: (line) => output.push(line),
+    loadCredentials: () => ({ token: 'user-jwt' }),
+    persistMintedAgentToken: (_credentials, token) => persisted.push(token),
+    apiRequestJson: async () => ({
+      ok: true,
+      status: 200,
+      data: { agent_access: minted, scopes: ['youtube'], daily_credit_cap: 12 },
+    }),
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(persisted, [minted]);
+  const payload = JSON.parse(output.join('\n'));
+  assert.equal(payload.ok, true);
+  assert.equal(payload.minted, true);
+  assert.deepEqual(payload.scopes, ['youtube']);
+  assert.equal(payload.daily_credit_cap, 12);
+  assert.equal(payload.expires_at, new Date(exp * 1000).toISOString());
+  assert.equal('token' in payload, false);
+  assert.equal('access_token' in payload, false);
+  assert.doesNotMatch(output.join('\n'), new RegExp(minted));
+});
+
+test('mintAgentToken without stored credentials does not call the API or open a login wall', async () => {
+  const calls = [];
+  const output = [];
+  const code = await mintAgentToken(['--agent'], {
+    output: (line) => output.push(line),
+    outputError: () => {},
+    loadCredentials: () => null,
+    persistMintedAgentToken: () => {
+      throw new Error('should not persist');
+    },
+    apiRequestJson: async () => {
+      calls.push('called');
+      return { ok: true, status: 200, data: { token: SECRET } };
+    },
+  });
+
+  assert.equal(code, 1);
+  assert.deepEqual(calls, []);
+  assert.match(output.join('\n'), /not signed in/);
+  assert.doesNotMatch(output.join('\n'), /Choose login method|Opening browser|\/auth\/cli|Google/);
+});
+
+test('mintAgentToken retries with the refresh JWT after a 401', async () => {
+  const calls = [];
+  const persisted = [];
+  const code = await mintAgentToken(['--agent'], {
+    output: () => {},
+    outputError: () => {},
+    loadCredentials: () => ({
+      token: 'expired-user-jwt',
+      refresh_token: 'refresh-jwt',
+    }),
+    persistMintedAgentToken: (_credentials, token) => persisted.push(token),
+    apiRequestJson: async (_pathname, options) => {
+      calls.push(options.token);
+      if (options.token === 'expired-user-jwt') {
+        return { ok: false, status: 401, error: 'expired' };
+      }
+      return {
+        ok: true,
+        status: 200,
+        data: { access_token: SECRET, scopes: ['x-search'], daily_credit_cap: 50 },
+      };
+    },
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(calls, ['expired-user-jwt', 'refresh-jwt']);
+  assert.deepEqual(persisted, [SECRET]);
+});
+
+test('login --help lists --agent without touching credentials', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  try {
+    const res = runCli(['login', '--help'], { cwd: dir, env: { HOME: home } });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Usage: atris login/);
+    assert.match(res.stdout, /--agent/);
+    assert.match(res.stdout, /--scopes/);
+    assert.match(res.stdout, /--daily-credit-cap/);
+    assert.doesNotMatch(res.stdout, /Choose login method|Opening browser/);
+    assert.equal(fs.existsSync(path.join(home, '.atris')), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('login --agent without credentials stays off the login wall', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  try {
+    const res = runCli(['login', '--agent'], { cwd: dir, env: { HOME: home } });
+    assert.equal(res.status, 1, res.stderr);
+    assert.match(res.stdout, /not signed in/);
+    assert.match(res.stdout, /atris login --agent/);
+    assert.doesNotMatch(`${res.stdout}\n${res.stderr}`, /Choose login method|Opening browser|\/auth\/cli|Google/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('atris login --agent mints through the live CLI with mocked HTTP', async () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  writeCredentials(home, {
+    token: 'stored-user-jwt',
+    refresh_token: 'stored-refresh-jwt',
+    email: 'owner@example.com',
+    user_id: 'u-9',
+    provider: 'atris',
+  });
+
+  const mock = await startHttpMock((request) => ({
+    status: 200,
+    body: {
+      access_token: SECRET,
+      token_type: 'agent_access',
+      scopes: ['x-search', 'youtube'],
+      daily_credit_cap: 50,
+      expires_at: '2026-08-26T15:00:00.000Z',
+    },
+  }));
+
+  try {
+    const res = await runCliAsync(['login', '--agent'], {
+      cwd: dir,
+      env: {
+        HOME: home,
+        ATRIS_API_URL: `http://127.0.0.1:${mock.port}/api`,
+      },
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(mock.requests.length, 1);
+    assert.equal(mock.requests[0].method, 'POST');
+    assert.equal(mock.requests[0].url, '/api/auth/agent-token');
+    assert.equal(mock.requests[0].authorization, 'Bearer stored-user-jwt');
+    assert.deepEqual(mock.requests[0].body, {
+      scopes: ['x-search', 'youtube'],
+      daily_credit_cap: 50,
+    });
+    assert.match(res.stdout, /minted scoped agent token/);
+    assert.match(res.stdout, /scopes: x-search, youtube/);
+    assert.match(res.stdout, /daily credit cap: 50/);
+    assert.match(res.stdout, /expires: 2026-08-26T15:00:00.000Z/);
+    assert.doesNotMatch(`${res.stdout}\n${res.stderr}`, new RegExp(SECRET));
+    assert.doesNotMatch(`${res.stdout}\n${res.stderr}`, /Choose login method|Opening browser|\/auth\/cli/);
+
+    const stored = readCredentials(home);
+    assert.equal(stored.token, SECRET);
+    assert.equal(stored.refresh_token, 'stored-refresh-jwt');
+    assert.equal(stored.email, 'owner@example.com');
+  } finally {
+    await closeServer(mock.server);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/fast-tests.txt
+++ b/test/fast-tests.txt
@@ -3,6 +3,7 @@ test/agent-spawn.test.js
 test/analytics-productivity.test.js
 test/api-stream.test.js
 test/apps.test.js
+test/auth-agent-token.test.js
 test/auth-profile-refresh.test.js
 test/attempted-ledger.test.js
 test/auto-accept-certified.test.js


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Already-authenticated users and agents can mint a scoped Atris token without a browser login wall.

`atris login --agent` POSTs `/auth/agent-token` using the stored user JWT, agent identity JWT, or refresh JWT. Defaults match the backend contract: scopes `x-search,youtube` and daily credit cap `50`. Override with `--scopes` and `--daily-credit-cap`.

The minted token is written to the existing credentials store. Stdout and `--json` report only scopes, cap, and expiry. The token is never printed.

## Usage

```bash
atris login --agent
atris login --agent --scopes youtube --daily-credit-cap 25
```

Help lists `--agent`, `--scopes`, and `--daily-credit-cap`. Tests mock HTTP and do not burn live credits.

Backend: atrislabs/atrisos-backend#2536

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69186db3-d153-45e8-9752-2eba8b52639b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69186db3-d153-45e8-9752-2eba8b52639b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

