### PR TITLE
dogfood: first-minute keeps named rooms under tmp

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1508,7 +1508,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
 - **Entry point:** `bin/atris.js:1344` (`interactiveEntry`)
-- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`; empty folders name `atris init --minimal`; certified review names `atris task accept <id>`; scratch `/tmp` folders stay "this folder"; person name prefers the saved account first name
+- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`; empty folders name `atris init --minimal`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
 - **Helper:** `lib/context-gatherer.js`
 - **State:** `.atris/state/context_profile.json`
 - **Regression:** `test/first-minute.test.js`, `test/context-gatherer.test.js`, `test/cli-smoke.test.js`

--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -75,18 +75,25 @@ function personName(env = process.env, account) {
   return givenNameFrom(env.USER || env.LOGNAME) || unixUser(env);
 }
 
+function isThrowawayFolderName(name) {
+  const text = String(name || '');
+  if (/^(tmp|temp|atris-)/i.test(text)) return true;
+  if (/^[0-9a-f]{8,}$/i.test(text)) return true;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(text);
+}
+
 function isScratchFolder(root = process.cwd()) {
   const resolved = path.resolve(root || '.');
   const name = path.basename(resolved);
-  const unix = resolved.replace(/\\/g, '/');
-  if (/(?:^|\/)(?:tmp|temp|var\/folders)(?:\/|$)/i.test(unix)) return true;
+  if (isThrowawayFolderName(name)) return true;
   try {
     const tmp = path.resolve(os.tmpdir()).replace(/\\/g, '/');
-    if (unix === tmp || unix.startsWith(`${tmp}/`)) return true;
+    const unix = resolved.replace(/\\/g, '/');
+    if (unix === tmp) return true;
   } catch {
-    // Keep the path regex above.
+    // Named rooms keep their basename even under tmp.
   }
-  return /^(tmp|temp|atris-)/i.test(name);
+  return false;
 }
 
 function folderName(root = process.cwd()) {

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -139,9 +139,22 @@ test('personName prefers a given name from the saved account', () => {
 test('scratch folders stay this folder and real names stay', () => {
   assert.equal(folderName('/tmp/atris-use-now'), 'this folder');
   assert.equal(folderName('/tmp/atris-first-min-try'), 'this folder');
-  assert.equal(folderName('/var/folders/xx/yy/T/launch'), 'this folder');
+  assert.equal(folderName('/tmp/tmp'), 'this folder');
+  assert.equal(folderName('/tmp/temp'), 'this folder');
+  assert.equal(folderName('/tmp/a1b2c3d4e5f67890'), 'this folder');
+  assert.equal(folderName('/tmp/550e8400-e29b-41d4-a716-446655440000'), 'this folder');
+  assert.equal(folderName('/var/folders/xx/yy/T/launch'), 'launch');
+  assert.equal(folderName('/tmp/launch-day'), 'launch-day');
   assert.equal(folderName('/Users/keshav/launch-day'), 'launch-day');
   assert.equal(folderName('/Users/keshav/atris'), 'atris');
+});
+
+test('named empty folder under tmp keeps the room name', () => {
+  const text = renderFresh({ person: 'keshav', folder: folderName('/tmp/launch-day') });
+  assert.match(text, /hey keshav, launch-day is a clean start\./);
+  assert.match(text, /I'll set this up when you want\./);
+  assert.match(text, /^next: atris init --minimal$/m);
+  assert.ok(spokenLineCount(text) <= 4);
 });
 
 test('buildFirstMinute reads a claimed task from the local projection', () => {
@@ -227,9 +240,9 @@ test('empty dir bare atris names init, stays short, and does not hang', () => {
       env: { HOME: home, USER: 'keshav', ATRIS_TASKS_DB: path.join(dir, 'tasks.db') },
     });
     assert.equal(res.status, 0, res.stderr || res.stdout);
-    assert.match(res.stdout, /init/);
+    assert.match(res.stdout, /this folder is a clean start/);
     assert.match(res.stdout, /atris init --minimal/);
-    assert.match(res.stdout, /keshav|this folder|clean start/);
+    assert.match(res.stdout, /hey keshav,/);
     assert.ok(spokenLineCount(res.stdout) <= 6);
     assert.ok(res.stdout.length < 400);
     assert.doesNotMatch(res.stdout, /operating system|What do you want to build/i);
@@ -237,6 +250,28 @@ test('empty dir bare atris names init, stays short, and does not hang', () => {
     assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
   } finally {
     cleanupTempDir(dir);
+  }
+});
+
+test('empty named folder under tmp greets with the room name', () => {
+  const parent = makeTempDir();
+  const dir = path.join(parent, 'launch-day');
+  const home = path.join(parent, 'home');
+  fs.mkdirSync(dir);
+  fs.mkdirSync(home);
+  try {
+    const res = runCli([], {
+      cwd: dir,
+      env: { HOME: home, USER: 'keshav', ATRIS_TASKS_DB: path.join(dir, 'tasks.db') },
+    });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /hey keshav, launch-day is a clean start\./);
+    assert.match(res.stdout, /I'll set this up when you want\./);
+    assert.match(res.stdout, /^next: atris init --minimal$/m);
+    assert.doesNotMatch(res.stdout, /this folder is a clean start/);
+    assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+  } finally {
+    cleanupTempDir(parent);
   }
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A named empty room under `/tmp` used to greet the same as a throwaway scratch folder. `/tmp/launch-day` and `/tmp/atris-first-min-try` both said `this folder`.

The greeting now keeps a real folder name even under `/tmp`. Throwaway names stay generic.

- `launch-day` stays `launch-day`, including `/tmp/launch-day`.
- `atris-*`, `tmp`, `temp`, and random hashes still print as `this folder`.
- Empty named folder: `hey keshav, launch-day is a clean start.` then `I'll set this up when you want.` then `next: atris init --minimal`.
- Accept/review truth is unchanged. No auto-init without `--yes`. Headless never prompts. Help is unchanged.

Verify: `node --test test/first-minute.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-368e1e51-94cd-4ce4-9a9b-47448a3b5dc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-368e1e51-94cd-4ce4-9a9b-47448a3b5dc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

