### PR TITLE
dogfood: claimed next is ready, not step

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1509,7 +1509,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
 - **Entry point:** `bin/atris.js:1344` (`interactiveEntry`)
-- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`; empty folders name `atris init --minimal`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
+- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`; empty folders name `atris init --minimal`; claimed work names `atris task ready <id> --verify "<cmd>" --result "<plain sentence>"`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
 - **Helper:** `lib/context-gatherer.js`
 - **State:** `.atris/state/context_profile.json`
 - **Regression:** `test/first-minute.test.js`, `test/context-gatherer.test.js`, `test/cli-smoke.test.js`

--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -196,7 +196,7 @@ function taskCommand(task, person) {
     if (isCertifiedReview(task)) return ref ? `atris task accept ${ref}` : 'atris task reviews --limit 5';
     return ref ? `atris task review-chat ${ref} --as codex-review` : 'atris task reviews --limit 5';
   }
-  if (task.status === 'claimed') return ref ? `atris task step ${ref}` : 'atris do';
+  if (task.status === 'claimed') return ref ? `atris task ready ${ref} --verify "<cmd>" --result "<plain sentence>"` : 'atris do';
   if (task.status === 'open') {
     return ref ? `atris task claim ${ref} --as ${who}` : 'atris task next';
   }

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -75,10 +75,10 @@ test('claimed task first-minute names the person or title and one next command',
     person: 'keshav',
     folder: 'atris',
     task: { title: 'Ship the landing page', status: 'claimed', display_id: 'CLI-9' },
-    nextCommand: 'atris task step CLI-9',
+    nextCommand: 'atris task ready CLI-9 --verify "<cmd>" --result "<plain sentence>"',
   });
   assert.match(text, /hey keshav, "ship the landing page" is already yours\./);
-  assert.match(text, /^next: atris task step CLI-9$/m);
+  assert.match(text, /^next: atris task ready CLI-9 --verify "<cmd>" --result "<plain sentence>"$/m);
   assert.equal(text.match(/^next:/mg).length, 1);
   assert.ok(spokenLineCount(text) <= 4);
 });
@@ -174,7 +174,7 @@ test('buildFirstMinute reads a claimed task from the local projection', () => {
       folder: 'atris',
     });
     assert.match(screen.text, /"ship the landing page"/);
-    assert.equal(screen.nextCommand, 'atris task step CLI-9');
+    assert.equal(screen.nextCommand, 'atris task ready CLI-9 --verify "<cmd>" --result "<plain sentence>"');
   } finally {
     cleanupTempDir(dir);
   }
@@ -329,7 +329,7 @@ test('workspace with a claimed task names the person or title and one next comma
     });
     assert.equal(res.status, 0, res.stderr || res.stdout);
     assert.match(res.stdout, /keshav|ship the landing page/i);
-    assert.match(res.stdout, /^next: atris task step CLI-9$/m);
+    assert.match(res.stdout, /^next: atris task ready CLI-9 --verify "<cmd>" --result "<plain sentence>"$/m);
     assert.equal(res.stdout.match(/^next:/mg).length, 1);
     assert.doesNotMatch(res.stdout, /What do you want to build|context   loaded|Atris Do/);
     assert.ok(spokenLineCount(res.stdout) <= 6);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After you claim a task, bare `atris` used to print `next: atris task step <id>`. That command cannot succeed. It errors with `meaningful proof required` and tells you to run `atris task ready` instead.

The first-minute screen now points at the documented ready argv: `atris task ready <id> --verify "<cmd>" --result "<plain sentence>"`.

Name, folder, and accept truth stay the same. An empty folder still prints `atris init --minimal`. Headless still never prompts. `task step` still requires proof.

Verify: `node --test test/first-minute.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af083d25-4afb-47d6-9563-2f58f9d84f64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af083d25-4afb-47d6-9563-2f58f9d84f64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

