### PR TITLE
dogfood: do after minimal init stays in the room

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -44,9 +44,9 @@ rg "missionDrive|destinationHash|mission_destination_change_proposed|pending_des
 rg "askCommand|currentMissionCommand|approveCommand|stopCommand|answerCommand|readyCommand|checkCommand|missionCard" commands/human-missions.js commands/mission.js lib/cloud-mission.js bin/atris.js test/human-missions.test.js  # Public human mission commands: ask, current card, answer, approve, stop, readiness, and check results over the cloud mission client
 rg "decideCommand|collectOpenDecisions|normalizeHumanAsk|answerMissionHumanAsk" commands/decide.js commands/mission.js lib/mission-human-asks.js lib/self-drive.js test/decide.test.js  # Mission human-decision bridge: list open asks deterministically, route yes/no through mission pings, persist answered metadata, and ignore answered asks in mission/self-drive reads
 rg "starterMembers|team members ready|firstMissionCommand|packed golden path|printedAtrisArgs|golden path e2e|what someone can do now|--minimal|mapStubFromTree" commands/init.js bin/atris.js commands/task.js test/init-non-interactive.test.js test/golden-path-e2e.test.js test/repo-shape.test.js test/dogfood-papercuts.test.js atris/team/customer-lead atris/GOLDEN_PATH_PAPERCUTS.md  # Quiet first-run output plus packed-install zero-knowledge contract: six-member starter team, init --minimal lean scaffold, ready-on-init mission, autoland, durable papercut status
-rg "function planAtris" commands/workflow.js   # Plan command (line 363)
-rg "function doAtris" commands/workflow.js     # Do command (line 709)
-rg "function reviewAtris" commands/workflow.js  # Review command (line 1062): default certified queue, --verbose legacy validator prompt
+rg "function planAtris" commands/workflow.js   # Plan command (line 370)
+rg "function doAtris" commands/workflow.js     # Do command (line 717): initialized workspace is enough; missing executor spec after init --minimal does not send you back to init
+rg "function reviewAtris" commands/workflow.js  # Review command (line 1077): default certified queue, --verbose legacy validator prompt
 rg "Confidence Gate|confidenceGatePrompt" commands/workflow.js test/confidence-gate.test.js  # Plan/do/review loophole gate prompt + regression
 rg "statusAtris|showStatusHelp|status and analytics --help" bin/atris.js commands/status.js test/commands.test.js # Status command + workspace-free help
 rg "analyticsAtris|showAnalyticsHelp|status and analytics --help" bin/atris.js commands/analytics.js test/commands.test.js  # Analytics command + workspace-free help
@@ -1176,19 +1176,20 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 1. **`atris plan`** - Navigator mode
 
-- Entry: `commands/workflow.js:362-701` (planAtris function)
+- Entry: `commands/workflow.js:370-714` (planAtris function)
 - Outputs: navigator.md spec + Inbox context + TODO.md
 - Purpose: Brainstorm and create tasks from inbox
 
 2. **`atris do`** - Executor mode
 
-- Entry: `commands/workflow.js:709-1060` (doAtris function)
+- Entry: `commands/workflow.js:717-1075` (doAtris function)
 - Outputs: executor.md spec + TODO.md + MAP.md
 - Purpose: Build tasks with step-by-step confirmation
+- Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do after init --yes --minimal does not send you back to init`).
 
 3. **`atris review`** - Validator mode
 
-- Entry: `commands/workflow.js:1062-1551` (reviewAtris function)
+- Entry: `commands/workflow.js:1077-1566` (reviewAtris function)
 - Outputs: validator.md spec + TODO.md + MAP.md + journal
 - Purpose: Ultrathink validation, test, clean docs
 
@@ -1799,9 +1800,9 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - `upgradeAtris()` — npm upgrade (line 1214)
 **Modular commands (in commands/):**
 
-- `planAtris()` → `commands/workflow.js:362-701`
-- `doAtris()` → `commands/workflow.js:709-1060`
-- `reviewAtris()` → `commands/workflow.js:1062-1551`
+- `planAtris()` → `commands/workflow.js:370-714`
+- `doAtris()` → `commands/workflow.js:717-1075`
+- `reviewAtris()` → `commands/workflow.js:1077-1566`
 - `statusAtris()` → `commands/status.js:124-384`
 - `analyticsAtris()` → `commands/analytics.js:4-147`
 - `brainstormAtris()` → `commands/brainstorm.js:21-355`

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -728,11 +728,16 @@ async function doAtris() {
 
   const cwd = process.cwd();
   const targetDir = path.join(cwd, 'atris');
-  const executorFile = fs.existsSync(path.join(targetDir, 'team', 'executor', 'MEMBER.md'))
-    ? path.join(targetDir, 'team', 'executor', 'MEMBER.md')
-    : path.join(targetDir, 'team', 'executor.md');
+  const memberExecutor = path.join(targetDir, 'team', 'executor', 'MEMBER.md');
+  const legacyExecutor = path.join(targetDir, 'team', 'executor.md');
+  const executorFile = fs.existsSync(memberExecutor)
+    ? memberExecutor
+    : (fs.existsSync(legacyExecutor) ? legacyExecutor : null);
 
-  if (!fs.existsSync(executorFile)) {
+  // Prompt-mode do only needs an initialized workspace. The executor spec is
+  // optional context, same as PERSONA.md. A missing spec after init --minimal
+  // must not send the operator back to init.
+  if (!executorFile && !fs.existsSync(targetDir)) {
     console.log('✗ executor.md not found. Run "atris init" first.');
     process.exit(1);
   }
@@ -755,8 +760,7 @@ async function doAtris() {
     }
   }
 
-  // Load executor spec
-  const executorSpec = fs.readFileSync(executorFile, 'utf8');
+  const executorSpec = executorFile ? fs.readFileSync(executorFile, 'utf8') : '';
 
   // Load PERSONA.md
   const personaFile = path.join(targetDir, 'PERSONA.md');
@@ -799,7 +803,7 @@ async function doAtris() {
   // All tasks available (no tag filtering)
   const filteredTasks = tasksContent;
 
-  const executorPath = path.relative(process.cwd(), executorFile);
+  const executorPath = executorFile ? path.relative(process.cwd(), executorFile) : null;
   const personaFileRef = fs.existsSync(personaFile) ? path.relative(process.cwd(), personaFile) : null;
   const taskSourcePath = taskFilePath ? path.relative(process.cwd(), taskFilePath) : null;
   const featuresReadmePath = path.join(targetDir, 'features', 'README.md');
@@ -846,7 +850,7 @@ async function doAtris() {
   console.log('');
 
   console.log('📁 CONTEXT FILES (agent should read):');
-  console.log(`- Executor spec: ${executorPath}`);
+  console.log(`- Executor spec: ${executorPath || 'atris/team/executor/MEMBER.md (missing)'}`);
   console.log(`- Persona: ${personaFileRef || 'atris/PERSONA.md (missing)'}`);
   const mapDisplay = mapPath
     ? `${mapPath}${mapIsPlaceholder ? ' (placeholder — generate first)' : ''}`
@@ -897,7 +901,7 @@ async function doAtris() {
   console.log('You are the Executor.');
   console.log('');
   console.log('Read these files:');
-  console.log(`- ${executorPath}`);
+  if (executorPath) console.log(`- ${executorPath}`);
   if (personaFileRef) console.log(`- ${personaFileRef}`);
   if (mapPath) console.log(`- ${mapPath}`);
   if (taskSourcePath) console.log(`- ${taskSourcePath}`);
@@ -934,10 +938,12 @@ async function doAtris() {
       console.log('');
     }
 
-    console.log('🔧 EXECUTOR SPEC (full):');
-    console.log('─────────────────────────────────────────────────────────────');
-    console.log(executorSpec);
-    console.log('');
+    if (executorSpec) {
+      console.log('🔧 EXECUTOR SPEC (full):');
+      console.log('─────────────────────────────────────────────────────────────');
+      console.log(executorSpec);
+      console.log('');
+    }
 
     if (filteredTasks) {
       console.log(`📋 TASKS TO EXECUTE (full, from ${taskSource}):`);

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -93,8 +93,29 @@ test('do in an uninitialized directory gives a plain error, not a stack trace', 
   const res = runCli(['do'], { cwd: dir });
   assert.equal(res.status, 1);
   assert.match(res.stdout, /executor\.md not found/);
+  assert.match(res.stdout, /atris init/);
   const combined = res.stdout + res.stderr;
   assert.ok(!/at .*workflow\.js:\d+/.test(combined), `stack trace leaked:\n${combined}`);
+});
+
+test('do after init --yes --minimal does not send you back to init', () => {
+  const dir = makeTempDir();
+  const init = runCli(['init', '--yes', '--minimal'], { cwd: dir });
+  assert.equal(init.status, 0, init.stderr || init.stdout);
+  assert.ok(fs.existsSync(path.join(dir, 'atris', 'MAP.md')));
+  assert.ok(fs.existsSync(path.join(dir, 'atris', 'atris.md')));
+  assert.equal(fs.existsSync(path.join(dir, 'atris', 'team', 'executor', 'MEMBER.md')), false);
+  assert.equal(fs.existsSync(path.join(dir, 'atris', 'team', 'executor.md')), false);
+
+  const res = runCli(['do'], { cwd: dir });
+  const combined = res.stdout + res.stderr;
+  assert.equal(res.status, 0, combined);
+  assert.match(res.stdout, /PROMPT ONLY/);
+  assert.match(res.stdout, /Atris Do — Executor Agent Activated/);
+  assert.match(res.stdout, /You are the Executor\./);
+  assert.match(res.stdout, /Executor spec: atris\/team\/executor\/MEMBER\.md \(missing\)/);
+  assert.doesNotMatch(combined, /executor\.md not found|Run "atris init"/);
+  assert.doesNotMatch(combined, /What do you want to build|Describe the desired outcome/);
 });
 
 test('plan on an initialized workspace prints the navigator prompt shape', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After `atris init --yes --minimal`, first-minute already treats the folder as set up. `atris do` still said `executor.md not found. Run "atris init" first` even though MAP, the protocol file, and a starter task were there.

`do` in prompt mode only needs an initialized workspace. The executor spec is optional context, same as PERSONA. If it is missing, `do` now prints the executor prompt and marks the spec missing. An empty folder still tells you to init.

No email, spend, or cloud work. Headless still does not prompt.

## Verify

```bash
node --test test/workflow-command.test.js
```

## Files

- `commands/workflow.js`
- `test/workflow-command.test.js`
- `atris/MAP.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46801c6d-c929-452b-9694-3a6df1b41686?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46801c6d-c929-452b-9694-3a6df1b41686&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

