### PR TITLE
dogfood: empty first-minute is two spoken lines

### DIFF
--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -255,7 +255,6 @@ function renderFresh({ person = '', folder = 'this folder' } = {}) {
   const room = folder || 'this folder';
   return [
     `${greet(person)}${room} is a clean start.`,
-    "I'll set this up when you want.",
     '',
     `next: ${INIT_COMMAND}`,
   ].join('\n');

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -68,9 +68,9 @@ function writeReadyWorkspace(dir, tasks) {
 test('fresh first-minute copy names init and stays short', () => {
   const text = renderFresh({ person: 'keshav', folder: 'this folder' });
   assert.match(text, /hey keshav, this folder is a clean start\./);
-  assert.match(text, /I'll set this up when you want\./);
+  assert.doesNotMatch(text, /I'll set this up when you want/);
   assert.match(text, /^next: atris init --minimal$/m);
-  assert.ok(spokenLineCount(text) <= 4);
+  assert.equal(spokenLineCount(text), 2);
   assert.ok(text.length < 200);
 });
 
@@ -212,9 +212,9 @@ test('scratch folders stay this folder and real names stay', () => {
 test('named empty folder under tmp keeps the room name', () => {
   const text = renderFresh({ person: 'keshav', folder: folderName('/tmp/launch-day') });
   assert.match(text, /hey keshav, launch-day is a clean start\./);
-  assert.match(text, /I'll set this up when you want\./);
+  assert.doesNotMatch(text, /I'll set this up when you want/);
   assert.match(text, /^next: atris init --minimal$/m);
-  assert.ok(spokenLineCount(text) <= 4);
+  assert.equal(spokenLineCount(text), 2);
 });
 
 test('buildFirstMinute reads a claimed task from the local projection', () => {
@@ -303,6 +303,7 @@ test('empty dir bare atris names init, stays short, and does not hang', () => {
     assert.match(res.stdout, /this folder is a clean start/);
     assert.match(res.stdout, /atris init --minimal/);
     assert.match(res.stdout, /hey keshav,/);
+    assert.doesNotMatch(res.stdout, /I'll set this up when you want/);
     assert.ok(spokenLineCount(res.stdout) <= 6);
     assert.ok(res.stdout.length < 400);
     assert.doesNotMatch(res.stdout, /operating system|What do you want to build/i);
@@ -326,7 +327,7 @@ test('empty named folder under tmp greets with the room name', () => {
     });
     assert.equal(res.status, 0, res.stderr || res.stdout);
     assert.match(res.stdout, /hey keshav, launch-day is a clean start\./);
-    assert.match(res.stdout, /I'll set this up when you want\./);
+    assert.doesNotMatch(res.stdout, /I'll set this up when you want/);
     assert.match(res.stdout, /^next: atris init --minimal$/m);
     assert.doesNotMatch(res.stdout, /this folder is a clean start/);
     assert.equal(fs.existsSync(path.join(dir, 'atris')), false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
An empty folder used to print three spoken lines. The middle one was a receptionist shrug: it would set things up when you want.

Bare `atris` in a clean folder now matches a live workspace: one win, then next.

```
hey keshav, studio-five is a clean start.
next: atris init --minimal
```

`--yes` still auto-inits. Headless without `--yes` still only prints the next command. Named folders keep their name. Scratch folders stay `this folder`. Workspace copy is unchanged. Headless never prompts.

Verify: `node --test test/first-minute.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ef88cba-5a4b-48f5-96a1-e7afb5404454?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ef88cba-5a4b-48f5-96a1-e7afb5404454&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

