### PR TITLE
dogfood: atris do talks like first-minute

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -45,7 +45,7 @@ rg "askCommand|currentMissionCommand|approveCommand|stopCommand|answerCommand|re
 rg "decideCommand|collectOpenDecisions|normalizeHumanAsk|answerMissionHumanAsk" commands/decide.js commands/mission.js lib/mission-human-asks.js lib/self-drive.js test/decide.test.js  # Mission human-decision bridge: list open asks deterministically, route yes/no through mission pings, persist answered metadata, and ignore answered asks in mission/self-drive reads
 rg "starterMembers|team members ready|firstMissionCommand|packed golden path|printedAtrisArgs|golden path e2e|what someone can do now|--minimal|mapStubFromTree" commands/init.js bin/atris.js commands/task.js test/init-non-interactive.test.js test/golden-path-e2e.test.js test/repo-shape.test.js test/dogfood-papercuts.test.js atris/team/customer-lead atris/GOLDEN_PATH_PAPERCUTS.md  # Quiet first-run output plus packed-install zero-knowledge contract: six-member starter team, init --minimal lean scaffold, ready-on-init mission, autoland, durable papercut status; printedAtrisArgs (test/golden-path-e2e.test.js:112) matches Next/next labels; packed path follows init --minimal, then the printed claim/ready/autoland commands
 rg "function planAtris" commands/workflow.js   # Plan command (line 370)
-rg "function doAtris" commands/workflow.js     # Do command (line 717): initialized workspace is enough; missing executor spec after init --minimal does not send you back to init
+rg "function doAtris" commands/workflow.js     # Do command (line 718): PERSONA head reuses buildFirstMinute; factory banner and file dump stay on --verbose/--full; missing executor spec after init --minimal does not send you back to init
 rg "function reviewAtris" commands/workflow.js  # Review command (line 1077): default certified queue, --verbose legacy validator prompt
 rg "Confidence Gate|confidenceGatePrompt" commands/workflow.js test/confidence-gate.test.js  # Plan/do/review loophole gate prompt + regression
 rg "statusAtris|showStatusHelp|status and analytics --help" bin/atris.js commands/status.js test/commands.test.js # Status command + workspace-free help
@@ -1187,10 +1187,10 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 2. **`atris do`** - Executor mode
 
-- Entry: `commands/workflow.js:717-1075` (doAtris function)
-- Outputs: executor.md spec + TODO.md + MAP.md
-- Purpose: Build tasks with step-by-step confirmation
-- Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do after init --yes --minimal does not send you back to init`).
+- Entry: `commands/workflow.js:718-1095` (doAtris function)
+- Human head: `lib/first-minute.js` `buildFirstMinute` (same win + next as bare `atris`); never prints `Context: UNKNOWN` or `Backlog tasks: 0` when a claimed/review/open task exists
+- Default stays PROMPT ONLY with the copy/paste executor prompt below the fold; `--verbose`/`--full` prints the file dump
+- Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do after init --yes --minimal does not send you back to init`, `do names a claimed task the same way first-minute does`)
 
 3. **`atris review`** - Validator mode
 
@@ -1515,13 +1515,13 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
 - **Entry point:** `bin/atris.js:1344` (`interactiveEntry`)
-- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris` and default `atris task` (`commands/task.js` `cmdFirstMinute`); empty folders name `atris init --minimal`; `shouldAutoInitFresh` runs `init --minimal` on `--yes`/`-y` even under `ATRIS_NO_INTERACTIVE`, then the post-init screen names the seeded claim; `--json` and headless without `--yes` stay print-only; claimed work names `atris task ready <id>`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
+- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`, default `atris task` (`commands/task.js` `cmdFirstMinute`), and the human head of `atris do` (`commands/workflow.js` `doAtris`); empty folders name `atris init --minimal`; `shouldAutoInitFresh` runs `init --minimal` on `--yes`/`-y` even under `ATRIS_NO_INTERACTIVE`, then the post-init screen names the seeded claim; `--json` and headless without `--yes` stay print-only; claimed work names `atris task ready <id>`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
 - **Task desk next:** `lib/first-minute.js` (`deskNextCommand`) reuses `pickNext`/`taskCommand` for `commands/task.js` `renderTaskDesk` on `atris task desk` and `atris task --all`; claimed desk copy is `atris task ready <id>`
 - **Task next:** `commands/task.js` (`cmdNextTruth`) reuses `pickNext`/`taskCommand`/`taskNextCommand` so `atris task next` names the same accept/ready/claim/new command as bare atris and the desk; `--create-next` still seeds Endgame fallback
 - **Helper:** `lib/context-gatherer.js`
 - **State:** `.atris/state/context_profile.json`
-- **Regression:** `test/first-minute.test.js`, `test/task-first-minute.test.js`, `test/task-desk-next.test.js`, `test/task-next-truth.test.js`, `test/context-gatherer.test.js`, `test/cli-smoke.test.js`
-- **Search:** `rg "shouldGatherContext|saveContextProfile|createStarterTask|buildFirstMinute|cmdFirstMinute|deskNextCommand|taskNextCommand|cmdNextTruth|Context gatherer" bin/atris.js lib/context-gatherer.js lib/first-minute.js commands/task.js test`
+- **Regression:** `test/first-minute.test.js`, `test/task-first-minute.test.js`, `test/task-desk-next.test.js`, `test/task-next-truth.test.js`, `test/context-gatherer.test.js`, `test/cli-smoke.test.js`, `test/workflow-command.test.js`
+- **Search:** `rg "shouldGatherContext|saveContextProfile|createStarterTask|buildFirstMinute|cmdFirstMinute|deskNextCommand|taskNextCommand|cmdNextTruth|Context gatherer" bin/atris.js lib/context-gatherer.js lib/first-minute.js commands/task.js commands/workflow.js test
 
 ---
 
@@ -1808,7 +1808,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Modular commands (in commands/):**
 
 - `planAtris()` → `commands/workflow.js:370-714`
-- `doAtris()` → `commands/workflow.js:717-1075`
+- `doAtris()` → `commands/workflow.js:718-1095`
 - `reviewAtris()` → `commands/workflow.js:1077-1566`
 - `statusAtris()` → `commands/status.js:124-384`
 - `analyticsAtris()` → `commands/analytics.js:4-147`

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -804,8 +804,8 @@ function showDoHelp() {
   console.log('');
   console.log('Description:');
   console.log('  Activate the Executor agent to build tasks.');
-  console.log('  Default is PROMPT ONLY: prints step-by-step execution instructions.');
-  console.log('  Reads TODO.md and features/*/build.md.');
+  console.log('  Default is PROMPT ONLY: same win and next command as bare atris, then the executor prompt.');
+  console.log('  --verbose prints the executor file dump. Reads TODO.md and features/*/build.md.');
   console.log('');
   console.log('Options:');
   console.log('  --execute   ACTION TAKEN: edit code + run commands via Atris cloud.');

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { getLogPath } = require('../lib/journal');
+const { buildFirstMinute } = require('../lib/first-minute');
 const { buildToolResultBody } = require('../lib/tool-result-encode');
 
 function wrapWorkflowText(text, width = 76) {
@@ -840,39 +841,25 @@ async function doAtris() {
     workspaceSummary = null;
   }
 
-  // Prompt-mode output (keep concise by default)
+  let firstMinute = null;
+  try {
+    firstMinute = buildFirstMinute({
+      root: cwd,
+      context: workspaceSummary || {},
+    });
+  } catch {
+    firstMinute = null;
+  }
+  const liveStatus = firstMinute && firstMinute.task && firstMinute.task.status;
+  const hasLiveTask = liveStatus === 'claimed' || liveStatus === 'review' || liveStatus === 'open';
+
+  // Prompt-mode output: PERSONA head first, same truth as bare atris.
   console.log(executionMode === 'prompt' ? 'PROMPT ONLY' : 'ACTION TAKEN');
   console.log('');
-  console.log('┌─────────────────────────────────────────────────────────────┐');
-  console.log('│ Atris Do — Executor Agent Activated                         │');
-  console.log(`│ Context: ${context}                                           │`);
-  console.log('└─────────────────────────────────────────────────────────────┘');
-  console.log('');
-
-  console.log('📁 CONTEXT FILES (agent should read):');
-  console.log(`- Executor spec: ${executorPath || 'atris/team/executor/MEMBER.md (missing)'}`);
-  console.log(`- Persona: ${personaFileRef || 'atris/PERSONA.md (missing)'}`);
-  const mapDisplay = mapPath
-    ? `${mapPath}${mapIsPlaceholder ? ' (placeholder — generate first)' : ''}`
-    : 'atris/MAP.md (missing)';
-  console.log(`- MAP: ${mapDisplay}`);
-  console.log(`- TODO: ${taskSourcePath || 'atris/TODO.md (missing)'}`);
-  console.log(`- Features index: ${featuresReadmeRef || 'atris/features/README.md (missing)'}`);
-
-  // Show top learnings during execution
-  try {
-    const { loadLearnings } = require('../lib/learnings');
-    const learnings = loadLearnings().filter(e => e._effectiveConfidence >= 7 && e.insight !== '[REMOVED]').slice(0, 3);
-    if (learnings.length > 0) {
-      console.log('');
-      console.log('🧠 Prior learnings (apply during build):');
-      for (const l of learnings) {
-        console.log(`  [${l._effectiveConfidence}/10] ${l.type}/${l.key}: ${l.insight}`);
-      }
-    }
-  } catch {}
-
-  console.log('');
+  if (firstMinute && firstMinute.text) {
+    console.log(firstMinute.text);
+    console.log('');
+  }
 
   const backlogCount = workspaceSummary && Array.isArray(workspaceSummary.backlogTasks)
     ? workspaceSummary.backlogTasks.length
@@ -881,18 +868,46 @@ async function doAtris() {
     ? workspaceSummary.inProgressFeatures.length
     : 0;
 
-  if (inProgressCount > 0) {
-    console.log(`🔨 In-progress features: ${workspaceSummary.inProgressFeatures.join(', ')}`);
-  }
-  console.log(`🧱 Feature build plans found: ${featureBuildPlanRefs.length}`);
-  if (featureBuildPlanRefs.length > 0) {
-    featureBuildPlanRefs.slice(0, 3).forEach((ref) => console.log(`- ${ref}`));
-    if (featureBuildPlanRefs.length > 3) {
-      console.log(`- ... (+${featureBuildPlanRefs.length - 3} more)`);
+  if (showFull) {
+    console.log('📁 CONTEXT FILES (agent should read):');
+    console.log(`- Executor spec: ${executorPath || 'atris/team/executor/MEMBER.md (missing)'}`);
+    console.log(`- Persona: ${personaFileRef || 'atris/PERSONA.md (missing)'}`);
+    const mapDisplay = mapPath
+      ? `${mapPath}${mapIsPlaceholder ? ' (placeholder — generate first)' : ''}`
+      : 'atris/MAP.md (missing)';
+    console.log(`- MAP: ${mapDisplay}`);
+    console.log(`- TODO: ${taskSourcePath || 'atris/TODO.md (missing)'}`);
+    console.log(`- Features index: ${featuresReadmeRef || 'atris/features/README.md (missing)'}`);
+
+    try {
+      const { loadLearnings } = require('../lib/learnings');
+      const learnings = loadLearnings().filter(e => e._effectiveConfidence >= 7 && e.insight !== '[REMOVED]').slice(0, 3);
+      if (learnings.length > 0) {
+        console.log('');
+        console.log('🧠 Prior learnings (apply during build):');
+        for (const l of learnings) {
+          console.log(`  [${l._effectiveConfidence}/10] ${l.type}/${l.key}: ${l.insight}`);
+        }
+      }
+    } catch {}
+
+    console.log('');
+
+    if (inProgressCount > 0) {
+      console.log(`🔨 In-progress features: ${workspaceSummary.inProgressFeatures.join(', ')}`);
     }
+    console.log(`🧱 Feature build plans found: ${featureBuildPlanRefs.length}`);
+    if (featureBuildPlanRefs.length > 0) {
+      featureBuildPlanRefs.slice(0, 3).forEach((ref) => console.log(`- ${ref}`));
+      if (featureBuildPlanRefs.length > 3) {
+        console.log(`- ... (+${featureBuildPlanRefs.length - 3} more)`);
+      }
+    }
+    if (!(hasLiveTask && backlogCount === 0)) {
+      console.log(`📋 Backlog tasks: ${backlogCount}`);
+    }
+    console.log('');
   }
-  console.log(`📋 Backlog tasks: ${backlogCount}`);
-  console.log('');
 
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('📋 COPY/PASTE PROMPT FOR YOUR CODING AGENT:');
@@ -954,13 +969,17 @@ async function doAtris() {
 
   }
 
-  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log('💡 Next: Run "atris review" after execution');
   if (!showFull) {
-    console.log('   Tip: `atris do --full` prints full spec/context for copy/paste.');
+    console.log('atris do --verbose prints the executor file dump.');
+    console.log('');
+  } else {
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    if (!hasLiveTask) {
+      console.log('💡 Next: Run "atris review" after execution');
+    }
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.log('');
   }
-  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log('');
 
   // Check execution mode
   if (executionMode === 'agent') {

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -962,6 +962,8 @@ test('do prints concise executor prompt by default', () => {
     assert.equal(res.status, 0, res.stderr);
     assert.match(res.stdout, /COPY\/PASTE PROMPT/);
     assert.match(res.stdout, /You are the Executor/);
+    assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
+    assert.doesNotMatch(res.stdout, /Context: UNKNOWN/);
     assert.doesNotMatch(res.stdout, /EXECUTOR SPEC — How to Build/);
   } finally {
     cleanupTempDir(dir);

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -40,7 +40,7 @@ test.after(() => {
   }
 });
 
-function runCli(args, { cwd, input } = {}) {
+function runCli(args, { cwd, input, env } = {}) {
   const result = spawnSync(process.execPath, [cliPath, ...args], {
     cwd,
     input: input === undefined ? '' : input,
@@ -49,10 +49,49 @@ function runCli(args, { cwd, input } = {}) {
     env: {
       ...process.env,
       ATRIS_SKIP_UPDATE_CHECK: '1',
+      ...(env || {}),
     },
   });
   if (result.error) throw result.error;
   return result;
+}
+
+function nextLine(stdout) {
+  const match = String(stdout || '').match(/^next: (.+)$/m);
+  return match ? match[1] : '';
+}
+
+function writeClaimedWorkspace(dir, task = {
+  id: 'task-1',
+  display_id: 'CLI-9',
+  title: 'Ship the landing page',
+  status: 'claimed',
+  claimed_by: 'keshav',
+  updated_at: 20,
+}) {
+  fs.mkdirSync(path.join(dir, 'atris', 'reports'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.atris', 'state'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'atris', 'MAP.md'), '# MAP.md\n\n## By-Feature\n- example: bin/atris.js:1\n', 'utf8');
+  fs.writeFileSync(path.join(dir, 'atris', 'TODO.md'), '# TODO.md\n\n## Backlog\n\n(Empty)\n', 'utf8');
+  fs.writeFileSync(path.join(dir, 'atris', 'PERSONA.md'), '# PERSONA\n\nTalk like a person.\n', 'utf8');
+  fs.writeFileSync(path.join(dir, '.atris', 'state', 'tasks.projection.json'), JSON.stringify({
+    schema: 'atris.task_projection.v1',
+    tasks: [task],
+  }, null, 2), 'utf8');
+}
+
+function isolatedDoEnv(dir) {
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  return {
+    HOME: home,
+    ATRIS_TASKS_DB: path.join(dir, 'tasks.db'),
+    ATRIS_NO_INTERACTIVE: '1',
+    ATRIS_NONINTERACTIVE: '1',
+    ATRIS_OPERATOR: 'keshav',
+    USER: 'keshav',
+    NODE_NO_WARNINGS: '1',
+  };
 }
 
 // One initialized workspace, built once; tests clone it so mutations stay isolated.
@@ -111,11 +150,16 @@ test('do after init --yes --minimal does not send you back to init', () => {
   const combined = res.stdout + res.stderr;
   assert.equal(res.status, 0, combined);
   assert.match(res.stdout, /PROMPT ONLY/);
-  assert.match(res.stdout, /Atris Do — Executor Agent Activated/);
+  assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
+  assert.doesNotMatch(res.stdout, /Context: UNKNOWN/);
   assert.match(res.stdout, /You are the Executor\./);
-  assert.match(res.stdout, /Executor spec: atris\/team\/executor\/MEMBER\.md \(missing\)/);
+  assert.doesNotMatch(res.stdout, /Executor spec: atris\/team\/executor\/MEMBER\.md \(missing\)/);
   assert.doesNotMatch(combined, /executor\.md not found|Run "atris init"/);
   assert.doesNotMatch(combined, /What do you want to build|Describe the desired outcome/);
+
+  const verbose = runCli(['do', '--verbose'], { cwd: dir });
+  assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
+  assert.match(verbose.stdout, /Executor spec: atris\/team\/executor\/MEMBER\.md \(missing\)/);
 });
 
 test('plan on an initialized workspace prints the navigator prompt shape', () => {
@@ -184,12 +228,47 @@ test('do prints the executor prompt shape and surfaces feature build plans', () 
 
   const res = runCli(['do'], { cwd: dir });
   assert.equal(res.status, 0, res.stderr);
-  assert.match(res.stdout, /Atris Do — Executor Agent Activated/);
+  assert.match(res.stdout, /^PROMPT ONLY/m);
+  assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
+  assert.doesNotMatch(res.stdout, /Context: UNKNOWN/);
   assert.match(res.stdout, /You are the Executor\./);
   assert.match(res.stdout, /claim next unclaimed Backlog task/);
   assert.match(res.stdout, /Do NOT plan — just execute/);
-  assert.match(res.stdout, /Feature build plans found: 1/);
-  assert.match(res.stdout, /sample-feature[\/\\]build\.md/);
+  assert.doesNotMatch(res.stdout, /Feature build plans found/);
+
+  const full = runCli(['do', '--full'], { cwd: dir });
+  assert.equal(full.status, 0, full.stderr);
+  assert.match(full.stdout, /Feature build plans found: 1/);
+  assert.match(full.stdout, /sample-feature[\/\\]build\.md/);
+});
+
+test('do names a claimed task the same way first-minute does', () => {
+  const dir = makeTempDir();
+  writeClaimedWorkspace(dir);
+  const env = isolatedDoEnv(dir);
+
+  const minute = runCli([], { cwd: dir, env });
+  const doit = runCli(['do'], { cwd: dir, env });
+  assert.equal(minute.status, 0, minute.stderr || minute.stdout);
+  assert.equal(doit.status, 0, doit.stderr || doit.stdout);
+  assert.match(doit.stdout, /^PROMPT ONLY/m);
+  assert.match(doit.stdout, /"ship the landing page" is already yours\./);
+  assert.equal(nextLine(doit.stdout), nextLine(minute.stdout));
+  assert.equal(nextLine(doit.stdout), 'atris task ready CLI-9');
+  assert.doesNotMatch(doit.stdout, /Atris Do — Executor Agent Activated/);
+  assert.doesNotMatch(doit.stdout, /Context: UNKNOWN/);
+  assert.doesNotMatch(doit.stdout, /Backlog tasks: 0/);
+  assert.doesNotMatch(doit.stdout, /CONTEXT FILES \(agent should read\)/);
+  assert.doesNotMatch(doit.stdout, /What do you want to build|Describe the desired outcome/);
+  assert.match(doit.stdout, /You are the Executor\./);
+
+  const verbose = runCli(['do', '--verbose'], { cwd: dir, env });
+  assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
+  assert.match(verbose.stdout, /"ship the landing page" is already yours\./);
+  assert.equal(nextLine(verbose.stdout), 'atris task ready CLI-9');
+  assert.doesNotMatch(verbose.stdout, /Context: UNKNOWN/);
+  assert.doesNotMatch(verbose.stdout, /Backlog tasks: 0/);
+  assert.match(verbose.stdout, /CONTEXT FILES \(agent should read\)/);
 });
 
 test('review --verbose prints the validator prompt and reacts to journal completions', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After first-minute says a claimed task is already yours, `atris do` still opened with a factory banner (`Atris Do — Executor Agent Activated`, `Context: UNKNOWN`) and a file dump that could say backlog 0.

This keeps prompt-only. The human head now reuses the same first-minute win and next command. The copy/paste executor prompt stays below that head. The old file dump is `--verbose` / `--full` only, and it will not say `Context: UNKNOWN` or `Backlog tasks: 0` when a claimed, review, or open task exists.

Headless still never prompts. `lib/first-minute.js` is unchanged.

Verify: `node --test test/workflow-command.test.js test/cli-smoke.test.js test/first-minute.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d648c48-7d7f-4cb8-9d8e-7530659942d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d648c48-7d7f-4cb8-9d8e-7530659942d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

