### PR TITLE
dogfood: recap tells first-minute truth

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1009,13 +1009,14 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 - **Entry point:** `commands/recap.js` (`recapAtris`, `buildRecapData`, `renderRecap`, `renderShare`)
 - **Routing:** `bin/atris.js` (`command === 'recap'` branch, `knownCommands` list, Context & tracking help line)
-- **Data sources:** task DB via `lib/task-db` (`listTasks` + `taskDisplayRefMap`), fallback `.atris/state/tasks.projection.json`, graceful empty state
-- **Buckets:** shipped = `done` within `--days` window (default 7); waiting = `review` (proven, needs human accept); in progress = `open`/`claimed`
+- **Data sources:** task DB via `lib/task-db` (`listTasks` + `taskDisplayRefMap`); empty or missing db falls through to `.atris/state/tasks.projection.json`, same as first-minute
+- **Buckets:** shipped = `done` within `--days` window (default 7); waiting = certified / two-pass `review` via `lib/first-minute.js` `isCertifiedReview` (needs human accept); checking = uncertified `review` (still being checked, not needs-you); in progress = `open`/`claimed`
+- **Next:** one certified accept names `atris task accept <id>`; recap does not send humans to `atris task reviews` when that accept is the next move
 - **Proof line:** `metadata.latest_agent_proof` (or certified marker), compressed to one line per item
 - **Modes:** default report, `--share` (paste-ready for Slack/email/customer), `--json` (agents/dashboards), `--days N`
-- **Regression:** `test/recap.test.js` (buckets, jargon ban, share format, projection fallback, empty workspace)
+- **Regression:** `test/recap.test.js` (buckets, jargon ban, share format, projection fallback, empty workspace, certified-only needs-you, headless mixed board)
 
-**Search:** `rg "recapAtris|plainCheck|isRealTestRunnerProof|classifyVerifier" commands/recap.js lib/verifier-quality.js commands/task.js test/recap.test.js test/dogfood-p1.test.js`
+**Search:** `rg "recapAtris|plainCheck|isCertifiedReview|isRealTestRunnerProof|classifyVerifier" commands/recap.js lib/first-minute.js lib/verifier-quality.js commands/task.js test/recap.test.js test/dogfood-p1.test.js`
 rg "fleetWorkspaceStatus|fleet --global" commands/fleet.js test/dogfood-p1.test.js # Fleet defaults to workspace; --global hits Swarlo
 rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js test/dogfood-p1.test.js # Engine roster workspace vs --global
 

--- a/commands/recap.js
+++ b/commands/recap.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { isCertifiedReview } = require('../lib/first-minute');
 const { isRealTestRunnerProof, quoteVerifierCommand } = require('../lib/verifier-quality');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -31,8 +32,10 @@ function loadTasks(root) {
       const db = taskDb.open();
       const ws = taskDb.workspaceRoot(root);
       const rows = taskDb.listTasks(db, { workspaceRoot: ws });
-      const refs = taskDb.taskDisplayRefMap(rows);
-      return rows.map(row => ({ ...row, display_id: refs.get(row.id) || row.id.slice(-6) }));
+      if (Array.isArray(rows) && rows.length) {
+        const refs = taskDb.taskDisplayRefMap(rows);
+        return rows.map(row => ({ ...row, display_id: refs.get(row.id) || row.id.slice(-6) }));
+      }
     } catch (e) {
       // fall through to projection
     }
@@ -108,28 +111,38 @@ function buildRecapData(root = process.cwd(), { days = DEFAULT_DAYS } = {}) {
     done_at: t.done_at || null,
   });
 
+  const newestFirst = (a, b) => (
+    Number(b.updated_at || b.created_at || 0) - Number(a.updated_at || a.created_at || 0)
+  );
   const shipped = tasks
     .filter(t => t.status === 'done' && Number(t.done_at || 0) >= cutoff)
     .sort((a, b) => Number(b.done_at || 0) - Number(a.done_at || 0))
     .map(pick);
-  const waiting = tasks
-    .filter(t => t.status === 'review')
-    .sort((a, b) => Number(b.updated_at || 0) - Number(a.updated_at || 0))
+  const reviewTasks = tasks.filter(t => t.status === 'review');
+  const waiting = reviewTasks
+    .filter(isCertifiedReview)
+    .sort(newestFirst)
+    .map(pick);
+  const checking = reviewTasks
+    .filter(t => !isCertifiedReview(t))
+    .sort(newestFirst)
     .map(pick);
   const inProgress = tasks
     .filter(t => t.status === 'open' || t.status === 'claimed')
     .map(pick);
 
-  const withProof = [...shipped, ...waiting].filter(t => t.proof).length;
+  const withProof = [...shipped, ...waiting, ...checking].filter(t => t.proof).length;
   return {
     empty: false,
     days: windowDays,
     workspace: path.basename(root),
     shipped,
     waiting,
+    checking,
     inProgress,
+    next: waiting.length ? `atris task accept ${waiting[0].id}` : null,
     proof_attached: withProof,
-    proof_total: shipped.length + waiting.length,
+    proof_total: shipped.length + waiting.length + checking.length,
   };
 }
 
@@ -149,8 +162,9 @@ function renderRecap(data) {
   const headline = [];
   if (data.shipped.length) headline.push(`${data.shipped.length} done`);
   if (data.waiting.length) headline.push(`${data.waiting.length} needs you`);
+  if (data.checking.length) headline.push(`${data.checking.length} still being checked`);
   if (data.inProgress.length) headline.push(`${data.inProgress.length} still working`);
-  lines.push(headline.length ? headline.join(' · ') : 'Quiet window — no movement in this period.');
+  lines.push(headline.length ? headline.join(' · ') : 'Quiet window. nothing moved in this period.');
 
   if (data.shipped.length) {
     lines.push('');
@@ -172,7 +186,16 @@ function renderRecap(data) {
       if (check) lines.push(`          checked: ${check}`);
     }
     if (data.waiting.length > 10) lines.push(`  … and ${data.waiting.length - 10} more`);
-    lines.push('  next: run atris task reviews');
+    if (data.next) lines.push(`  next: ${data.next}`);
+  }
+
+  if (data.checking.length) {
+    lines.push('');
+    lines.push(`STILL BEING CHECKED — ${data.checking.length}`);
+    for (const t of data.checking.slice(0, 10)) {
+      lines.push(`  ${t.id}  ${shortTitle(t.title)}`);
+    }
+    if (data.checking.length > 10) lines.push(`  … and ${data.checking.length - 10} more`);
   }
 
   if (data.inProgress.length) {
@@ -196,6 +219,7 @@ function renderShare(data) {
   lines.push('');
   if (data.shipped.length) lines.push(`- ${data.shipped.length} done and accepted`);
   if (data.waiting.length) lines.push(`- ${data.waiting.length} ready for you to approve or send back`);
+  if (data.checking.length) lines.push(`- ${data.checking.length} still being checked`);
   if (data.inProgress.length) lines.push(`- ${data.inProgress.length} still being worked on`);
   const highlights = [...data.shipped, ...data.waiting].filter(t => t.proof).slice(0, 5);
   if (highlights.length) {
@@ -214,7 +238,7 @@ function printRecapHelp() {
   console.log(`
 atris recap - what got done, in plain English
 
-  atris recap              Last 7 days: done, needs you, still working
+  atris recap              Last 7 days: done, needs you, still being checked, still working
   atris recap --days 30    Widen the window
   atris recap --share      Paste-ready summary for Slack, email, or a customer
   atris recap --json       Structured output for agents and dashboards

--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -357,6 +357,7 @@ module.exports = {
   deskNextCommand,
   folderName,
   isBareAtrisFlag,
+  isCertifiedReview,
   personName,
   pickNext,
   renderFresh,

--- a/test/recap.test.js
+++ b/test/recap.test.js
@@ -3,8 +3,12 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const { buildRecapData, renderRecap, renderShare } = require('../commands/recap');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
 
 function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-recap-test-'));
@@ -22,9 +26,25 @@ function seedDb(dir, tasks) {
   const db = taskDb.open(dbPath);
   const ws = taskDb.workspaceRoot(dir);
   for (const t of tasks) {
-    const { id } = taskDb.addTask(db, { title: t.title, workspaceRoot: ws, status: t.status === 'done' ? 'open' : t.status, claimedBy: t.claimedBy });
+    const { id } = taskDb.addTask(db, {
+      title: t.title,
+      workspaceRoot: ws,
+      status: t.status === 'done' ? 'open' : t.status,
+      claimedBy: t.claimedBy,
+      metadata: t.metadata,
+    });
     if (t.proof) {
       taskDb.readyTask(db, { id, actor: 'tester', proof: t.proof });
+    }
+    if (t.certified) {
+      const row = taskDb.getTask(db, id);
+      const meta = {
+        ...(row.metadata || {}),
+        agent_certified: true,
+        agent_review_pass_count: 2,
+      };
+      db.prepare('UPDATE tasks SET status = ?, metadata = ?, updated_at = ? WHERE id = ?')
+        .run('review', JSON.stringify(meta), Date.now(), id);
     }
     if (t.status === 'done') {
       db.prepare('UPDATE tasks SET status = ?, done_at = ?, updated_at = ? WHERE id = ?')
@@ -32,6 +52,34 @@ function seedDb(dir, tasks) {
     }
   }
   return { db, ws };
+}
+
+function writeProjection(dir, tasks) {
+  fs.mkdirSync(path.join(dir, '.atris', 'state'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.atris', 'state', 'tasks.projection.json'),
+    JSON.stringify({ schema: 'atris.task_projection.v1', tasks }, null, 2),
+    'utf8'
+  );
+}
+
+function runCli(args, { cwd, env, timeout = 15000 } = {}) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout,
+    env: {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ATRIS_NO_INTERACTIVE: '1',
+      ...(env || {}),
+    },
+  });
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    assert.fail(`cli hung past ${timeout}ms (args: ${args.join(' ') || '(none)'})`);
+  }
+  if (result.error) throw result.error;
+  return result;
 }
 
 function resetDbEnv() {
@@ -67,8 +115,10 @@ test('buildRecapData buckets shipped, waiting, and in-progress with proof counts
     assert.equal(data.empty, false);
     assert.equal(data.shipped.length, 1);
     assert.equal(data.shipped[0].title, 'Fix the login crash');
-    assert.equal(data.waiting.length, 1, 'readyTask moves claimed->review, lands in waiting');
+    assert.equal(data.waiting.length, 0, 'one-pass readyTask is not certified, so it is not needs-you');
+    assert.equal(data.checking.length, 1, 'readyTask moves claimed->review, lands in still being checked');
     assert.equal(data.inProgress.length, 1);
+    assert.equal(data.next, null);
     assert.equal(data.proof_attached, 2);
     assert.equal(data.proof_total, 2);
   } finally {
@@ -82,16 +132,18 @@ test('renderRecap speaks plain English with checks and no internal jargon', () =
   try {
     seedDb(dir, [
       { title: 'Fix the login crash', status: 'done', proof: 'node --test test/login.test.js -> pass', doneAt: Date.now() - 1000 },
-      { title: 'Speed up the dashboard', status: 'claimed', claimedBy: 'agent-a', proof: 'bench: 2.1s -> 0.4s' },
+      { title: 'Speed up the dashboard', status: 'claimed', claimedBy: 'agent-a', proof: 'bench: 2.1s -> 0.4s', certified: true },
     ]);
-    const out = renderRecap(buildRecapData(dir, { days: 7 }));
+    const data = buildRecapData(dir, { days: 7 });
+    const out = renderRecap(data);
     assert.match(out, /Plain English: what changed, how it was checked, and what still needs you/);
     assert.match(out, /DONE — 1/);
     assert.match(out, /Fix the login crash/);
     assert.match(out, /checked: tests passed/);
     assert.match(out, /NEEDS YOU — 1/);
     assert.match(out, /checked: measured improvement/);
-    assert.match(out, /next: run atris task reviews/);
+    assert.match(out, new RegExp(`next: atris task accept ${data.waiting[0].id}`));
+    assert.doesNotMatch(out, /task reviews/);
     for (const jargon of [/\bproof\b/i, /receipt/i, /sign-off/i, /\blane\b/i, /certified/i, /projection/i, /\brung\b/i, /AgentXP/i]) {
       assert.doesNotMatch(out, jargon);
     }
@@ -173,9 +225,158 @@ test('buildRecapData falls back to projection JSON when the db is unavailable', 
     assert.equal(data.empty, false);
     assert.equal(data.shipped.length, 1);
     assert.equal(data.shipped[0].id, 'T-1');
-    assert.equal(data.waiting.length, 1);
+    assert.equal(data.waiting.length, 0);
+    assert.equal(data.checking.length, 1);
+    assert.equal(data.checking[0].id, 'T-2');
+    assert.equal(data.next, null);
   } finally {
     resetDbEnv();
     cleanup(dir);
+  }
+});
+
+test('recap treats only certified review as needs you, same as first-minute', () => {
+  const dir = makeTempDir();
+  try {
+    process.env.ATRIS_TASKS_DB = path.join(dir, 'empty.db');
+    require('../lib/task-db').close();
+    writeProjection(dir, [
+      {
+        id: 'task-1',
+        display_id: 'UNW-1',
+        title: 'Open follow-up',
+        status: 'open',
+        updated_at: 10,
+      },
+      {
+        id: 'task-2',
+        display_id: 'UNW-2',
+        title: 'Print a human line like 4 words so the count is easy to read.',
+        status: 'review',
+        updated_at: 20,
+        review: { agent_certified: true, agent_review_pass_count: 2 },
+      },
+      {
+        id: 'task-3',
+        display_id: 'UNW-3',
+        title: 'Second check still open',
+        status: 'review',
+        updated_at: 30,
+        review: { agent_review_pass_count: 1 },
+      },
+      {
+        id: 'task-4',
+        display_id: 'UNW-4',
+        title: 'Newer review still waiting',
+        status: 'review',
+        updated_at: 40,
+        review: { agent_review_pass_count: 1 },
+      },
+    ]);
+    const data = buildRecapData(dir, { days: 7 });
+    const out = renderRecap(data);
+    assert.equal(data.waiting.map(t => t.id).join(','), 'UNW-2');
+    assert.deepEqual(data.checking.map(t => t.id), ['UNW-4', 'UNW-3']);
+    assert.equal(data.next, 'atris task accept UNW-2');
+    assert.match(out, /1 needs you/);
+    assert.match(out, /2 still being checked/);
+    assert.match(out, /1 still working/);
+    assert.match(out, /NEEDS YOU — 1/);
+    assert.match(out, /UNW-2/);
+    assert.match(out, /^ {2}next: atris task accept UNW-2$/m);
+    assert.match(out, /STILL BEING CHECKED — 2/);
+    assert.match(out, /UNW-3/);
+    assert.match(out, /UNW-4/);
+    assert.doesNotMatch(out, /3 needs you/);
+    assert.doesNotMatch(out, /task reviews/);
+    const share = renderShare(data);
+    assert.match(share, /1 ready for you to approve or send back/);
+    assert.match(share, /2 still being checked/);
+    assert.doesNotMatch(share, /3 ready for you to approve/);
+  } finally {
+    resetDbEnv();
+    cleanup(dir);
+  }
+});
+
+test('two-pass review without the certified flag still needs you', () => {
+  const dir = makeTempDir();
+  try {
+    process.env.ATRIS_TASKS_DB = path.join(dir, 'empty.db');
+    require('../lib/task-db').close();
+    writeProjection(dir, [{
+      id: 'task-8',
+      display_id: 'UNW-8',
+      title: 'Two pass no flag',
+      status: 'review',
+      updated_at: 10,
+      review: { agent_review_pass_count: 2 },
+    }]);
+    const data = buildRecapData(dir, { days: 7 });
+    assert.equal(data.waiting.map(t => t.id).join(','), 'UNW-8');
+    assert.equal(data.checking.length, 0);
+    assert.equal(data.next, 'atris task accept UNW-8');
+    assert.match(renderRecap(data), /^ {2}next: atris task accept UNW-8$/m);
+  } finally {
+    resetDbEnv();
+    cleanup(dir);
+  }
+});
+
+test('headless recap on mixed review board names one accept and does not prompt', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-recap-parent-'));
+  const dir = path.join(parent, 'atris-use-now');
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    writeProjection(dir, [
+      {
+        id: 'task-2',
+        display_id: 'UNW-2',
+        title: 'Print a human line like 4 words so the count is easy to read.',
+        status: 'review',
+        updated_at: 20,
+        review: { agent_certified: true, agent_review_pass_count: 2 },
+      },
+      {
+        id: 'task-3',
+        display_id: 'UNW-3',
+        title: 'Second check still open',
+        status: 'review',
+        updated_at: 30,
+        review: { agent_review_pass_count: 1 },
+      },
+      {
+        id: 'task-4',
+        display_id: 'UNW-4',
+        title: 'Newer review still waiting',
+        status: 'review',
+        updated_at: 40,
+        review: { agent_review_pass_count: 1 },
+      },
+    ]);
+    const env = {
+      HOME: path.join(parent, 'home'),
+      USER: 'keshavrao',
+      ATRIS_TASKS_DB: path.join(dir, 'empty.db'),
+      ATRIS_NO_INTERACTIVE: '1',
+    };
+    const recap = runCli(['recap'], { cwd: dir, env });
+    assert.equal(recap.status, 0, recap.stderr || recap.stdout);
+    assert.match(recap.stdout, /1 needs you/);
+    assert.match(recap.stdout, /2 still being checked/);
+    assert.match(recap.stdout, /^ {2}next: atris task accept UNW-2$/m);
+    assert.doesNotMatch(recap.stdout, /3 needs you/);
+    assert.doesNotMatch(recap.stdout, /task reviews/);
+    assert.doesNotMatch(recap.stdout, /\? $/m);
+    assert.doesNotMatch(recap.stdout, /What do you want/);
+    const json = runCli(['recap', '--json'], { cwd: dir, env });
+    assert.equal(json.status, 0, json.stderr || json.stdout);
+    const payload = JSON.parse(json.stdout);
+    assert.equal(payload.next, 'atris task accept UNW-2');
+    assert.equal(payload.waiting.length, 1);
+    assert.equal(payload.checking.length, 2);
+  } finally {
+    resetDbEnv();
+    cleanup(parent);
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recap was counting every review job as something you had to approve. First-minute and review already knew better: only a certified or two-pass job needs your yes.

Recap now uses that same rule.

Certified or two-pass review: needs you, and next is `atris task accept <id>`.

Uncertified review: still being checked, not needs you.

If one accept is the next move, recap does not send you to `atris task reviews`.

Verify:

```
node --test test/recap.test.js
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3897bd98-728b-4de1-9da7-577309aad00b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3897bd98-728b-4de1-9da7-577309aad00b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

