### PR TITLE
atris gmail --account flag and accounts subcommand

### DIFF
--- a/bin/atris.js
+++ b/bin/atris.js
@@ -726,7 +726,7 @@ function showHelpAll() {
   console.log('  supabase  - supabase cli wrapper (doctor, auth, status/db/functions)');
   console.log('  linear    - linear cli wrapper (doctor, auth, issue list/create/view/update)');
   console.log('  stripe    - stripe cli wrapper (doctor, auth, listen/trigger/products)');
-  console.log('  gmail      - Email commands (inbox, read, archive)');
+  console.log('  gmail      - Email commands (inbox, read, archive, accounts)');
   console.log('  calendar   - Calendar commands (today, week)');
   console.log('  twitter    - Twitter commands (post)');
   console.log('  slack      - Slack commands (channels)');
@@ -2728,11 +2728,16 @@ if (command === 'init') {
   {
     const raw = process.argv.slice(3);
     const helpOnly = raw.length === 0 || raw.includes('--help') || raw.includes('-h') || raw[0] === 'help';
-    const gate = helpOnly ? { ok: true, args: raw } : requireAccountBound(raw);
+    const { gmailCommand, extractGmailMailboxAccount } = require('../commands/integrations');
+    const mailbox = extractGmailMailboxAccount(raw);
+    const gateInput = helpOnly
+      ? mailbox.args
+      : (mailbox.mailboxAccountId ? ['--account', ...mailbox.args] : mailbox.args);
+    const gate = helpOnly ? { ok: true, args: mailbox.args } : requireAccountBound(gateInput);
     if (!gate.ok) process.exit(refuseAccountGlobal());
-    const { gmailCommand } = require('../commands/integrations');
     const subcommand = gate.args[0];
     const args = gate.args.slice(1);
+    if (mailbox.mailboxAccountId) args.push('--account', mailbox.mailboxAccountId);
     gmailCommand(subcommand, ...args)
       .then(() => process.exit(0))
       .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });

--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -2,8 +2,10 @@
  * Integration commands for Atris CLI
  *
  * Usage:
- *   atris gmail inbox       - List recent emails
- *   atris gmail read <id>   - Read specific email
+ *   atris gmail inbox [--account <id>]       - List recent emails
+ *   atris gmail read <id> [--account <id>]   - Read specific email
+ *   atris gmail archive <id> [...] [--account <id>] - Archive messages
+ *   atris gmail accounts    - List connected Gmail accounts
  *   atris calendar today    - Show today's events
  *   atris calendar yesterday - Show yesterday's events
  *   atris calendar week     - Show this week's events
@@ -51,13 +53,52 @@ async function getAuthToken() {
 // GMAIL
 // ============================================================================
 
+function extractGmailMailboxAccount(args = []) {
+  const out = [];
+  let mailboxAccountId = null;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--account' && args[i + 1] && !String(args[i + 1]).startsWith('-')) {
+      mailboxAccountId = args[i + 1];
+      i += 1;
+      continue;
+    }
+    out.push(arg);
+  }
+  return { args: out, mailboxAccountId };
+}
+
+function parseGmailArgs(args = []) {
+  const options = { accountId: null };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--account') {
+      options.accountId = String(args[i + 1] || '').trim();
+      if (!options.accountId) {
+        console.error('Usage: --account requires an account id');
+        process.exit(1);
+      }
+      i += 1;
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { ...options, positional };
+}
+
 async function gmailInbox(options = {}) {
   const { token, email } = await getAuth();
   const limit = options.limit || 10;
 
   console.log('📬 Fetching inbox...\n');
 
-  const result = await apiRequestJson(`/integrations/gmail/messages?max_results=${limit}`, {
+  let path = `/integrations/gmail/messages?max_results=${limit}`;
+  if (options.accountId) {
+    path = `/integrations/gmail/messages?max_results=${limit}&account_id=${encodeURIComponent(options.accountId)}`;
+  }
+
+  const result = await apiRequestJson(path, {
     method: 'GET',
     token,
   });
@@ -97,9 +138,9 @@ async function gmailInbox(options = {}) {
   }
 }
 
-async function gmailRead(messageId) {
+async function gmailRead(messageId, options = {}) {
   if (!messageId) {
-    console.error('Usage: atris gmail read <message_id>');
+    console.error('Usage: atris gmail read <message_id> [--account <id>]');
     process.exit(1);
   }
 
@@ -107,7 +148,12 @@ async function gmailRead(messageId) {
 
   console.log('📧 Fetching message...\n');
 
-  const result = await apiRequestJson(`/integrations/gmail/messages/${messageId}`, {
+  let path = `/integrations/gmail/messages/${messageId}`;
+  if (options.accountId) {
+    path = `${path}?account_id=${encodeURIComponent(options.accountId)}`;
+  }
+
+  const result = await apiRequestJson(path, {
     method: 'GET',
     token,
   });
@@ -129,10 +175,10 @@ async function gmailRead(messageId) {
   console.log(msg.body || msg.snippet || '(no body)');
 }
 
-async function gmailArchive(messageIds) {
+async function gmailArchive(messageIds, options = {}) {
   const ids = (messageIds || []).map(id => String(id || '').trim()).filter(Boolean);
   if (!ids.length) {
-    console.error('Usage: atris gmail archive <message_id> [<message_id> ...]');
+    console.error('Usage: atris gmail archive <message_id> [<message_id> ...] [--account <id>]');
     process.exit(1);
   }
 
@@ -140,10 +186,13 @@ async function gmailArchive(messageIds) {
 
   console.log(`Archiving ${ids.length} message${ids.length === 1 ? '' : 's'}...`);
 
+  const body = { message_ids: ids };
+  if (options.accountId) body.account_id = options.accountId;
+
   const result = await apiRequestJson('/integrations/gmail/messages/batch-archive', {
     method: 'POST',
     token,
-    body: { message_ids: ids },
+    body,
   });
 
   if (!result.ok) {
@@ -155,23 +204,60 @@ async function gmailArchive(messageIds) {
   console.log(`Archived ${archived} message${archived === 1 ? '' : 's'}. They stay searchable in All Mail.`);
 }
 
+async function gmailAccounts() {
+  const token = await getAuthToken();
+
+  const result = await apiRequestJson('/integrations/gmail/accounts', {
+    method: 'GET',
+    token,
+  });
+
+  if (!result.ok) {
+    console.error(`Error: ${result.error || 'Failed to fetch accounts'}`);
+    process.exit(1);
+  }
+
+  const accounts = result.data?.accounts || result.data || [];
+
+  if (!accounts.length) {
+    console.log('no connected accounts.');
+    return;
+  }
+
+  for (const account of accounts) {
+    const email = String(account.email_address || account.email || 'unknown').toLowerCase();
+    const name = String(account.display_name || account.name || '').toLowerCase();
+    console.log(`${email}, ${name}`);
+  }
+}
+
 async function gmailCommand(subcommand, ...args) {
   switch (subcommand) {
     case 'inbox':
-    case 'list':
-      await gmailInbox();
+    case 'list': {
+      const parsed = parseGmailArgs(args);
+      await gmailInbox({ accountId: parsed.accountId || undefined });
       break;
-    case 'read':
-      await gmailRead(args[0]);
+    }
+    case 'read': {
+      const parsed = parseGmailArgs(args);
+      await gmailRead(parsed.positional[0], { accountId: parsed.accountId || undefined });
       break;
-    case 'archive':
-      await gmailArchive(args);
+    }
+    case 'archive': {
+      const parsed = parseGmailArgs(args);
+      await gmailArchive(parsed.positional, { accountId: parsed.accountId || undefined });
+      break;
+    }
+    case 'accounts':
+      await gmailAccounts();
       break;
     default:
       console.log('Gmail commands:');
-      console.log('  atris gmail inbox       - List recent emails');
-      console.log('  atris gmail read <id>   - Read specific email');
-      console.log('  atris gmail archive <id> [...] - Archive messages (reversible, All Mail keeps them)');
+      console.log('  atris gmail inbox [--account <id>]       - List recent emails');
+      console.log('  atris gmail read <id> [--account <id>]   - Read specific email');
+      console.log('  atris gmail archive <id> [...] [--account <id>] - Archive messages (reversible, All Mail keeps them)');
+      console.log('  atris gmail accounts                     - List connected Gmail accounts');
   }
 }
 
@@ -1680,6 +1766,8 @@ async function integrationsStatus(args = []) {
 
 module.exports = {
   gmailCommand,
+  extractGmailMailboxAccount,
+  parseGmailArgs,
   calendarCommand,
   twitterCommand,
   slackCommand,

--- a/test/gmail-account.test.js
+++ b/test/gmail-account.test.js
@@ -1,0 +1,197 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  extractGmailMailboxAccount,
+  parseGmailArgs,
+} = require('../commands/integrations');
+
+function withMockedIntegrations(apiRequestJson) {
+  const authPath = require.resolve('../utils/auth');
+  const apiPath = require.resolve('../utils/api');
+  const integrationsPath = require.resolve('../commands/integrations');
+  const originals = {
+    auth: require.cache[authPath],
+    api: require.cache[apiPath],
+    integrations: require.cache[integrationsPath],
+  };
+
+  delete require.cache[integrationsPath];
+  require.cache[authPath] = {
+    id: authPath,
+    filename: authPath,
+    loaded: true,
+    exports: {
+      loadCredentials: () => ({ token: 'test-token', email: 'sender@example.com' }),
+      ensureValidCredentials: async () => ({
+        credentials: { token: 'test-token', email: 'sender@example.com' },
+      }),
+    },
+  };
+  require.cache[apiPath] = {
+    id: apiPath,
+    filename: apiPath,
+    loaded: true,
+    exports: { apiRequestJson },
+  };
+
+  const integrations = require('../commands/integrations');
+  return {
+    integrations,
+    restore() {
+      if (originals.auth) require.cache[authPath] = originals.auth; else delete require.cache[authPath];
+      if (originals.api) require.cache[apiPath] = originals.api; else delete require.cache[apiPath];
+      if (originals.integrations) require.cache[integrationsPath] = originals.integrations; else delete require.cache[integrationsPath];
+    },
+  };
+}
+
+test('extractGmailMailboxAccount pulls mailbox id before account gate handling', () => {
+  assert.deepEqual(extractGmailMailboxAccount(['inbox', '--account', 'work']), {
+    args: ['inbox'],
+    mailboxAccountId: 'work',
+  });
+  assert.deepEqual(extractGmailMailboxAccount(['inbox', '--account']), {
+    args: ['inbox', '--account'],
+    mailboxAccountId: null,
+  });
+});
+
+test('parseGmailArgs splits account flag from positional ids', () => {
+  assert.deepEqual(parseGmailArgs(['msg-1', 'msg-2', '--account', 'personal']), {
+    accountId: 'personal',
+    positional: ['msg-1', 'msg-2'],
+  });
+});
+
+test('gmail inbox without --account keeps the legacy request path', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    return { ok: true, status: 200, data: { messages: [] } };
+  });
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await integrations.gmailCommand('inbox');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10');
+  assert.equal(calls[0].options.method, 'GET');
+  assert.equal(calls[0].options.token, 'test-token');
+});
+
+test('gmail inbox with --account adds account_id query param', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    return { ok: true, status: 200, data: { messages: [] } };
+  });
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await integrations.gmailCommand('inbox', '--account', 'work');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10&account_id=work');
+});
+
+test('gmail read with --account adds account_id query param', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    return {
+      ok: true,
+      status: 200,
+      data: { from: 'a@example.com', to: 'b@example.com', subject: 'hi', body: 'hello' },
+    };
+  });
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await integrations.gmailCommand('read', 'msg-42', '--account', 'work');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pathname, '/integrations/gmail/messages/msg-42?account_id=work');
+});
+
+test('gmail archive without --account keeps legacy json body', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    return { ok: true, status: 200, data: { archived: 1 } };
+  });
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await integrations.gmailCommand('archive', 'msg-1');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pathname, '/integrations/gmail/messages/batch-archive');
+  assert.deepEqual(calls[0].options.body, { message_ids: ['msg-1'] });
+});
+
+test('gmail archive with --account adds account_id to json body', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    return { ok: true, status: 200, data: { archived: 2 } };
+  });
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await integrations.gmailCommand('archive', 'msg-1', 'msg-2', '--account', 'work');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].options.body, {
+    message_ids: ['msg-1', 'msg-2'],
+    account_id: 'work',
+  });
+});
+
+test('gmail accounts renders one lowercase line per connected account', async () => {
+  const { integrations, restore } = withMockedIntegrations(async (pathname) => {
+    assert.equal(pathname, '/integrations/gmail/accounts');
+    return {
+      ok: true,
+      status: 200,
+      data: [
+        { account_id: 'default', email_address: 'Me@Example.com', display_name: 'Work Inbox' },
+        { account_id: 'personal', email_address: 'home@example.com', display_name: 'Personal' },
+      ],
+    };
+  });
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await integrations.gmailCommand('accounts');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.deepEqual(lines, [
+    'me@example.com, work inbox',
+    'home@example.com, personal',
+  ]);
+});


### PR DESCRIPTION
Gmail CLI commands accept --account <id>; omitted flag keeps requests byte-identical. New: atris gmail accounts lists connected mailboxes. 8 new tests + 43 smoke tests pass, exit 0, re-run by orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)