### PR TITLE
atris gmail use: sticky account switching, v3.55.0

### DIFF
--- a/bin/atris.js
+++ b/bin/atris.js
@@ -726,7 +726,7 @@ function showHelpAll() {
   console.log('  supabase  - supabase cli wrapper (doctor, auth, status/db/functions)');
   console.log('  linear    - linear cli wrapper (doctor, auth, issue list/create/view/update)');
   console.log('  stripe    - stripe cli wrapper (doctor, auth, listen/trigger/products)');
-  console.log('  gmail      - Email commands (inbox, read, archive, accounts)');
+  console.log('  gmail      - Email commands (inbox, read, archive, accounts, use)');
   console.log('  calendar   - Calendar commands (today, week)');
   console.log('  twitter    - Twitter commands (post)');
   console.log('  slack      - Slack commands (channels)');

--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -5,7 +5,8 @@
  *   atris gmail inbox [--account <id>]       - List recent emails
  *   atris gmail read <id> [--account <id>]   - Read specific email
  *   atris gmail archive <id> [...] [--account <id>] - Archive messages
- *   atris gmail accounts    - List connected Gmail accounts
+ *   atris gmail accounts                     - List connected Gmail accounts
+ *   atris gmail use [<account_id>]           - Set or show sticky Gmail account
  *   atris calendar today    - Show today's events
  *   atris calendar yesterday - Show yesterday's events
  *   atris calendar week     - Show this week's events
@@ -30,6 +31,60 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const CALENDAR_CACHE_PATH = path.join(os.homedir(), '.atris', 'calendar-events-cache.json');
+
+function gmailAccountStatePath() {
+  return process.env.ATRIS_GMAIL_ACCOUNT_FILE
+    || path.join(os.homedir(), '.atris', 'gmail-account.json');
+}
+
+function readGmailStickyAccount() {
+  try {
+    const data = JSON.parse(fs.readFileSync(gmailAccountStatePath(), 'utf8'));
+    const id = String(data.account_id || '').trim();
+    return id || null;
+  } catch {
+    return null;
+  }
+}
+
+function writeGmailStickyAccount(accountId) {
+  const filePath = gmailAccountStatePath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify({ account_id: accountId }, null, 2)}\n`, 'utf8');
+}
+
+function resolveGmailAccountId(explicitId) {
+  const trimmed = String(explicitId || '').trim();
+  if (trimmed) return trimmed;
+  const sticky = readGmailStickyAccount();
+  if (sticky) return sticky;
+  return 'default';
+}
+
+function gmailAccountIdentity(account = {}) {
+  const id = String(account.account_id || account.id || 'default').trim() || 'default';
+  const email = String(account.email_address || account.email || 'unknown').toLowerCase();
+  const name = String(account.display_name || account.name || id).toLowerCase();
+  return { id, email, name };
+}
+
+async function fetchGmailAccounts(token) {
+  const result = await apiRequestJson('/integrations/gmail/accounts', {
+    method: 'GET',
+    token,
+  });
+  if (!result.ok) {
+    console.error(`Error: ${result.error || 'Failed to fetch accounts'}`);
+    process.exit(1);
+  }
+  const accounts = result.data?.accounts || result.data || [];
+  return Array.isArray(accounts) ? accounts : [];
+}
+
+function findGmailAccount(accounts, accountId) {
+  const wanted = String(accountId || '').trim().toLowerCase();
+  return accounts.find((account) => gmailAccountIdentity(account).id.toLowerCase() === wanted) || null;
+}
 
 async function getAuth() {
   const ensured = await ensureValidCredentials(apiRequestJson);
@@ -90,13 +145,11 @@ function parseGmailArgs(args = []) {
 async function gmailInbox(options = {}) {
   const { token, email } = await getAuth();
   const limit = options.limit || 10;
+  const accountId = resolveGmailAccountId(options.accountId);
 
   console.log('📬 Fetching inbox...\n');
 
-  let path = `/integrations/gmail/messages?max_results=${limit}`;
-  if (options.accountId) {
-    path = `/integrations/gmail/messages?max_results=${limit}&account_id=${encodeURIComponent(options.accountId)}`;
-  }
+  const path = `/integrations/gmail/messages?max_results=${limit}&account_id=${encodeURIComponent(accountId)}`;
 
   const result = await apiRequestJson(path, {
     method: 'GET',
@@ -145,13 +198,11 @@ async function gmailRead(messageId, options = {}) {
   }
 
   const token = await getAuthToken();
+  const accountId = resolveGmailAccountId(options.accountId);
 
   console.log('📧 Fetching message...\n');
 
-  let path = `/integrations/gmail/messages/${messageId}`;
-  if (options.accountId) {
-    path = `${path}?account_id=${encodeURIComponent(options.accountId)}`;
-  }
+  const path = `/integrations/gmail/messages/${messageId}?account_id=${encodeURIComponent(accountId)}`;
 
   const result = await apiRequestJson(path, {
     method: 'GET',
@@ -183,11 +234,11 @@ async function gmailArchive(messageIds, options = {}) {
   }
 
   const token = await getAuthToken();
+  const accountId = resolveGmailAccountId(options.accountId);
 
   console.log(`Archiving ${ids.length} message${ids.length === 1 ? '' : 's'}...`);
 
-  const body = { message_ids: ids };
-  if (options.accountId) body.account_id = options.accountId;
+  const body = { message_ids: ids, account_id: accountId };
 
   const result = await apiRequestJson('/integrations/gmail/messages/batch-archive', {
     method: 'POST',
@@ -206,18 +257,8 @@ async function gmailArchive(messageIds, options = {}) {
 
 async function gmailAccounts() {
   const token = await getAuthToken();
-
-  const result = await apiRequestJson('/integrations/gmail/accounts', {
-    method: 'GET',
-    token,
-  });
-
-  if (!result.ok) {
-    console.error(`Error: ${result.error || 'Failed to fetch accounts'}`);
-    process.exit(1);
-  }
-
-  const accounts = result.data?.accounts || result.data || [];
+  const accounts = await fetchGmailAccounts(token);
+  const activeId = resolveGmailAccountId(null);
 
   if (!accounts.length) {
     console.log('no connected accounts.');
@@ -225,10 +266,47 @@ async function gmailAccounts() {
   }
 
   for (const account of accounts) {
-    const email = String(account.email_address || account.email || 'unknown').toLowerCase();
-    const name = String(account.display_name || account.name || '').toLowerCase();
-    console.log(`${email}, ${name}`);
+    const { id, email, name } = gmailAccountIdentity(account);
+    const active = id.toLowerCase() === activeId.toLowerCase() ? ' (active)' : '';
+    console.log(`${email}, ${name}${active}`);
   }
+}
+
+async function gmailUse(accountId) {
+  const token = await getAuthToken();
+  const accounts = await fetchGmailAccounts(token);
+  const trimmed = String(accountId || '').trim();
+
+  if (!trimmed) {
+    const effectiveId = resolveGmailAccountId(null);
+    const match = findGmailAccount(accounts, effectiveId);
+    if (match) {
+      const { name, email } = gmailAccountIdentity(match);
+      console.log(`using ${name} (${email})`);
+      return;
+    }
+    console.log(`using ${effectiveId}`);
+    return;
+  }
+
+  const match = findGmailAccount(accounts, trimmed);
+  if (!match) {
+    console.error(`unknown gmail account "${trimmed}".`);
+    if (accounts.length) {
+      console.error('connected accounts:');
+      for (const account of accounts) {
+        const { id, email, name } = gmailAccountIdentity(account);
+        console.error(`  ${id}: ${email}, ${name}`);
+      }
+    } else {
+      console.error('no connected accounts.');
+    }
+    process.exit(1);
+  }
+
+  const { id, name, email } = gmailAccountIdentity(match);
+  writeGmailStickyAccount(id);
+  console.log(`now using ${name} (${email})`);
 }
 
 async function gmailCommand(subcommand, ...args) {
@@ -252,12 +330,16 @@ async function gmailCommand(subcommand, ...args) {
     case 'accounts':
       await gmailAccounts();
       break;
+    case 'use':
+      await gmailUse(args[0]);
+      break;
     default:
       console.log('Gmail commands:');
       console.log('  atris gmail inbox [--account <id>]       - List recent emails');
       console.log('  atris gmail read <id> [--account <id>]   - Read specific email');
       console.log('  atris gmail archive <id> [...] [--account <id>] - Archive messages (reversible, All Mail keeps them)');
       console.log('  atris gmail accounts                     - List connected Gmail accounts');
+      console.log('  atris gmail use [<account_id>]           - Set or show sticky Gmail account');
   }
 }
 
@@ -1768,6 +1850,10 @@ module.exports = {
   gmailCommand,
   extractGmailMailboxAccount,
   parseGmailArgs,
+  readGmailStickyAccount,
+  writeGmailStickyAccount,
+  resolveGmailAccountId,
+  gmailAccountStatePath,
   calendarCommand,
   twitterCommand,
   slackCommand,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.54.0",
+  "version": "3.55.0",
   "description": "you say what you want in plain words. atris builds it, checks it, and shows you proof.",
   "main": "bin/atris.js",
   "bin": {

--- a/test/gmail-account.test.js
+++ b/test/gmail-account.test.js
@@ -1,11 +1,21 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const {
   extractGmailMailboxAccount,
   parseGmailArgs,
+  gmailAccountStatePath,
 } = require('../commands/integrations');
 
-function withMockedIntegrations(apiRequestJson) {
+const SAMPLE_ACCOUNTS = [
+  { account_id: 'default', email_address: 'Me@Example.com', display_name: 'Work Inbox' },
+  { account_id: 'personal', email_address: 'home@example.com', display_name: 'Personal' },
+  { account_id: 'research', email_address: 'keshav@research.com', display_name: 'Research' },
+];
+
+function withMockedIntegrations(apiRequestJson, { stickyAccountId = null } = {}) {
   const authPath = require.resolve('../utils/auth');
   const apiPath = require.resolve('../utils/api');
   const integrationsPath = require.resolve('../commands/integrations');
@@ -13,7 +23,16 @@ function withMockedIntegrations(apiRequestJson) {
     auth: require.cache[authPath],
     api: require.cache[apiPath],
     integrations: require.cache[integrationsPath],
+    gmailAccountFile: process.env.ATRIS_GMAIL_ACCOUNT_FILE,
   };
+
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-gmail-account-'));
+  const gmailAccountFile = path.join(homeDir, 'gmail-account.json');
+  process.env.ATRIS_GMAIL_ACCOUNT_FILE = gmailAccountFile;
+  if (stickyAccountId) {
+    fs.mkdirSync(path.dirname(gmailAccountFile), { recursive: true });
+    fs.writeFileSync(gmailAccountFile, `${JSON.stringify({ account_id: stickyAccountId }, null, 2)}\n`, 'utf8');
+  }
 
   delete require.cache[integrationsPath];
   require.cache[authPath] = {
@@ -37,11 +56,25 @@ function withMockedIntegrations(apiRequestJson) {
   const integrations = require('../commands/integrations');
   return {
     integrations,
+    gmailAccountFile,
+    homeDir,
     restore() {
       if (originals.auth) require.cache[authPath] = originals.auth; else delete require.cache[authPath];
       if (originals.api) require.cache[apiPath] = originals.api; else delete require.cache[apiPath];
       if (originals.integrations) require.cache[integrationsPath] = originals.integrations; else delete require.cache[integrationsPath];
+      if (originals.gmailAccountFile === undefined) delete process.env.ATRIS_GMAIL_ACCOUNT_FILE;
+      else process.env.ATRIS_GMAIL_ACCOUNT_FILE = originals.gmailAccountFile;
+      fs.rmSync(homeDir, { recursive: true, force: true });
     },
+  };
+}
+
+function accountsApi(apiRequestJson, accounts = SAMPLE_ACCOUNTS) {
+  return async (pathname, options) => {
+    if (pathname === '/integrations/gmail/accounts') {
+      return { ok: true, status: 200, data: accounts };
+    }
+    return apiRequestJson(pathname, options);
   };
 }
 
@@ -63,7 +96,18 @@ test('parseGmailArgs splits account flag from positional ids', () => {
   });
 });
 
-test('gmail inbox without --account keeps the legacy request path', async () => {
+test('gmailAccountStatePath honors ATRIS_GMAIL_ACCOUNT_FILE', () => {
+  const previous = process.env.ATRIS_GMAIL_ACCOUNT_FILE;
+  process.env.ATRIS_GMAIL_ACCOUNT_FILE = '/tmp/custom-gmail-account.json';
+  try {
+    assert.equal(gmailAccountStatePath(), '/tmp/custom-gmail-account.json');
+  } finally {
+    if (previous === undefined) delete process.env.ATRIS_GMAIL_ACCOUNT_FILE;
+    else process.env.ATRIS_GMAIL_ACCOUNT_FILE = previous;
+  }
+});
+
+test('gmail inbox without --account uses default account_id when no sticky account', async () => {
   const calls = [];
   const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
     calls.push({ pathname, options });
@@ -79,17 +123,34 @@ test('gmail inbox without --account keeps the legacy request path', async () => 
   }
 
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10');
-  assert.equal(calls[0].options.method, 'GET');
-  assert.equal(calls[0].options.token, 'test-token');
+  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10&account_id=default');
 });
 
-test('gmail inbox with --account adds account_id query param', async () => {
+test('gmail inbox uses sticky account when flag absent', async () => {
   const calls = [];
   const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
     calls.push({ pathname, options });
     return { ok: true, status: 200, data: { messages: [] } };
-  });
+  }, { stickyAccountId: 'personal' });
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await integrations.gmailCommand('inbox');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10&account_id=personal');
+});
+
+test('gmail inbox with --account overrides sticky account', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    return { ok: true, status: 200, data: { messages: [] } };
+  }, { stickyAccountId: 'personal' });
   const originalLog = console.log;
   console.log = () => {};
   try {
@@ -126,7 +187,7 @@ test('gmail read with --account adds account_id query param', async () => {
   assert.equal(calls[0].pathname, '/integrations/gmail/messages/msg-42?account_id=work');
 });
 
-test('gmail archive without --account keeps legacy json body', async () => {
+test('gmail archive without --account uses default account_id', async () => {
   const calls = [];
   const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
     calls.push({ pathname, options });
@@ -143,7 +204,7 @@ test('gmail archive without --account keeps legacy json body', async () => {
 
   assert.equal(calls.length, 1);
   assert.equal(calls[0].pathname, '/integrations/gmail/messages/batch-archive');
-  assert.deepEqual(calls[0].options.body, { message_ids: ['msg-1'] });
+  assert.deepEqual(calls[0].options.body, { message_ids: ['msg-1'], account_id: 'default' });
 });
 
 test('gmail archive with --account adds account_id to json body', async () => {
@@ -168,18 +229,8 @@ test('gmail archive with --account adds account_id to json body', async () => {
   });
 });
 
-test('gmail accounts renders one lowercase line per connected account', async () => {
-  const { integrations, restore } = withMockedIntegrations(async (pathname) => {
-    assert.equal(pathname, '/integrations/gmail/accounts');
-    return {
-      ok: true,
-      status: 200,
-      data: [
-        { account_id: 'default', email_address: 'Me@Example.com', display_name: 'Work Inbox' },
-        { account_id: 'personal', email_address: 'home@example.com', display_name: 'Personal' },
-      ],
-    };
-  });
+test('gmail accounts marks the active account and keeps lowercase output', async () => {
+  const { integrations, restore } = withMockedIntegrations(accountsApi(async () => ({ ok: true, status: 200, data: [] })));
   const lines = [];
   const originalLog = console.log;
   console.log = (line) => lines.push(String(line));
@@ -191,7 +242,74 @@ test('gmail accounts renders one lowercase line per connected account', async ()
   }
 
   assert.deepEqual(lines, [
-    'me@example.com, work inbox',
+    'me@example.com, work inbox (active)',
     'home@example.com, personal',
+    'keshav@research.com, research',
+  ]);
+});
+
+test('gmail use with no arg prints the current sticky account', async () => {
+  const { integrations, restore } = withMockedIntegrations(
+    accountsApi(async () => ({ ok: true, status: 200, data: [] })),
+    { stickyAccountId: 'research' },
+  );
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await integrations.gmailCommand('use');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.deepEqual(lines, ['using research (keshav@research.com)']);
+});
+
+test('gmail use persists a valid account and prints confirmation', async () => {
+  const { integrations, gmailAccountFile, restore } = withMockedIntegrations(
+    accountsApi(async () => ({ ok: true, status: 200, data: [] })),
+  );
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await integrations.gmailCommand('use', 'research');
+    assert.deepEqual(lines, ['now using research (keshav@research.com)']);
+    assert.deepEqual(JSON.parse(fs.readFileSync(gmailAccountFile, 'utf8')), { account_id: 'research' });
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+});
+
+test('gmail use rejects unknown ids and lists available accounts', async () => {
+  const { integrations, restore } = withMockedIntegrations(
+    accountsApi(async () => ({ ok: true, status: 200, data: [] })),
+  );
+  const errors = [];
+  const originalError = console.error;
+  const originalExit = process.exit;
+  console.error = (line) => errors.push(String(line));
+  process.exit = (code) => {
+    throw new Error(`exit:${code}`);
+  };
+  try {
+    await assert.rejects(
+      () => integrations.gmailCommand('use', 'missing'),
+      /exit:1/,
+    );
+  } finally {
+    console.error = originalError;
+    process.exit = originalExit;
+    restore();
+  }
+
+  assert.deepEqual(errors, [
+    'unknown gmail account "missing".',
+    'connected accounts:',
+    '  default: me@example.com, work inbox',
+    '  personal: home@example.com, personal',
+    '  research: keshav@research.com, research',
   ]);
 });


### PR DESCRIPTION
Pick an account once with atris gmail use <id> and every gmail command follows it; --account still wins per call. atris gmail accounts marks the active one. 13 + 43 tests pass, exit 0, re-run by orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)