### PR TITLE
dogfood: atris do default is first-minute only

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -45,7 +45,7 @@ rg "askCommand|currentMissionCommand|approveCommand|stopCommand|answerCommand|re
 rg "decideCommand|collectOpenDecisions|normalizeHumanAsk|answerMissionHumanAsk" commands/decide.js commands/mission.js lib/mission-human-asks.js lib/self-drive.js test/decide.test.js  # Mission human-decision bridge: list open asks deterministically, route yes/no through mission pings, persist answered metadata, and ignore answered asks in mission/self-drive reads
 rg "starterMembers|team members ready|firstMissionCommand|packed golden path|printedAtrisArgs|golden path e2e|what someone can do now|--minimal|mapStubFromTree" commands/init.js bin/atris.js commands/task.js test/init-non-interactive.test.js test/golden-path-e2e.test.js test/repo-shape.test.js test/dogfood-papercuts.test.js atris/team/customer-lead atris/GOLDEN_PATH_PAPERCUTS.md  # Quiet first-run output plus packed-install zero-knowledge contract: six-member starter team, init --minimal lean scaffold, ready-on-init mission, autoland, durable papercut status; printedAtrisArgs (test/golden-path-e2e.test.js:112) matches Next/next labels; packed path follows init --minimal, then the printed claim/ready/autoland commands
 rg "function planAtris" commands/workflow.js   # Plan command (line 370)
-rg "function doAtris" commands/workflow.js     # Do command (line 718): PERSONA head reuses buildFirstMinute; factory banner and file dump stay on --verbose/--full; missing executor spec after init --minimal does not send you back to init
+rg "function doAtris" commands/workflow.js     # Do command (line 718): PERSONA head reuses buildFirstMinute; executor paste and file dump stay on --verbose/--full; missing executor spec after init --minimal does not send you back to init
 rg "function reviewAtris" commands/workflow.js  # Review command (line 1077): default certified queue, --verbose legacy validator prompt
 rg "Confidence Gate|confidenceGatePrompt" commands/workflow.js test/confidence-gate.test.js  # Plan/do/review loophole gate prompt + regression
 rg "statusAtris|showStatusHelp|status and analytics --help" bin/atris.js commands/status.js test/commands.test.js # Status command + workspace-free help
@@ -1191,14 +1191,14 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 2. **`atris do`** - Executor mode
 
-- Entry: `commands/workflow.js:718-1095` (doAtris function)
+- Entry: `commands/workflow.js:718-1086` (doAtris function)
 - Human head: `lib/first-minute.js` `buildFirstMinute` (same win + next as bare `atris`); never prints `Context: UNKNOWN` or `Backlog tasks: 0` when a claimed/review/open task exists
-- Default stays PROMPT ONLY with the copy/paste executor prompt below the fold; `--verbose`/`--full` prints the file dump
+- Default stays PROMPT ONLY plus the first-minute two lines; `--verbose`/`--full` prints the executor paste and file dump
 - Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do after init --yes --minimal does not send you back to init`, `do names a claimed task the same way first-minute does`)
 
 3. **`atris review`** - Validator mode
 
-- Entry: `commands/workflow.js:1077-1566` (reviewAtris function)
+- Entry: `commands/workflow.js:1088-1582` (reviewAtris function)
 - Outputs: validator.md spec + TODO.md + MAP.md + journal
 - Purpose: Ultrathink validation, test, clean docs
 
@@ -1812,8 +1812,8 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Modular commands (in commands/):**
 
 - `planAtris()` → `commands/workflow.js:370-714`
-- `doAtris()` → `commands/workflow.js:718-1095`
-- `reviewAtris()` → `commands/workflow.js:1077-1566`
+- `doAtris()` → `commands/workflow.js:718-1086`
+- `reviewAtris()` → `commands/workflow.js:1088-1582`
 - `statusAtris()` → `commands/status.js:124-384`
 - `analyticsAtris()` → `commands/analytics.js:4-147`
 - `brainstormAtris()` → `commands/brainstorm.js:21-355`

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -804,8 +804,8 @@ function showDoHelp() {
   console.log('');
   console.log('Description:');
   console.log('  Activate the Executor agent to build tasks.');
-  console.log('  Default is PROMPT ONLY: same win and next command as bare atris, then the executor prompt.');
-  console.log('  --verbose prints the executor file dump. Reads TODO.md and features/*/build.md.');
+  console.log('  Default is PROMPT ONLY: same win and next command as bare atris.');
+  console.log('  --verbose prints the executor paste and file dump. Reads TODO.md and features/*/build.md.');
   console.log('');
   console.log('Options:');
   console.log('  --execute   ACTION TAKEN: edit code + run commands via Atris cloud.');

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -907,40 +907,38 @@ async function doAtris() {
       console.log(`📋 Backlog tasks: ${backlogCount}`);
     }
     console.log('');
-  }
 
-  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log('📋 COPY/PASTE PROMPT FOR YOUR CODING AGENT:');
-  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log('');
-  console.log('You are the Executor.');
-  console.log('');
-  console.log('Read these files:');
-  if (executorPath) console.log(`- ${executorPath}`);
-  if (personaFileRef) console.log(`- ${personaFileRef}`);
-  if (mapPath) console.log(`- ${mapPath}`);
-  if (taskSourcePath) console.log(`- ${taskSourcePath}`);
-  if (featuresReadmeRef) console.log(`- ${featuresReadmeRef}`);
-  console.log('');
-  if (!mapPath || mapIsPlaceholder) {
-    console.log('Note: If `atris/MAP.md` is missing or placeholder, generate it from `atris/atris.md` before navigating the codebase.');
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.log('📋 COPY/PASTE PROMPT FOR YOUR CODING AGENT:');
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
     console.log('');
-  }
-  console.log('Workflow:');
-  console.log('1) Read atris/TODO.md — claim next unclaimed Backlog task');
-  console.log('   Move to ## In Progress: add "Claimed by: executor at YYYY-MM-DD HH:MM"');
-  console.log('2) Run the Confidence Gate against the task before editing');
-  printConfidenceGate('   ');
-  console.log('3) Execute step-by-step. Run tests as you go.');
-  console.log('4) Before completion, rerun the gate against proof and residual risk');
-  console.log('5) When done, move task to ## Completed');
-  console.log('6) Log to atris/team/executor/logs/YYYY-MM-DD.md');
-  console.log('   (Task, Delivered, Errors hit, Learned)');
-  console.log('');
-  console.log('⛔ Do NOT plan — just execute what\'s written.');
-  console.log('');
+    console.log('You are the Executor.');
+    console.log('');
+    console.log('Read these files:');
+    if (executorPath) console.log(`- ${executorPath}`);
+    if (personaFileRef) console.log(`- ${personaFileRef}`);
+    if (mapPath) console.log(`- ${mapPath}`);
+    if (taskSourcePath) console.log(`- ${taskSourcePath}`);
+    if (featuresReadmeRef) console.log(`- ${featuresReadmeRef}`);
+    console.log('');
+    if (!mapPath || mapIsPlaceholder) {
+      console.log('Note: If `atris/MAP.md` is missing or placeholder, generate it from `atris/atris.md` before navigating the codebase.');
+      console.log('');
+    }
+    console.log('Workflow:');
+    console.log('1) Read atris/TODO.md — claim next unclaimed Backlog task');
+    console.log('   Move to ## In Progress: add "Claimed by: executor at YYYY-MM-DD HH:MM"');
+    console.log('2) Run the Confidence Gate against the task before editing');
+    printConfidenceGate('   ');
+    console.log('3) Execute step-by-step. Run tests as you go.');
+    console.log('4) Before completion, rerun the gate against proof and residual risk');
+    console.log('5) When done, move task to ## Completed');
+    console.log('6) Log to atris/team/executor/logs/YYYY-MM-DD.md');
+    console.log('   (Task, Delivered, Errors hit, Learned)');
+    console.log('');
+    console.log('⛔ Do NOT plan — just execute what\'s written.');
+    console.log('');
 
-  if (showFull) {
     console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
     console.log('📎 APPENDIX (full context dumps):');
     console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
@@ -967,12 +965,6 @@ async function doAtris() {
       console.log('');
     }
 
-  }
-
-  if (!showFull) {
-    console.log('atris do --verbose prints the executor file dump.');
-    console.log('');
-  } else {
     console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
     if (!hasLiveTask) {
       console.log('💡 Next: Run "atris review" after execution');

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -953,15 +953,17 @@ test('plan suggests brainstorm when uncertainty detected', () => {
   }
 });
 
-test('do prints concise executor prompt by default', () => {
+test('do prints first-minute only by default', () => {
   const dir = makeTempDir();
   try {
     runCli(['init'], { cwd: dir, input: '\n' });
 
     const res = runCli(['do'], { cwd: dir });
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /COPY\/PASTE PROMPT/);
-    assert.match(res.stdout, /You are the Executor/);
+    assert.match(res.stdout, /^PROMPT ONLY/m);
+    assert.match(res.stdout, /^next: /m);
+    assert.doesNotMatch(res.stdout, /COPY\/PASTE PROMPT/);
+    assert.doesNotMatch(res.stdout, /You are the Executor/);
     assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
     assert.doesNotMatch(res.stdout, /Context: UNKNOWN/);
     assert.doesNotMatch(res.stdout, /EXECUTOR SPEC — How to Build/);

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -24,6 +24,8 @@ const path = require('node:path');
 const http = require('node:http');
 const { spawnSync } = require('node:child_process');
 
+const { spokenLineCount } = require('../lib/first-minute');
+
 const repoRoot = path.resolve(__dirname, '..');
 const cliPath = path.join(repoRoot, 'bin', 'atris.js');
 
@@ -59,6 +61,10 @@ function runCli(args, { cwd, input, env } = {}) {
 function nextLine(stdout) {
   const match = String(stdout || '').match(/^next: (.+)$/m);
   return match ? match[1] : '';
+}
+
+function spokenDoBody(stdout) {
+  return String(stdout || '').replace(/^(PROMPT ONLY|ACTION TAKEN)\s*/m, '');
 }
 
 function writeClaimedWorkspace(dir, task = {
@@ -152,13 +158,14 @@ test('do after init --yes --minimal does not send you back to init', () => {
   assert.match(res.stdout, /PROMPT ONLY/);
   assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
   assert.doesNotMatch(res.stdout, /Context: UNKNOWN/);
-  assert.match(res.stdout, /You are the Executor\./);
+  assert.doesNotMatch(res.stdout, /COPY\/PASTE PROMPT|You are the Executor\./);
   assert.doesNotMatch(res.stdout, /Executor spec: atris\/team\/executor\/MEMBER\.md \(missing\)/);
   assert.doesNotMatch(combined, /executor\.md not found|Run "atris init"/);
   assert.doesNotMatch(combined, /What do you want to build|Describe the desired outcome/);
 
   const verbose = runCli(['do', '--verbose'], { cwd: dir });
   assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
+  assert.match(verbose.stdout, /You are the Executor\./);
   assert.match(verbose.stdout, /Executor spec: atris\/team\/executor\/MEMBER\.md \(missing\)/);
 });
 
@@ -220,7 +227,7 @@ test('plan --full dumps the actual navigator spec content', () => {
   assert.ok(full.stdout.includes(marker), '--full should include the spec content');
 });
 
-test('do prints the executor prompt shape and surfaces feature build plans', () => {
+test('do prints the first-minute head; executor paste stays on --verbose', () => {
   const dir = initializedWorkspace();
   const featureDir = path.join(dir, 'atris', 'features', 'sample-feature');
   fs.mkdirSync(featureDir, { recursive: true });
@@ -231,13 +238,15 @@ test('do prints the executor prompt shape and surfaces feature build plans', () 
   assert.match(res.stdout, /^PROMPT ONLY/m);
   assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
   assert.doesNotMatch(res.stdout, /Context: UNKNOWN/);
-  assert.match(res.stdout, /You are the Executor\./);
-  assert.match(res.stdout, /claim next unclaimed Backlog task/);
-  assert.match(res.stdout, /Do NOT plan — just execute/);
+  assert.doesNotMatch(res.stdout, /COPY\/PASTE PROMPT|You are the Executor\./);
+  assert.doesNotMatch(res.stdout, /claim next unclaimed Backlog task/);
+  assert.doesNotMatch(res.stdout, /Do NOT plan — just execute/);
   assert.doesNotMatch(res.stdout, /Feature build plans found/);
 
   const full = runCli(['do', '--full'], { cwd: dir });
   assert.equal(full.status, 0, full.stderr);
+  assert.match(full.stdout, /COPY\/PASTE PROMPT FOR YOUR CODING AGENT:/);
+  assert.match(full.stdout, /You are the Executor\./);
   assert.match(full.stdout, /Feature build plans found: 1/);
   assert.match(full.stdout, /sample-feature[\/\\]build\.md/);
 });
@@ -255,12 +264,13 @@ test('do names a claimed task the same way first-minute does', () => {
   assert.match(doit.stdout, /"ship the landing page" is already yours\./);
   assert.equal(nextLine(doit.stdout), nextLine(minute.stdout));
   assert.equal(nextLine(doit.stdout), 'atris task ready CLI-9');
+  assert.equal(spokenLineCount(spokenDoBody(doit.stdout)), 2);
   assert.doesNotMatch(doit.stdout, /Atris Do — Executor Agent Activated/);
   assert.doesNotMatch(doit.stdout, /Context: UNKNOWN/);
   assert.doesNotMatch(doit.stdout, /Backlog tasks: 0/);
   assert.doesNotMatch(doit.stdout, /CONTEXT FILES \(agent should read\)/);
+  assert.doesNotMatch(doit.stdout, /COPY\/PASTE PROMPT|You are the Executor\./);
   assert.doesNotMatch(doit.stdout, /What do you want to build|Describe the desired outcome/);
-  assert.match(doit.stdout, /You are the Executor\./);
 
   const verbose = runCli(['do', '--verbose'], { cwd: dir, env });
   assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
@@ -269,6 +279,8 @@ test('do names a claimed task the same way first-minute does', () => {
   assert.doesNotMatch(verbose.stdout, /Context: UNKNOWN/);
   assert.doesNotMatch(verbose.stdout, /Backlog tasks: 0/);
   assert.match(verbose.stdout, /CONTEXT FILES \(agent should read\)/);
+  assert.match(verbose.stdout, /COPY\/PASTE PROMPT FOR YOUR CODING AGENT:/);
+  assert.match(verbose.stdout, /You are the Executor\./);
 });
 
 test('review --verbose prints the validator prompt and reacts to journal completions', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Default `atris do` now matches the first minute: `PROMPT ONLY` plus the two spoken lines (hey, win, next). The long executor paste no longer follows those lines.

`--verbose` / `--full` still print the copy/paste prompt and file dump. Empty folders still tell you to init. A claimed task still names that task and `atris task ready <id>`. Headless still does not prompt.

## Why

The first-minute head was already honest. Dumping the COPY/PASTE wall right after it undid that feel.

## Proof

```
node --test test/workflow-command.test.js test/cli-smoke.test.js
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d0da601-73ed-4827-ab59-77874aecfef3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d0da601-73ed-4827-ab59-77874aecfef3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

