### PR TITLE
dogfood: review talks like first-minute

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -44,9 +44,9 @@ rg "missionDrive|destinationHash|mission_destination_change_proposed|pending_des
 rg "askCommand|currentMissionCommand|approveCommand|stopCommand|answerCommand|readyCommand|checkCommand|missionCard" commands/human-missions.js commands/mission.js lib/cloud-mission.js bin/atris.js test/human-missions.test.js  # Public human mission commands: ask, current card, answer, approve, stop, readiness, and check results over the cloud mission client
 rg "decideCommand|collectOpenDecisions|normalizeHumanAsk|answerMissionHumanAsk" commands/decide.js commands/mission.js lib/mission-human-asks.js lib/self-drive.js test/decide.test.js  # Mission human-decision bridge: list open asks deterministically, route yes/no through mission pings, persist answered metadata, and ignore answered asks in mission/self-drive reads
 rg "starterMembers|team members ready|firstMissionCommand|packed golden path|printedAtrisArgs|golden path e2e|what someone can do now|--minimal|mapStubFromTree" commands/init.js bin/atris.js commands/task.js test/init-non-interactive.test.js test/golden-path-e2e.test.js test/repo-shape.test.js test/dogfood-papercuts.test.js atris/team/customer-lead atris/GOLDEN_PATH_PAPERCUTS.md  # Quiet first-run output plus packed-install zero-knowledge contract: six-member starter team, init --minimal lean scaffold, ready-on-init mission, autoland, durable papercut status; printedAtrisArgs (test/golden-path-e2e.test.js:112) matches Next/next labels; packed path follows init --minimal, then the printed claim/ready/autoland commands
-rg "function planAtris" commands/workflow.js   # Plan command (line 370)
-rg "function doAtris" commands/workflow.js     # Do command (line 718): PERSONA head reuses buildFirstMinute; executor paste and file dump stay on --verbose/--full; missing executor spec after init --minimal does not send you back to init
-rg "function reviewAtris" commands/workflow.js  # Review command (line 1077): default certified queue, --verbose legacy validator prompt
+rg "function planAtris" commands/workflow.js   # Plan command (line 443)
+rg "function doAtris" commands/workflow.js     # Do command (line 790): PERSONA head reuses buildFirstMinute; executor paste and file dump stay on --verbose/--full; missing executor spec after init --minimal does not send you back to init
+rg "function reviewAtris|renderReviewMinute" commands/workflow.js test/workflow-command.test.js  # Review command: default first-minute spoken screen (certified -> accept; uncertified still being checked); --json/--all/--limit/--group-by keep the queue; --verbose legacy validator prompt; headless never prompts
 rg "Confidence Gate|confidenceGatePrompt" commands/workflow.js test/confidence-gate.test.js  # Plan/do/review loophole gate prompt + regression
 rg "statusAtris|showStatusHelp|status and analytics --help" bin/atris.js commands/status.js test/commands.test.js # Status command + workspace-free help
 rg "analyticsAtris|showAnalyticsHelp|status and analytics --help" bin/atris.js commands/analytics.js test/commands.test.js  # Analytics command + workspace-free help
@@ -1196,11 +1196,14 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - Default stays PROMPT ONLY plus the first-minute two lines; `--verbose`/`--full` prints the executor paste and file dump
 - Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do after init --yes --minimal does not send you back to init`, `do names a claimed task the same way first-minute does`)
 
-3. **`atris review`** - Validator mode
+3. **`atris review`** - Human checkpoint, first-minute voice
 
-- Entry: `commands/workflow.js:1088-1582` (reviewAtris function)
-- Outputs: validator.md spec + TODO.md + MAP.md + journal
-- Purpose: Ultrathink validation, test, clean docs
+- Entry: `commands/workflow.js` `reviewAtris` / `renderReviewMinute`
+- Default: 2-4 spoken lines. Certified leads with the win and `atris task accept <id>`. Uncertified stays "still being checked", not needs-you. Reuses `pickNext` / `taskCommand` from `lib/first-minute.js`.
+- `--json` / `--all` / `--limit` / `--group-by`: certified queue via `task reviews`
+- `--verbose` / `--full`: legacy Validator prompt
+- Headless never prompts (`isNonInteractive`)
+- Regression: `test/workflow-command.test.js` (`review talks like first-minute`)
 
 4. **`atris launch`** - REMOVED (was dead code, deleted)
 
@@ -1811,9 +1814,9 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - `upgradeAtris()` — npm upgrade (line 1214)
 **Modular commands (in commands/):**
 
-- `planAtris()` → `commands/workflow.js:370-714`
-- `doAtris()` → `commands/workflow.js:718-1086`
-- `reviewAtris()` → `commands/workflow.js:1088-1582`
+- `planAtris()` → `commands/workflow.js:443-788`
+- `doAtris()` → `commands/workflow.js:790-1158`
+- `reviewAtris()` / `renderReviewMinute()` → `commands/workflow.js` (default first-minute screen; --verbose validator prompt)
 - `statusAtris()` → `commands/status.js:124-384`
 - `analyticsAtris()` → `commands/analytics.js:4-147`
 - `brainstormAtris()` → `commands/brainstorm.js:21-355`

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -819,8 +819,9 @@ function showReviewHelp() {
   console.log('Usage: atris review [--limit N|--all|--json] [--full|--execute]');
   console.log('');
   console.log('Description:');
-  console.log('  Show the certified Review queue: proof-ready work waiting for');
-  console.log('  human accept or revise. Human accept is the AgentXP gate.');
+  console.log('  Show the one finished thing waiting for your ok.');
+  console.log('  Certified work leads with atris task accept. Uncertified stays');
+  console.log('  still being checked. Use --json/--all for the full queue.');
   console.log('  Use --full/--verbose for the legacy Validator prompt.');
   console.log('');
   console.log('Options:');

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const { getLogPath } = require('../lib/journal');
-const { buildFirstMinute } = require('../lib/first-minute');
+const { buildFirstMinute, isCertifiedReview, personName, pickNext, taskCommand } = require('../lib/first-minute');
+const { isNonInteractive } = require('../lib/noninteractive');
 const { buildToolResultBody } = require('../lib/tool-result-encode');
 
 function wrapWorkflowText(text, width = 76) {
@@ -41,6 +42,77 @@ function printWorkflowBrief(lines) {
     }
   }
   console.log('');
+}
+
+function reviewSoftTitle(title, maxWords = 5) {
+  const words = String(title || '').replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  if (!words.length) return '';
+  const text = words.slice(0, maxWords).join(' ').replace(/[.,;:!?]+$/g, '');
+  return `"${text.toLowerCase()}"`;
+}
+
+function loadReviewTasks(root = process.cwd()) {
+  try {
+    const taskDb = require('../lib/task-db');
+    const db = taskDb.open();
+    const workspaceRoot = taskDb.workspaceRoot(root);
+    const rows = taskDb.listTasks(db, { workspaceRoot, limit: 200 });
+    if (Array.isArray(rows) && rows.length) return taskDb.withTaskDisplayRefs(rows);
+  } catch {
+    // Fall through to the local projection. Tests and fresh folders often have no db.
+  }
+  const projectionPath = path.join(root, '.atris', 'state', 'tasks.projection.json');
+  try {
+    const parsed = JSON.parse(fs.readFileSync(projectionPath, 'utf8'));
+    return Array.isArray(parsed.tasks) ? parsed.tasks : [];
+  } catch {
+    return [];
+  }
+}
+
+function wantsReviewQueue(args = []) {
+  const list = Array.isArray(args) ? args : [];
+  return list.includes('--json')
+    || list.includes('--all')
+    || list.includes('--limit')
+    || list.includes('--group-by');
+}
+
+function renderReviewMinute({
+  root = process.cwd(),
+  person,
+  tasks,
+} = {}) {
+  const who = person != null ? person : personName();
+  const greet = who ? `hey ${who}, ` : '';
+  const all = Array.isArray(tasks) ? tasks : loadReviewTasks(root);
+  const reviews = all.filter((task) => task && task.status === 'review');
+  const checking = reviews.filter((task) => !isCertifiedReview(task));
+  const picked = pickNext({ tasks: reviews, person: who });
+  const task = picked.task || null;
+  const title = task ? reviewSoftTitle(task.title) : '';
+
+  if (task && isCertifiedReview(task)) {
+    const win = title
+      ? `${greet}${title} is waiting for your ok.`
+      : `${greet}one finished thing is waiting for your ok.`;
+    const lines = [win];
+    if (checking.length === 1) lines.push('1 still being checked.');
+    if (checking.length > 1) lines.push(`${checking.length} still being checked.`);
+    lines.push('');
+    lines.push(`next: ${taskCommand(task, who)}`);
+    return lines.join('\n');
+  }
+
+  if (checking.length === 1) {
+    const named = title || reviewSoftTitle(checking[0] && checking[0].title);
+    if (named) return `${greet}${named} is still being checked.`;
+    return `${greet}1 finished thing is still being checked.`;
+  }
+  if (checking.length > 1) {
+    return `${greet}${checking.length} finished things are still being checked.`;
+  }
+  return 'nothing is waiting on you.';
 }
 
 const CONFIDENCE_GATE_LINES = [
@@ -1098,19 +1170,11 @@ async function reviewAtris() {
   if (!executeFlag && !showFull) {
     const forwarded = ['reviews', ...args.filter(arg => !['--execute', '--full', '--verbose'].includes(arg))];
     const { run: runTaskCommand } = require('./task');
-    if (!wantsTaskJson) {
-      printWorkflowBrief([
-        'Atris Review is the human checkpoint for proof-ready work.',
-        'Accept only when the proof is real; revise when the claim is vague, stale, or too narrow.',
-        'Agents can add review proof here, but XP waits for human accept.',
-      ]);
+    if (wantsTaskJson || wantsReviewQueue(args)) {
+      await runTaskCommand(forwarded);
+      return;
     }
-    await runTaskCommand(forwarded);
-    if (!wantsTaskJson) {
-      printWorkflowBrief([
-        'Need the legacy Validator prompt? Run `atris review --verbose`.',
-      ]);
-    }
+    console.log(renderReviewMinute());
     return;
   }
 
@@ -1513,8 +1577,8 @@ async function reviewAtris() {
     }
   }
 
-  // Prompt for learnings (skip if stdin is not a TTY)
-  if (!process.stdin.isTTY) return;
+  // Prompt for learnings. Headless and forced non-interactive never ask.
+  if (isNonInteractive()) return;
 
   console.log('');
   if (showFull) {
@@ -1667,6 +1731,7 @@ module.exports = {
   planAtris,
   doAtris,
   reviewAtris,
+  renderReviewMinute,
   executeAgentSDKFast,
   makeCloudExecutor,
   postToolResult

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -985,17 +985,17 @@ test('do --full includes full executor dumps', () => {
   }
 });
 
-test('review prints concise validator prompt by default', () => {
+test('review prints a first-minute screen by default', () => {
   const dir = makeTempDir();
   try {
     runCli(['init'], { cwd: dir, input: '\n' });
 
     const res = runCli(['review'], { cwd: dir });
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /Atris Review is the human checkpoint/);
-    assert.match(res.stdout, /nothing is waiting on you\. everything that finished has already landed\./);
+    assert.match(res.stdout, /nothing is waiting on you\./);
+    assert.doesNotMatch(res.stdout, /Atris Review is the human checkpoint/);
+    assert.doesNotMatch(res.stdout, /Need the legacy Validator prompt/);
     assert.doesNotMatch(res.stdout, /clear completed tasks out of TODO/);
-    assert.match(res.stdout, /Need the legacy Validator prompt\? Run `atris review --verbose`/);
     assert.doesNotMatch(res.stdout, /COPY\/PASTE PROMPT/);
   } finally {
     cleanupTempDir(dir);

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -19452,7 +19452,7 @@ test('status stays local even when .atris/business.json exists', () => {
   }
 });
 
-test('review default mode renders certified task review console', () => {
+test('review default mode leads with certified accept like first-minute', () => {
   if (!hasNodeSqlite()) return;
   const dir = makeTempDir();
   const dbPath = path.join(dir, 'tasks.db');
@@ -19470,10 +19470,10 @@ test('review default mode renders certified task review console', () => {
 
     const res = runCli(['review'], { cwd: dir, env });
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /Atris Review is the human checkpoint/);
-    assert.match(res.stdout, /one finished thing is waiting for your ok\. it passed both checks\./);
-    assert.match(res.stdout, new RegExp(`say yes: atris task accept ${ref}`));
-    assert.match(res.stdout, /Need the legacy Validator prompt/);
+    assert.match(res.stdout, /is waiting for your ok\./);
+    assert.match(res.stdout, new RegExp(`^next: atris task accept ${ref}$`, 'm'));
+    assert.doesNotMatch(res.stdout, /Atris Review is the human checkpoint/);
+    assert.doesNotMatch(res.stdout, /Need the legacy Validator prompt/);
     assert.doesNotMatch(res.stdout, /I checked the review setup\./);
     assert.doesNotMatch(res.stdout, /┌|└|│|Validator Agent Activated/);
   } finally {

--- a/test/confidence-gate.test.js
+++ b/test/confidence-gate.test.js
@@ -51,10 +51,11 @@ test('plan, do, and review prompts include the confidence gate', () => {
     assert.match(doing.stdout, /Run the Confidence Gate against the task before editing/);
     assert.match(doing.stdout, /rerun the gate against proof and residual risk/);
 
-    // Default review is concise and points to --verbose for the legacy gate.
+    // Default review is a short spoken screen, not the validator lecture.
     const review = runCli(['review'], { cwd: dir });
     assert.equal(review.status, 0, review.stderr);
-    assert.match(review.stdout, /atris review --verbose/);
+    assert.doesNotMatch(review.stdout, /Atris Review is the human checkpoint/);
+    assert.doesNotMatch(review.stdout, /Confidence Gate:/);
 
     // The full Confidence Gate lives in the verbose validator prompt.
     const verboseReview = runCli(['review', '--verbose'], { cwd: dir });

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -360,10 +360,10 @@ test('review headless never prompts', () => {
   const env = isolatedDoEnv(dir);
   const review = runCli(['review'], { cwd: dir, env, input: '' });
   assert.equal(review.status, 0, review.stderr || review.stdout);
-  assert.doesNotMatch(review.stdout + review.stderr, /any learnings\?|^> /m);
+  assert.doesNotMatch(review.stdout + review.stderr, /any learnings\?/);
   const verbose = runCli(['review', '--verbose'], { cwd: dir, env, input: '' });
   assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
-  assert.doesNotMatch(verbose.stdout + verbose.stderr, /any learnings\?|^> /m);
+  assert.doesNotMatch(verbose.stdout + verbose.stderr, /any learnings\?/);
 });
 
 test('renderReviewMinute leads with certified accept and keeps uncertified checking', () => {

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -23,6 +23,8 @@ const os = require('node:os');
 const path = require('node:path');
 const http = require('node:http');
 const { spawnSync } = require('node:child_process');
+const { spokenLineCount } = require('../lib/first-minute');
+const { renderReviewMinute } = require('../commands/workflow');
 
 const { spokenLineCount } = require('../lib/first-minute');
 
@@ -283,7 +285,121 @@ test('do names a claimed task the same way first-minute does', () => {
   assert.match(verbose.stdout, /You are the Executor\./);
 });
 
-test('review --verbose prints the validator prompt and reacts to journal completions', () => {
+test('review talks like first-minute when a certified task is waiting', () => {
+  const dir = makeTempDir();
+  writeClaimedWorkspace(dir, {
+    id: 'task-2',
+    display_id: 'UNW-2',
+    title: 'Print a human line like 4 words so the count is easy to read.',
+    status: 'review',
+    updated_at: 20,
+    review: { agent_certified: true, agent_review_pass_count: 2 },
+  });
+  const env = isolatedDoEnv(dir);
+
+  const minute = runCli([], { cwd: dir, env });
+  const review = runCli(['review'], { cwd: dir, env });
+  assert.equal(minute.status, 0, minute.stderr || minute.stdout);
+  assert.equal(review.status, 0, review.stderr || review.stdout);
+  assert.match(review.stdout, /"print a human line like" is waiting for your ok\./);
+  assert.equal(nextLine(review.stdout), 'atris task accept UNW-2');
+  assert.equal(nextLine(review.stdout), nextLine(minute.stdout));
+  assert.ok(spokenLineCount(review.stdout) >= 2 && spokenLineCount(review.stdout) <= 4);
+  assert.doesNotMatch(review.stdout, /Atris Review is the human checkpoint/);
+  assert.doesNotMatch(review.stdout, /Need the legacy Validator prompt/);
+  assert.doesNotMatch(review.stdout, /needs you|say yes:/);
+  assert.doesNotMatch(review.stdout, /any learnings\?/);
+  assert.doesNotMatch(review.stdout, /┌|└|│|Validator Agent Activated/);
+});
+
+test('review keeps uncertified work still being checked, not needs-you', () => {
+  const dir = makeTempDir();
+  writeClaimedWorkspace(dir, {
+    id: 'task-3',
+    display_id: 'UNW-3',
+    title: 'Second check still open',
+    status: 'review',
+    updated_at: 30,
+    review: { agent_review_pass_count: 1 },
+  });
+  const env = isolatedDoEnv(dir);
+  const review = runCli(['review'], { cwd: dir, env });
+  assert.equal(review.status, 0, review.stderr || review.stdout);
+  assert.match(review.stdout, /"second check still open" is still being checked\./);
+  assert.doesNotMatch(review.stdout, /waiting for your ok|needs you|atris task accept/);
+  assert.doesNotMatch(review.stdout, /Atris Review is the human checkpoint/);
+  assert.ok(spokenLineCount(review.stdout) <= 4);
+});
+
+test('review --json still emits the certified queue', () => {
+  const dir = makeTempDir();
+  writeClaimedWorkspace(dir, {
+    id: 'task-2',
+    display_id: 'UNW-2',
+    title: 'Print a human line like 4 words so the count is easy to read.',
+    status: 'review',
+    updated_at: 20,
+    review: {
+      approval_status: 'pending',
+      agent_certified: true,
+      agent_review_pass_count: 2,
+      proof: 'context '.repeat(35) + 'Verifiers: node --test test/workflow-command.test.js passed',
+    },
+  });
+  const env = isolatedDoEnv(dir);
+  const res = runCli(['review', '--json'], { cwd: dir, env });
+  assert.equal(res.status, 0, res.stderr || res.stdout);
+  const payload = JSON.parse(res.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.action, 'review_queue');
+  assert.ok(payload.queue);
+});
+
+test('review headless never prompts', () => {
+  const dir = initializedWorkspace();
+  const env = isolatedDoEnv(dir);
+  const review = runCli(['review'], { cwd: dir, env, input: '' });
+  assert.equal(review.status, 0, review.stderr || review.stdout);
+  assert.doesNotMatch(review.stdout + review.stderr, /any learnings\?|^> /m);
+  const verbose = runCli(['review', '--verbose'], { cwd: dir, env, input: '' });
+  assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
+  assert.doesNotMatch(verbose.stdout + verbose.stderr, /any learnings\?|^> /m);
+});
+
+test('renderReviewMinute leads with certified accept and keeps uncertified checking', () => {
+  const text = renderReviewMinute({
+    person: 'keshav',
+    tasks: [
+      {
+        title: 'Print a human line like 4 words so the count is easy to read.',
+        status: 'review',
+        display_id: 'UNW-2',
+        updated_at: 20,
+        review: { agent_certified: true, agent_review_pass_count: 2 },
+      },
+      {
+        title: 'Second check still open',
+        status: 'review',
+        display_id: 'UNW-3',
+        updated_at: 30,
+        review: { agent_review_pass_count: 1 },
+      },
+    ],
+  });
+  assert.match(text, /hey keshav, "print a human line like" is waiting for your ok\./);
+  assert.match(text, /1 still being checked\./);
+  assert.match(text, /^next: atris task accept UNW-2$/m);
+  assert.doesNotMatch(text, /needs you|ready to look at|human checkpoint/);
+  assert.equal(spokenLineCount(text), 3);
+});
+
+test('renderReviewMinute empty queue is one spoken line', () => {
+  const text = renderReviewMinute({ person: 'keshav', tasks: [] });
+  assert.equal(text, 'nothing is waiting on you.');
+  assert.equal(spokenLineCount(text), 1);
+});
+
+test('review --verbose keeps the old validator explainer', () => {
   const dir = initializedWorkspace();
   fs.writeFileSync(
     todayLogFile(dir),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Default `atris review` was opening with a manifesto, then later telling the truth.

It now talks like first-minute: two to four short spoken lines. If a certified review exists, it leads with that win and `atris task accept <id>`. Uncertified work stays "still being checked", not needs-you.

`--json` / `--all` / `--limit` / `--group-by` still print the queue. `--verbose` keeps the old validator prompt. Headless never prompts.

`lib/first-minute.js` is unchanged. Review reuses `pickNext` and `taskCommand` from it.

Checks passed:
`node --test test/workflow-command.test.js test/confidence-gate.test.js`
`node --test --test-name-pattern='review default mode leads with certified accept|review verbose mode keeps' test/commands.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87c2a214-d117-4496-b8dd-6c3487f75b36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87c2a214-d117-4496-b8dd-6c3487f75b36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

