### PR TITLE
dogfood: recap talks like first-minute

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1007,18 +1007,19 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 ### Feature: Recap (`atris recap`)
 
-**Purpose:** Plain-English report of what the AI team did — for the operator, or paste-ready for a customer. Receipts made legible; zero internal jargon in output.
+**Purpose:** Spoken recap of what the AI team did for the operator. Receipts stay legible; zero internal jargon in output. `--share` is paste-ready for a customer.
 
-- **Entry point:** `commands/recap.js` (`recapAtris`, `buildRecapData`, `renderRecap`, `renderShare`)
+- **Entry point:** `commands/recap.js` (`recapAtris`, `buildRecapData`, `renderRecapMinute`, `renderRecap`, `renderShare`)
 - **Routing:** `bin/atris.js` (`command === 'recap'` branch, `knownCommands` list, Context & tracking help line)
 - **Data sources:** task DB via `lib/task-db` (`listTasks` + `taskDisplayRefMap`); empty or missing db falls through to `.atris/state/tasks.projection.json`, same as first-minute
 - **Buckets:** shipped = `done` within `--days` window (default 7); waiting = certified / two-pass `review` via `lib/first-minute.js` `isCertifiedReview` (needs human accept); checking = uncertified `review` (still being checked, not needs-you); in progress = `open`/`claimed`
+- **Default:** `renderRecapMinute` talks like first-minute / review: a few spoken lines. Certified waiting names `atris task accept <id>`. Uncertified stays still being checked. No `RECAP` header, Plain English manifesto, or share footer.
 - **Next:** one certified accept names `atris task accept <id>`; recap does not send humans to `atris task reviews` when that accept is the next move
-- **Proof line:** `metadata.latest_agent_proof` (or certified marker), compressed to one line per item
-- **Modes:** default report, `--share` (paste-ready for Slack/email/customer), `--json` (agents/dashboards), `--days N`
-- **Regression:** `test/recap.test.js` (buckets, jargon ban, share format, projection fallback, empty workspace, certified-only needs-you, headless mixed board)
+- **Proof line:** `metadata.latest_agent_proof` (or certified marker), compressed to one line per item on `--verbose` / `--share`
+- **Modes:** default spoken lines, `--verbose`/`--full` old report, `--share` (paste-ready for Slack/email/customer), `--json` (agents/dashboards), `--days N`
+- **Regression:** `test/recap.test.js` (buckets, jargon ban, share format, projection fallback, empty workspace, certified-only needs-you, spoken default, verbose report, headless mixed board)
 
-**Search:** `rg "recapAtris|plainCheck|isCertifiedReview|isRealTestRunnerProof|classifyVerifier" commands/recap.js lib/first-minute.js lib/verifier-quality.js commands/task.js test/recap.test.js test/dogfood-p1.test.js`
+**Search:** `rg "recapAtris|renderRecapMinute|plainCheck|isCertifiedReview|isRealTestRunnerProof|classifyVerifier" commands/recap.js lib/first-minute.js lib/verifier-quality.js commands/task.js test/recap.test.js test/dogfood-p1.test.js`
 rg "fleetWorkspaceStatus|fleet --global" commands/fleet.js test/dogfood-p1.test.js # Fleet defaults to workspace; --global hits Swarlo
 rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js test/dogfood-p1.test.js # Engine roster workspace vs --global
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -492,7 +492,7 @@ function showHelpShort() {
   console.log('  atris task claim <id> --as <m>  take ownership');
   console.log('  atris task ready <id> --proof "..."');
   console.log('  atris review                    validate');
-  console.log('  atris recap                     plain-english what landed');
+  console.log('  atris recap                     spoken recap of what landed');
   console.log('  atris mission status            active goals + next move');
   console.log('');
   console.log('More: atris help --all   ·   machine list: atris help --json');
@@ -503,7 +503,7 @@ function helpCatalog() {
     { name: 'init', summary: 'scaffold atris/ in this project', json: false, interactive_risk: 'medium' },
     { name: 'task', summary: 'local task plane: new, claim, ready, accept', json: true, interactive_risk: 'low' },
     { name: 'review', summary: 'validate work and capture learnings', json: false, interactive_risk: 'low' },
-    { name: 'recap', summary: 'plain-english what your team did', json: true, interactive_risk: 'low' },
+    { name: 'recap', summary: 'spoken recap of what your team did', json: true, interactive_risk: 'low' },
     { name: 'mission', summary: 'durable goal + owner + verifier + tick', json: true, interactive_risk: 'medium' },
     { name: 'log', summary: 'append an idea to today inbox (or --repl)', json: false, interactive_risk: 'medium' },
     { name: 'wish', summary: 'headless inbox / mission intake', json: true, interactive_risk: 'low' },
@@ -589,7 +589,7 @@ function showHelpAll() {
   console.log('  launchpad  - Show the next action from local brain, task, mission, and proof state');
   console.log('  brief      - Show the one-glance operator brief');
   console.log('  status     - See local work and completions (`atris status <business>` for remote)');
-  console.log('  recap      - What your AI team did, in plain English (--share for paste-ready)');
+  console.log('  recap      - What your AI team did, in spoken lines (--verbose for the old report)');
   console.log('  report     - Weekly block: landings, journal completions, and Career XP');
   console.log('  xp         - Show Career XP and contribution graph');
   console.log('  analytics  - Show recent productivity from journals');

--- a/commands/recap.js
+++ b/commands/recap.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { isCertifiedReview } = require('../lib/first-minute');
+const { isCertifiedReview, personName } = require('../lib/first-minute');
 const { isRealTestRunnerProof, quoteVerifierCommand } = require('../lib/verifier-quality');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -234,17 +234,83 @@ function renderShare(data) {
   return lines.join('\n');
 }
 
+function recapSoftTitle(title, maxWords = 5) {
+  const words = String(title || '').replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  if (!words.length) return '';
+  const text = words.slice(0, maxWords).join(' ').replace(/[.,;:!?]+$/g, '');
+  return `"${text.toLowerCase()}"`;
+}
+
+function renderRecapMinute(data, { person } = {}) {
+  const who = person != null ? person : personName();
+  const greet = who ? `hey ${who}, ` : '';
+  if (data.empty) {
+    return [
+      `${greet}no task history yet.`,
+      '',
+      'next: atris init --minimal',
+    ].join('\n');
+  }
+
+  const waiting = Array.isArray(data.waiting) ? data.waiting : [];
+  const checking = Array.isArray(data.checking) ? data.checking : [];
+  const shipped = Array.isArray(data.shipped) ? data.shipped : [];
+  const inProgress = Array.isArray(data.inProgress) ? data.inProgress : [];
+  const certified = waiting[0] || null;
+  const title = certified ? recapSoftTitle(certified.title) : '';
+
+  if (certified) {
+    const win = title
+      ? `${greet}${title} is waiting for your ok.`
+      : `${greet}one finished thing is waiting for your ok.`;
+    const lines = [win];
+    if (checking.length === 1) lines.push('1 still being checked.');
+    if (checking.length > 1) lines.push(`${checking.length} still being checked.`);
+    if (data.next) {
+      lines.push('');
+      lines.push(`next: ${data.next}`);
+    }
+    return lines.join('\n');
+  }
+
+  if (checking.length === 1) {
+    const named = recapSoftTitle(checking[0] && checking[0].title);
+    if (named) return `${greet}${named} is still being checked.`;
+    return `${greet}1 finished thing is still being checked.`;
+  }
+  if (checking.length > 1) {
+    return `${greet}${checking.length} finished things are still being checked.`;
+  }
+
+  if (shipped.length) {
+    const named = recapSoftTitle(shipped[0].title);
+    return named
+      ? `${greet}you already shipped ${named}.`
+      : `${greet}you already shipped the last finished thing.`;
+  }
+
+  if (inProgress.length) {
+    const item = inProgress[0];
+    const named = recapSoftTitle(item && item.title);
+    if (item && item.owner && named) return `${greet}${named} is already yours.`;
+    if (named) return `${greet}${named} is ready to claim.`;
+  }
+
+  return `${greet}quiet window. nothing moved in this period.`;
+}
+
 function printRecapHelp() {
   console.log(`
-atris recap - what got done, in plain English
+atris recap - what got done, in spoken lines
 
-  atris recap              Last 7 days: done, needs you, still being checked, still working
-  atris recap --days 30    Widen the window
-  atris recap --share      Paste-ready summary for Slack, email, or a customer
-  atris recap --json       Structured output for agents and dashboards
+  atris recap              a few spoken lines: waiting for your ok, still being checked
+  atris recap --verbose    the old report
+  atris recap --days 30    widen the window
+  atris recap --share      paste-ready summary for Slack, email, or a customer
+  atris recap --json       structured output for agents and dashboards
 
-Looks at Atris' saved work and explains it without internal jargon:
-what changed, how it was checked, and what still needs you.
+certified work names atris task accept. uncertified stays still being checked.
+use --verbose or --share for the old report.
 `);
 }
 
@@ -260,7 +326,15 @@ function recapAtris(args = []) {
     console.log(JSON.stringify(data, null, 2));
     return;
   }
-  console.log(args.includes('--share') ? renderShare(data) : renderRecap(data));
+  if (args.includes('--share')) {
+    console.log(renderShare(data));
+    return;
+  }
+  if (args.includes('--verbose') || args.includes('--full')) {
+    console.log(renderRecap(data));
+    return;
+  }
+  console.log(renderRecapMinute(data));
 }
 
-module.exports = { recapAtris, buildRecapData, renderRecap, renderShare };
+module.exports = { recapAtris, buildRecapData, renderRecap, renderRecapMinute, renderShare };

--- a/test/recap.test.js
+++ b/test/recap.test.js
@@ -5,7 +5,8 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
-const { buildRecapData, renderRecap, renderShare } = require('../commands/recap');
+const { spokenLineCount } = require('../lib/first-minute');
+const { buildRecapData, renderRecap, renderRecapMinute, renderShare } = require('../commands/recap');
 
 const repoRoot = path.resolve(__dirname, '..');
 const cliPath = path.join(repoRoot, 'bin', 'atris.js');
@@ -95,6 +96,9 @@ test('buildRecapData reports empty workspace without crashing', () => {
     const data = buildRecapData(dir);
     assert.equal(data.empty, true);
     assert.match(renderRecap(data), /No task history yet/);
+    assert.match(renderRecapMinute(data, { person: 'keshav' }), /hey keshav, no task history yet\./);
+    assert.match(renderRecapMinute(data, { person: 'keshav' }), /^next: atris init --minimal$/m);
+    assert.doesNotMatch(renderRecapMinute(data), /RECAP|Plain English|Share this/);
     assert.match(renderShare(data), /Nothing to share yet/);
   } finally {
     resetDbEnv();
@@ -289,6 +293,12 @@ test('recap treats only certified review as needs you, same as first-minute', ()
     assert.match(out, /UNW-4/);
     assert.doesNotMatch(out, /3 needs you/);
     assert.doesNotMatch(out, /task reviews/);
+    const spoken = renderRecapMinute(data, { person: 'keshav' });
+    assert.match(spoken, /hey keshav, "print a human line like" is waiting for your ok\./);
+    assert.match(spoken, /2 still being checked\./);
+    assert.match(spoken, /^next: atris task accept UNW-2$/m);
+    assert.doesNotMatch(spoken, /RECAP|Plain English|Share this|needs you|NEEDS YOU/);
+    assert.equal(spokenLineCount(spoken), 3);
     const share = renderShare(data);
     assert.match(share, /1 ready for you to approve or send back/);
     assert.match(share, /2 still being checked/);
@@ -317,10 +327,45 @@ test('two-pass review without the certified flag still needs you', () => {
     assert.equal(data.checking.length, 0);
     assert.equal(data.next, 'atris task accept UNW-8');
     assert.match(renderRecap(data), /^ {2}next: atris task accept UNW-8$/m);
+    assert.match(renderRecapMinute(data, { person: 'keshav' }), /^next: atris task accept UNW-8$/m);
+    assert.match(renderRecapMinute(data, { person: 'keshav' }), /"two pass no flag" is waiting for your ok\./);
   } finally {
     resetDbEnv();
     cleanup(dir);
   }
+});
+
+test('renderRecapMinute leads with certified accept and keeps uncertified checking', () => {
+  const text = renderRecapMinute({
+    empty: false,
+    waiting: [{
+      id: 'UNW-2',
+      title: 'Print a human line like 4 words so the count is easy to read.',
+    }],
+    checking: [{ id: 'UNW-3', title: 'Second check still open' }],
+    shipped: [],
+    inProgress: [],
+    next: 'atris task accept UNW-2',
+  }, { person: 'keshav' });
+  assert.match(text, /hey keshav, "print a human line like" is waiting for your ok\./);
+  assert.match(text, /1 still being checked\./);
+  assert.match(text, /^next: atris task accept UNW-2$/m);
+  assert.doesNotMatch(text, /RECAP|Plain English|Share this|needs you|NEEDS YOU/);
+  assert.equal(spokenLineCount(text), 3);
+});
+
+test('renderRecapMinute keeps uncertified work still being checked, not needs-you', () => {
+  const text = renderRecapMinute({
+    empty: false,
+    waiting: [],
+    checking: [{ id: 'UNW-3', title: 'Second check still open' }],
+    shipped: [],
+    inProgress: [],
+    next: null,
+  }, { person: 'keshav' });
+  assert.equal(text, 'hey keshav, "second check still open" is still being checked.');
+  assert.doesNotMatch(text, /waiting for your ok|needs you|atris task accept|RECAP|Share this/);
+  assert.equal(spokenLineCount(text), 1);
 });
 
 test('headless recap on mixed review board names one accept and does not prompt', () => {
@@ -362,13 +407,26 @@ test('headless recap on mixed review board names one accept and does not prompt'
     };
     const recap = runCli(['recap'], { cwd: dir, env });
     assert.equal(recap.status, 0, recap.stderr || recap.stdout);
-    assert.match(recap.stdout, /1 needs you/);
-    assert.match(recap.stdout, /2 still being checked/);
-    assert.match(recap.stdout, /^ {2}next: atris task accept UNW-2$/m);
+    assert.match(recap.stdout, /"print a human line like" is waiting for your ok\./);
+    assert.match(recap.stdout, /2 still being checked\./);
+    assert.match(recap.stdout, /^next: atris task accept UNW-2$/m);
+    assert.doesNotMatch(recap.stdout, /RECAP/);
+    assert.doesNotMatch(recap.stdout, /Plain English/);
+    assert.doesNotMatch(recap.stdout, /Share this/);
+    assert.doesNotMatch(recap.stdout, /needs you/);
     assert.doesNotMatch(recap.stdout, /3 needs you/);
     assert.doesNotMatch(recap.stdout, /task reviews/);
     assert.doesNotMatch(recap.stdout, /\? $/m);
     assert.doesNotMatch(recap.stdout, /What do you want/);
+    assert.ok(spokenLineCount(recap.stdout) >= 2 && spokenLineCount(recap.stdout) <= 4);
+    const verbose = runCli(['recap', '--verbose'], { cwd: dir, env });
+    assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
+    assert.match(verbose.stdout, /RECAP/);
+    assert.match(verbose.stdout, /Plain English: what changed, how it was checked, and what still needs you/);
+    assert.match(verbose.stdout, /Share this: atris recap --share/);
+    assert.match(verbose.stdout, /^ {2}next: atris task accept UNW-2$/m);
+    assert.doesNotMatch(verbose.stdout, /\? $/m);
+    assert.doesNotMatch(verbose.stdout, /What do you want/);
     const json = runCli(['recap', '--json'], { cwd: dir, env });
     assert.equal(json.status, 0, json.stderr || json.stdout);
     const payload = JSON.parse(json.stdout);
@@ -378,5 +436,51 @@ test('headless recap on mixed review board names one accept and does not prompt'
   } finally {
     resetDbEnv();
     cleanup(parent);
+  }
+});
+
+test('headless recap keeps uncertified work still being checked and does not prompt', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-recap-parent-'));
+  const dir = path.join(parent, 'atris-use-now');
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    writeProjection(dir, [{
+      id: 'task-3',
+      display_id: 'UNW-3',
+      title: 'Second check still open',
+      status: 'review',
+      updated_at: 30,
+      review: { agent_review_pass_count: 1 },
+    }]);
+    const env = {
+      HOME: path.join(parent, 'home'),
+      USER: 'keshavrao',
+      ATRIS_TASKS_DB: path.join(dir, 'empty.db'),
+      ATRIS_NO_INTERACTIVE: '1',
+    };
+    const recap = runCli(['recap'], { cwd: dir, env, timeout: 15000 });
+    assert.equal(recap.status, 0, recap.stderr || recap.stdout);
+    assert.match(recap.stdout, /"second check still open" is still being checked\./);
+    assert.doesNotMatch(recap.stdout, /waiting for your ok|needs you|atris task accept|RECAP|Share this/);
+    assert.doesNotMatch(recap.stdout, /\? $/m);
+    assert.doesNotMatch(recap.stdout, /What do you want/);
+    assert.ok(spokenLineCount(recap.stdout) <= 4);
+  } finally {
+    resetDbEnv();
+    cleanup(parent);
+  }
+});
+
+test('recap --help names spoken default and verbose report', () => {
+  const dir = makeTempDir();
+  try {
+    const help = runCli(['recap', '--help'], { cwd: dir });
+    assert.equal(help.status, 0, help.stderr || help.stdout);
+    assert.match(help.stdout, /spoken lines/);
+    assert.match(help.stdout, /--verbose/);
+    assert.match(help.stdout, /old report/);
+    assert.doesNotMatch(help.stdout, /Last 7 days: done, needs you/);
+  } finally {
+    cleanup(dir);
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Default `atris recap` now talks like first-minute and review: a few spoken lines.

Certified work says it is waiting for your ok and names `atris task accept <id>`. Uncertified work stays still being checked. The RECAP header, Plain English manifesto, and share footer are gone from the default.

`--verbose` and `--share` keep the old report. `--json` is unchanged. Headless never prompts.

## Verify

```
node --test test/recap.test.js test/dogfood-p1.test.js
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb7cc778-bd0b-4b0f-8848-e4d7b14067e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb7cc778-bd0b-4b0f-8848-e4d7b14067e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

