### PR TITLE
dogfood: plan leftover words stay a request

### DIFF
--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -448,6 +448,10 @@ async function planAtris(userInput = null) {
   const args = process.argv.slice(3);
   const executeFlag = args.includes('--execute');
   const showFull = args.includes('--full') || args.includes('--verbose');
+  const leftoverRequest = args
+    .filter((token) => !['--execute', '--full', '--verbose'].includes(token))
+    .join(' ')
+    .trim();
 
   const config = loadConfig();
   // Auto-enable local execution mode for "2 fast" / "2 pro" product aliases.
@@ -507,7 +511,8 @@ async function planAtris(userInput = null) {
 
   // Detect uncertainty in inbox context (or direct user input)
   const uncertaintySignals = ['not sure', 'maybe', 'but ', 'thinking about', 'uncertain', 'unclear', 'unsure', 'don\'t know'];
-  const combinedContext = [userInput, inboxContext].filter(Boolean).join('\n');
+  const requestText = String(userInput || leftoverRequest || '').trim();
+  const combinedContext = [requestText, inboxContext].filter(Boolean).join('\n');
   const hasUncertainty = combinedContext && uncertaintySignals.some(signal =>
     combinedContext.toLowerCase().includes(signal)
   );
@@ -550,7 +555,7 @@ async function planAtris(userInput = null) {
   }
   const liveStatus = firstMinute && firstMinute.task && firstMinute.task.status;
   const hasLiveTask = liveStatus === 'claimed' || liveStatus === 'review' || liveStatus === 'open';
-  const showFactory = showFull || Boolean(userInput) || !hasLiveTask;
+  const showFactory = showFull || Boolean(requestText) || !hasLiveTask;
 
   console.log(executionMode === 'prompt' ? 'PROMPT ONLY' : 'ACTION TAKEN');
   console.log('');
@@ -578,10 +583,10 @@ async function planAtris(userInput = null) {
     console.log('');
   }
 
-  if (userInput) {
+  if (requestText) {
     console.log('🎯 DIRECT REQUEST:');
     console.log('─────────────────────────────────────────────────────────────');
-    console.log(userInput);
+    console.log(requestText);
     console.log('');
     console.log('─────────────────────────────────────────────────────────────');
     console.log('');
@@ -653,9 +658,9 @@ async function planAtris(userInput = null) {
     console.log('Note: If `atris/MAP.md` is missing or placeholder, generate it from `atris/atris.md` before writing tasks.');
     console.log('');
   }
-  if (userInput) {
+  if (requestText) {
     console.log('Direct request:');
-    console.log(userInput);
+    console.log(requestText);
     console.log('');
   }
   console.log('Workflow:');
@@ -715,8 +720,8 @@ async function planAtris(userInput = null) {
     let userPrompt = `You are the Navigator. Take ideas from Inbox → break them down into perfect, manageable tasks.\n\n`;
     userPrompt += `⚠️ CRITICAL: You MUST create visualizations BEFORE writing tasks!\n\n`;
 
-    if (userInput) {
-      userPrompt += `## DIRECT REQUEST:\n${userInput}\n\n`;
+    if (requestText) {
+      userPrompt += `## DIRECT REQUEST:\n${requestText}\n\n`;
     }
 
     if (inboxContext) {

--- a/test/confidence-gate.test.js
+++ b/test/confidence-gate.test.js
@@ -46,7 +46,7 @@ test('plan, do, and review prompts include the confidence gate', () => {
     assert.match(plan.stdout, /Run the Confidence Gate before writing tasks/);
     assert.match(plan.stdout, /stale sources, missing owner, weak proof/);
 
-    const doing = runCli(['do'], { cwd: dir });
+    const doing = runCli(['do', '--verbose'], { cwd: dir });
     assert.equal(doing.status, 0, doing.stderr);
     assert.match(doing.stdout, /Run the Confidence Gate against the task before editing/);
     assert.match(doing.stdout, /rerun the gate against proof and residual risk/);

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -26,8 +26,6 @@ const { spawnSync } = require('node:child_process');
 const { spokenLineCount } = require('../lib/first-minute');
 const { renderReviewMinute } = require('../commands/workflow');
 
-const { spokenLineCount } = require('../lib/first-minute');
-
 const repoRoot = path.resolve(__dirname, '..');
 const cliPath = path.join(repoRoot, 'bin', 'atris.js');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the plan lobby-bounce fix.

Bare `atris plan` after a claimed or open task still speaks like first-minute. `atris plan ship a thing` keeps the navigator prompt so a direct request is not swallowed.

Also drops a duplicate import that blocked the workflow tests, and reads the do Confidence Gate from `--verbose` now that default do is first-minute only.

## Verify

```
node --test test/workflow-command.test.js test/confidence-gate.test.js
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08974696-fcd2-4d6a-9d47-d99c58733e6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08974696-fcd2-4d6a-9d47-d99c58733e6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

