### PR TITLE
dogfood: test after init talks like first-minute

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -226,7 +226,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris build user dashboard` → Hot start with feature
 - **Value:** Single command for everything, natural language input
 - **Argument routing:** `bin/atris.js:127-165` strips only recognized controls, preserves the operator sentence, and keeps single-word command typo behavior.
-- **Natural entry:** `bin/atris.js:1045-1074` routes multiword unknown input into the one-lap path; `bin/atris.js:1135-1335` preserves fresh-workspace context gathering and uses one lap only after MAP/context readiness.
+- **Natural entry:** `bin/atris.js:1045-1074` routes multiword unknown input into the one-lap path; `bin/atris.js:1335` `interactiveEntry` keeps a placeholder or missing MAP on first-minute, gathers first-contact only after MAP is real, and uses one lap only after MAP/context readiness.
 - **Coordinator:** `commands/one-lap.js:1-361` resumes matching active wishes, requires one exact task and mission, blocks protected actions, selects a ready executor, requires an allowlisted mission verifier, and renders text or `atris.one_lap.v1` JSON.
 - **Execution gate:** `lib/fleet.js:757-1076` atomically claims the exact task, builds in an isolated worktree, reruns the coordinator-owned verifier without a shell, leaves master unchanged, moves passing work to Review, and writes `atris.dispatch_receipt.v1`.
 - **Proof gate:** `lib/receipt-evidence.js:31-66` treats missing verifier state as non-passing.
@@ -1523,8 +1523,9 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
-- **Entry point:** `bin/atris.js:1344` (`interactiveEntry`)
+- **Entry point:** `bin/atris.js:1335` (`interactiveEntry`)
 - **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`, default `atris task` (`commands/task.js` `cmdFirstMinute`), and the human head of `atris do` (`commands/workflow.js` `doAtris`); empty folders name `atris init --minimal`; `shouldAutoInitFresh` runs `init --minimal` on `--yes`/`-y` even under `ATRIS_NO_INTERACTIVE`, then the post-init screen names the seeded claim; `--json` and headless without `--yes` stay print-only; claimed work names `atris task ready <id>`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
+- **Placeholder MAP:** after init, `bin/atris.js` `interactiveEntry` keeps `atris test` and other requests on first-minute when `MAP.md` is placeholder or missing. The generate-map task is already yours or ready to claim. It does not print `BOOTSTRAP REQUIRED` or ask an agent to rewrite MAP as a wall. Empty folders with no `atris/` can still name init. Headless never prompts. Regression: `test/first-minute.test.js`
 - **Task desk next:** `lib/first-minute.js` (`deskNextCommand`) reuses `pickNext`/`taskCommand` for `commands/task.js` `renderTaskDesk` on `atris task desk` and `atris task --all`; claimed desk copy is `atris task ready <id>`
 - **Task next:** `commands/task.js` (`cmdNextTruth`) reuses `pickNext`/`taskCommand`/`taskNextCommand` so `atris task next` names the same accept/ready/claim/new command as bare atris and the desk; `--create-next` still seeds Endgame fallback
 - **Helper:** `lib/context-gatherer.js`

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -1314,15 +1314,6 @@ function printFirstUseNext() {
   console.log(`Then: ${firstUseCommand()}`);
 }
 
-function printStarterTaskNext(starter) {
-  console.log('next setup: open atris/MAP.md, then claim the starter task.');
-  if (starter && starter.display_id) {
-    console.log(`Next: atris task claim ${starter.display_id} --as ${localOwnerName()}`);
-    return;
-  }
-  console.log('Next: atris task next --as ' + localOwnerName());
-}
-
 function runMinimalInit() {
   const script = process.argv[1] || path.join(__dirname, 'atris.js');
   const result = spawnSync(process.execPath, [script, 'init', '--minimal', '--yes'], {
@@ -1446,6 +1437,29 @@ async function interactiveEntry(userInput, options = {}) {
     return 2;
   }
 
+  // Placeholder or missing MAP is already a first-minute job. Do not send the
+  // operator to a rewrite lobby, and do not treat `test` as a new first task.
+  if (mapStatus !== 'ready') {
+    const screenOptions = {
+      root: workspaceDir,
+      context,
+      missions: activeMissions,
+    };
+    if (options.asJson) {
+      const screen = buildFirstMinute(screenOptions);
+      console.log(JSON.stringify({
+        schema: 'atris.one_lap.v1',
+        ok: false,
+        status: 'stuck',
+        reason: 'the generate-map task is already waiting',
+        next_action: screen.nextCommand,
+      }, null, 2));
+      return 2;
+    }
+    printFirstMinuteScreen(screenOptions);
+    return 0;
+  }
+
   if (userInput && mapStatus === 'ready' && !gatherContext && options.oneLap !== false) {
     return require('../commands/one-lap').runOneLap(userInput, {
       root: workspaceDir,
@@ -1460,8 +1474,8 @@ async function interactiveEntry(userInput, options = {}) {
       schema: 'atris.one_lap.v1',
       ok: false,
       status: 'stuck',
-      reason: mapStatus !== 'ready' ? 'the workspace map is not ready' : 'first-contact context is required',
-      next_action: mapStatus !== 'ready' ? 'atris init --yes' : 'atris "<first direction>"',
+      reason: 'first-contact context is required',
+      next_action: 'atris "<first direction>"',
     }, null, 2));
     return 2;
   }
@@ -1492,10 +1506,6 @@ async function interactiveEntry(userInput, options = {}) {
       } else if (starter && starter.title) {
         console.log(`First task: ${starter.title}`);
       }
-      if (mapStatus !== 'ready') {
-        printStarterTaskNext(starter);
-        return;
-      }
       await planCmd(answer);
       return;
     }
@@ -1523,16 +1533,7 @@ async function interactiveEntry(userInput, options = {}) {
     } else if (starter && starter.title) {
       console.log(`First task: ${starter.title}`);
     }
-    if (mapStatus !== 'ready') {
-      printStarterTaskNext(starter);
-      return;
-    }
     await planCmd(answer);
-    return;
-  }
-
-  if (mapStatus !== 'ready') {
-    printMapBootstrap({ userInput });
     return;
   }
 
@@ -1549,30 +1550,6 @@ async function askContextGatherer(workspaceDir) {
   const answer = await new Promise(r => rl.question('> ', r));
   rl.close();
   return answer;
-}
-
-function printMapBootstrap({ userInput, prefix = 'Bootstrap required' } = {}) {
-  console.log('');
-  console.log('┌─────────────────────────────────────────────────────────────┐');
-  console.log(`│ ${String(prefix).toUpperCase().padEnd(60)}│`);
-  console.log('└─────────────────────────────────────────────────────────────┘');
-  console.log('');
-  console.log('Atris needs a real `atris/MAP.md` so future steps are grounded in the workspace.');
-  console.log('');
-  console.log('For an agent:');
-  console.log('─────────────────────────────────────────────────────────────');
-  console.log('Read `atris/atris.md`, then generate a complete `atris/MAP.md` for this repo.');
-  console.log('Rules: include file:line refs, keep it grep-friendly, do NOT change code.');
-  if (userInput) {
-    console.log('');
-    console.log('After MAP is generated, continue with:');
-    console.log(`- ${userInput}`);
-  } else {
-    console.log('');
-    console.log('Then rerun: atris');
-  }
-  console.log('─────────────────────────────────────────────────────────────');
-  console.log('');
 }
 
 // Boot status: plain rows, honest numbers, one next action.

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -589,7 +589,7 @@ test('default entry auto-advances to plan when inbox has items', () => {
   }
 });
 
-test('default entry gathers first-contact context before MAP bootstrap', () => {
+test('default entry keeps placeholder MAP on first-minute and gathers after MAP is real', () => {
   const dir = makeTempDir();
   try {
     const env = {
@@ -606,14 +606,19 @@ test('default entry gathers first-contact context before MAP bootstrap', () => {
     assert.match(bare.stdout, /^next: atris /m);
     assert.doesNotMatch(bare.stdout, /What do you want to build/);
 
-    // the hot-start path (answer passed as argv) still gathers context
+    // placeholder MAP stays on first-minute. `test` is not a new first task.
+    const verb = runCli(['test'], { cwd: dir, env });
+    assert.equal(verb.status, 0, verb.stderr);
+    assert.match(verb.stdout, /generate map\.md/i);
+    assert.match(verb.stdout, /^next: atris task (claim|ready) /m);
+    assert.doesNotMatch(verb.stdout, /BOOTSTRAP REQUIRED|Got it\. I saved your first direction|First useful step: test|next setup:/);
+
+    // first-contact still gathers once MAP is a real index
+    fs.writeFileSync(path.join(dir, 'atris', 'MAP.md'), '# MAP.md\n\n## By-Feature\n- example: bin/atris.js:1\n', 'utf8');
     const res = runCli(['help me organize college applications'], { cwd: dir, env });
     assert.equal(res.status, 0, res.stderr);
     assert.match(res.stdout, /Got it\. I saved your first direction/);
     assert.match(res.stdout, /First task:/);
-    assert.match(res.stdout, /next setup:/i);
-    assert.match(res.stdout, /next setup/i);
-    assert.match(res.stdout, /MAP\.md/i);
     assert.match(fs.readFileSync(path.join(dir, '.atris', 'state', 'context_profile.json'), 'utf8'), /college applications/);
     assert.match(fs.readFileSync(path.join(dir, 'atris', 'TODO.md'), 'utf8'), /First useful step: help me organize college applications/);
   } finally {

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -35,6 +35,11 @@ function writeAccount(home, account) {
   fs.writeFileSync(path.join(home, '.atris', 'credentials.json'), JSON.stringify(account, null, 2), 'utf8');
 }
 
+function nextLine(stdout) {
+  const match = String(stdout || '').match(/^next: (.+)$/m);
+  return match ? match[1] : '';
+}
+
 function runCli(args, { cwd, env, timeout = 15000 } = {}) {
   const result = spawnSync(process.execPath, [cliPath, ...args], {
     cwd,
@@ -498,6 +503,85 @@ test('workspace with a ready task names the win and points at accept', () => {
     assert.doesNotMatch(res.stdout, /review-chat/);
     assert.doesNotMatch(res.stdout, /What do you want to build/);
     assert.ok(spokenLineCount(res.stdout) <= 6);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('atris test in an empty folder still names init', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  try {
+    const res = runCli(['test'], {
+      cwd: dir,
+      env: { HOME: home, USER: 'keshav', ATRIS_TASKS_DB: path.join(dir, 'tasks.db') },
+    });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /this folder is a clean start/);
+    assert.match(res.stdout, /^next: atris init --minimal$/m);
+    assert.doesNotMatch(res.stdout, /BOOTSTRAP REQUIRED|For an agent|generate a complete `atris\/MAP\.md`/);
+    assert.doesNotMatch(res.stdout, /Got it\. I saved your first direction|First useful step: test/);
+    assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('atris test after init --minimal talks like first-minute, not bootstrap', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  const env = {
+    HOME: home,
+    USER: 'keshav',
+    ATRIS_NO_INTERACTIVE: '1',
+    ATRIS_TASKS_DB: path.join(dir, 'tasks.db'),
+  };
+  try {
+    const init = runCli(['init', '--yes', '--minimal'], { cwd: dir, env, timeout: 60000 });
+    assert.equal(init.status, 0, init.stderr || init.stdout);
+    assert.match(init.stdout, /generate map\.md/i);
+    assert.match(init.stdout, /^next: atris task claim /m);
+
+    const minute = runCli([], { cwd: dir, env });
+    const verb = runCli(['test'], { cwd: dir, env });
+    assert.equal(minute.status, 0, minute.stderr || minute.stdout);
+    assert.equal(verb.status, 0, verb.stderr || verb.stdout);
+    assert.match(verb.stdout, /generate map\.md/i);
+    assert.match(verb.stdout, /ready to claim|already yours/);
+    assert.equal(nextLine(verb.stdout), nextLine(minute.stdout));
+    assert.match(nextLine(verb.stdout), /^atris task (claim|ready) /);
+    assert.equal(verb.stdout.match(/^next:/mg).length, 1);
+    assert.doesNotMatch(verb.stdout, /BOOTSTRAP REQUIRED|For an agent|generate a complete `atris\/MAP\.md`/);
+    assert.doesNotMatch(verb.stdout, /Got it\. I saved your first direction|First useful step: test|next setup: open atris\/MAP\.md/);
+
+    const claim = nextLine(minute.stdout).match(/^atris task claim (\S+) --as (\S+)$/);
+    assert.ok(claim, `expected claim next, got: ${nextLine(minute.stdout)}`);
+    const claimed = runCli(['task', 'claim', claim[1], '--as', claim[2]], { cwd: dir, env });
+    assert.equal(claimed.status, 0, claimed.stderr || claimed.stdout);
+
+    const afterMinute = runCli([], { cwd: dir, env });
+    const afterVerb = runCli(['test'], { cwd: dir, env });
+    assert.equal(afterMinute.status, 0, afterMinute.stderr || afterMinute.stdout);
+    assert.equal(afterVerb.status, 0, afterVerb.stderr || afterVerb.stdout);
+    assert.match(afterVerb.stdout, /already yours/);
+    assert.equal(nextLine(afterVerb.stdout), nextLine(afterMinute.stdout));
+    assert.equal(nextLine(afterVerb.stdout), `atris task ready ${claim[1]}`);
+    assert.doesNotMatch(afterVerb.stdout, /BOOTSTRAP REQUIRED|For an agent|generate a complete `atris\/MAP\.md`/);
+    assert.doesNotMatch(afterVerb.stdout, /Got it\. I saved your first direction|First useful step: test|next setup: open atris\/MAP\.md/);
+
+    fs.rmSync(path.join(dir, 'atris', 'MAP.md'), { force: true });
+    const missing = runCli(['test'], { cwd: dir, env });
+    assert.equal(missing.status, 0, missing.stderr || missing.stdout);
+    assert.equal(nextLine(missing.stdout), `atris task ready ${claim[1]}`);
+    assert.doesNotMatch(missing.stdout, /BOOTSTRAP REQUIRED|For an agent|generate a complete `atris\/MAP\.md`/);
+
+    const json = runCli(['test', '--json'], { cwd: dir, env });
+    assert.equal(json.status, 2, json.stderr || json.stdout);
+    const payload = JSON.parse(json.stdout);
+    assert.equal(payload.next_action, `atris task ready ${claim[1]}`);
+    assert.notEqual(payload.next_action, 'atris init --yes');
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/init-non-interactive.test.js
+++ b/test/init-non-interactive.test.js
@@ -181,17 +181,25 @@ test('force init and update preserve extra members in an existing workspace', ()
   }
 });
 
-test('first-use command after init creates a starter task instead of MAP homework', () => {
+test('first-use command after init talks like first-minute instead of MAP homework', () => {
   const dir = makeTempDir();
   try {
     const init = runInit(['--yes'], { cwd: dir });
     assert.equal(init.status, 0, `stdout:\n${init.stdout}\nstderr:\n${init.stderr}`);
 
+    const minute = runCli([], { cwd: dir });
     const res = runCli(['help me choose the first useful step for this project'], { cwd: dir });
+    assert.equal(minute.status, 0, `stdout:\n${minute.stdout}\nstderr:\n${minute.stderr}`);
     assert.equal(res.status, 0, `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`);
-    assert.match(res.stdout, /First task: [A-Z]+-\d+/);
-    assert.match(res.stdout, /Next: atris task claim [A-Z]+-\d+ --as /);
-    assert.match(res.stdout, /next setup: open atris\/MAP\.md, then claim the starter task\./);
+    assert.match(res.stdout, /generate map\.md/i);
+    assert.match(res.stdout, /ready to claim|already yours/);
+    assert.match(res.stdout, /^next: atris task (claim|ready) /m);
+    assert.equal(
+      (res.stdout.match(/^next: (.+)$/m) || [])[1],
+      (minute.stdout.match(/^next: (.+)$/m) || [])[1]
+    );
+    assert.doesNotMatch(res.stdout, /First useful step: help me choose/);
+    assert.doesNotMatch(res.stdout, /next setup: open atris\/MAP\.md/);
     assert.doesNotMatch(res.stdout, /^Mission: atris mission start/m);
     assert.doesNotMatch(res.stdout, /BOOTSTRAP REQUIRED|generate a complete `atris\/MAP\.md`/);
   } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After `atris init --yes --minimal`, first-minute already names the generate-map job. `atris test` was sending you to a lobby: either a new "first useful step: test" task, or a BOOTSTRAP REQUIRED box asking an agent to rewrite MAP.md.

This keeps `test` on the same first-minute screen. The generate-map task is already yours or ready to claim. One next command.

Empty folders with no atris/ can still say init. Headless never prompts.

Prove:

```
node --test test/first-minute.test.js test/init-non-interactive.test.js
```

That suite passed here (29/29). The change is in `interactiveEntry`: placeholder or missing MAP prints first-minute instead of the bootstrap wall.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e360e68-2255-4a57-8b3e-f5a461df6304?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e360e68-2255-4a57-8b3e-f5a461df6304&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

