### PR TITLE
dogfood: slack refuses from a scratch folder

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -147,7 +147,7 @@ rg "addTask|claimTask|doneTask|appendTaskCompletionLogs|listTasks|workspaceRoot"
 rg "missionBlockerTitle|missionXpTaskTitle|Mission XP" lib/self-drive.js commands/mission.js commands/task.js test/self-drive.test.js test/mission-xp.test.js  # Mission-generated task titles stay short and plain while full context remains in task metadata and dialogue
 rg "codexGoalCommand|completed_task_closed|thread_goals" commands/codex-goal.js commands/mission.js test/codex-goal.test.js test/mission-status.test.js  # Native Codex goal boundary: read-only status, completed-task reset refusal, and scheduled-loop stop
 rg "integrationsStatus|--global|scope: 'workspace'" bin/atris.js commands/integrations.js test/dogfood-p1.test.js # Integrations default workspace; --global for account hosts
-rg "requireAccountBound|refuseAccountGlobal|ACCOUNT_GLOBAL_MESSAGE|isBoundBusinessWorkspace|join --help|friends --help|inbox --help|signup help|avail --help" lib/account-bound.js bin/atris.js commands/social.js commands/signup.js commands/avail.js test/dogfood-pass3-27-28.test.js test/dogfood-p0-safety.test.js test/signup.test.js # Unbound folders refuse account-global inbox/gmail/slack/errors; join/friends/inbox/signup/avail help prints usage and does not hit the network
+rg "requireAccountBound|refuseAccountGlobal|ACCOUNT_GLOBAL_MESSAGE|isBoundBusinessWorkspace|join --help|friends --help|inbox --help|signup help|avail --help" lib/account-bound.js bin/atris.js commands/social.js commands/signup.js commands/avail.js test/dogfood-pass3-27-28.test.js test/dogfood-p0-safety.test.js test/signup.test.js # Unbound folders refuse account-global inbox/gmail/slack/errors; bare atris slack refuses the same way (no send/dm/channels listing); slack --help still prints usage and does not hit the network; join/friends/inbox/signup/avail help prints usage and does not hit the network
 - Help-before-network: `commands/social.js:173` friends, `commands/social.js:391` join, `commands/social.js:571` friendsCommand, `commands/social.js:581` inboxCommand, `commands/signup.js:53` signup help, `commands/avail.js:385` avail help (before the `--` show path). Regression: `test/dogfood-p0-safety.test.js` (`29:` `31:`) and `test/signup.test.js`.
 - Typo-plus-args: `bin/atris.js:1219` `unknownCommandToken` refuses `taks list` / `misson status` without creating a task. Regression: `test/dogfood-p0-safety.test.js` (`30:`).
 - Lone unknown verbs: `bin/atris.js:1219` also refuses `atris build` / `atris fix` (not in `help --json`) so they cannot mint `First useful step: build`. Quoted `atris "<request>"`, multiword `atris build a thing`, `task new`, and `wish` still create work. Regression: `test/dogfood-pass2.test.js` (`14:`) and `test/one-lap-router.test.js`.
@@ -1492,10 +1492,10 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - `atris gmail [inbox|read <id>]` (lines 105-123): Email inbox and message reading
 - `atris calendar [today|week]` (lines 167-184): Calendar events
 - `atris twitter [post <text>]` (lines 232-246): Twitter posting
-- `atris slack [channels]` (lines 282-296): Slack channel listing
+- `atris slack [channels]` (`commands/integrations.js:1078`): Slack channel listing; unbound scratch folders refuse bare `atris slack` via `requireAccountBound` before this runs
 - `atris integrations` (lines 298-338): Show status of all integrations
 - **Auth:** Uses `getAuthToken()` (line 16) from `~/.atris/credentials.json`
-- **Routing:** `bin/atris.js:760-792`
+- **Routing:** `bin/atris.js:2741` (`command === 'slack'`): always `requireAccountBound`; `--help` still prints usage
 - **Help:** `bin/atris.js:884-894` (`showIntegrationsHelp`) and `bin/atris.js:1467-1472` route `integrations --help` before auth/session state or backend status checks
 - **Regression:** `test/commands.test.js:4279-4294` covers integrations help without login errors or `.atris` creation
 - **Value:** Manage external services without leaving the CLI

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -2741,8 +2741,7 @@ if (command === 'init') {
 } else if (command === 'slack') {
   {
     const raw = process.argv.slice(3);
-    const helpOnly = raw.length === 0 || raw.includes('--help') || raw.includes('-h') || raw[0] === 'help';
-    const gate = helpOnly ? { ok: true, args: raw } : requireAccountBound(raw);
+    const gate = requireAccountBound(raw);
     if (!gate.ok) process.exit(refuseAccountGlobal());
     const { slackCommand } = require('../commands/integrations');
     const subcommand = gate.args[0];

--- a/test/dogfood-pass3-27-28.test.js
+++ b/test/dogfood-pass3-27-28.test.js
@@ -58,20 +58,30 @@ test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumpi
     for (const args of [
       ['inbox'],
       ['gmail', 'inbox'],
+      ['slack'],
       ['slack', 'channels'],
+      ['slack', 'dms'],
       ['errors', '--json'],
       ['truth'],
     ]) {
       const result = runCli(args, {
         cwd: dir,
-        env: { HOME: home, ATRIS_HOME: home },
+        env: { HOME: home, ATRIS_HOME: home, ATRIS_NONINTERACTIVE: '1' },
       });
       assert.equal(result.status, 2, `${args.join(' ')} status=${result.status}`);
       const out = `${result.stderr}${result.stdout}`;
       assert.match(out, /account-global; pass --account to continue/);
-      assert.doesNotMatch(out, /web-guardian|dogfood@example|Conversations|Channels|payroll|502/);
+      assert.doesNotMatch(out, /web-guardian|dogfood@example|Conversations|Channels|payroll|502|Slack commands|Fetching Slack/);
       assert.equal(out.includes(ACCOUNT_GLOBAL_MESSAGE), true);
     }
+
+    const slackHelp = runCli(['slack', '--help'], {
+      cwd: dir,
+      env: { HOME: home, ATRIS_HOME: home, ATRIS_NONINTERACTIVE: '1' },
+    });
+    assert.equal(slackHelp.status, 0, slackHelp.stderr + slackHelp.stdout);
+    assert.match(slackHelp.stdout, /Slack commands/);
+    assert.doesNotMatch(`${slackHelp.stderr}${slackHelp.stdout}`, /account-global|Fetching Slack/);
   } finally {
     cleanupTempDir(dir);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bare `atris slack` from an unbound scratch folder (no `.atris/business.json`, no project) printed live send/dm/channels help and exited 0.

Inbox and `gmail inbox` already refuse with `account-global; pass --account` and exit 2. Slack now uses that same lock before it loads Slack code.

What someone can do now:
- From `/tmp` or any unbound folder, `atris slack` prints a short refuse and exits non-zero
- No channel listing, no DMs, no send, no network
- `atris slack --help` still prints usage without calling Slack
- Headless runs never prompt

Verify: `node --test test/dogfood-pass3-27-28.test.js`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cefc6f4-36ad-414b-90c0-b7cb3c078c57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cefc6f4-36ad-414b-90c0-b7cb3c078c57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

