### PR TITLE
dogfood: gmail refuses from a scratch folder

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -147,7 +147,7 @@ rg "addTask|claimTask|doneTask|appendTaskCompletionLogs|listTasks|workspaceRoot"
 rg "missionBlockerTitle|missionXpTaskTitle|Mission XP" lib/self-drive.js commands/mission.js commands/task.js test/self-drive.test.js test/mission-xp.test.js  # Mission-generated task titles stay short and plain while full context remains in task metadata and dialogue
 rg "codexGoalCommand|completed_task_closed|thread_goals" commands/codex-goal.js commands/mission.js test/codex-goal.test.js test/mission-status.test.js  # Native Codex goal boundary: read-only status, completed-task reset refusal, and scheduled-loop stop
 rg "integrationsStatus|--global|scope: 'workspace'" bin/atris.js commands/integrations.js test/dogfood-p1.test.js # Integrations default workspace; --global for account hosts
-rg "requireAccountBound|refuseAccountGlobal|ACCOUNT_GLOBAL_MESSAGE|isBoundBusinessWorkspace|join --help|friends --help|inbox --help|signup help|avail --help" lib/account-bound.js bin/atris.js commands/social.js commands/signup.js commands/avail.js test/dogfood-pass3-27-28.test.js test/dogfood-p0-safety.test.js test/signup.test.js # Unbound folders refuse account-global inbox/gmail/slack/errors; bare atris slack refuses the same way (no send/dm/channels listing); slack --help still prints usage and does not hit the network; join/friends/inbox/signup/avail help prints usage and does not hit the network
+rg "requireAccountBound|refuseAccountGlobal|ACCOUNT_GLOBAL_MESSAGE|isBoundBusinessWorkspace|join --help|friends --help|inbox --help|signup help|avail --help" lib/account-bound.js bin/atris.js commands/social.js commands/signup.js commands/avail.js test/dogfood-pass3-27-28.test.js test/dogfood-p0-safety.test.js test/signup.test.js # Unbound folders refuse account-global inbox/gmail/slack/errors; bare atris slack and atris gmail refuse the same way (no send/dm/channels or inbox/read/archive listing); slack/gmail --help still print usage and do not hit the network; join/friends/inbox/signup/avail help prints usage and does not hit the network
 - Help-before-network: `commands/social.js:173` friends, `commands/social.js:391` join, `commands/social.js:571` friendsCommand, `commands/social.js:581` inboxCommand, `commands/signup.js:53` signup help, `commands/avail.js:385` avail help (before the `--` show path). Regression: `test/dogfood-p0-safety.test.js` (`29:` `31:`) and `test/signup.test.js`.
 - Typo-plus-args: `bin/atris.js:1219` `unknownCommandToken` refuses `taks list` / `misson status` without creating a task. Regression: `test/dogfood-p0-safety.test.js` (`30:`).
 - Lone unknown verbs: `bin/atris.js:1219` also refuses `atris build` / `atris fix` (not in `help --json`) so they cannot mint `First useful step: build`. Quoted `atris "<request>"`, multiword `atris build a thing`, `task new`, and `wish` still create work. Regression: `test/dogfood-pass2.test.js` (`14:`) and `test/one-lap-router.test.js`.
@@ -1489,13 +1489,13 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 - **Entry point:** `commands/integrations.js`
 - **Commands:**
-- `atris gmail [inbox|read <id>]` (lines 105-123): Email inbox and message reading
+- `atris gmail [inbox|read <id>]` (`commands/integrations.js:312`): Email inbox and message reading; unbound scratch folders refuse bare `atris gmail` via `requireAccountBound` before this runs
 - `atris calendar [today|week]` (lines 167-184): Calendar events
 - `atris twitter [post <text>]` (lines 232-246): Twitter posting
 - `atris slack [channels]` (`commands/integrations.js:1078`): Slack channel listing; unbound scratch folders refuse bare `atris slack` via `requireAccountBound` before this runs
 - `atris integrations` (lines 298-338): Show status of all integrations
 - **Auth:** Uses `getAuthToken()` (line 16) from `~/.atris/credentials.json`
-- **Routing:** `bin/atris.js:2741` (`command === 'slack'`): always `requireAccountBound`; `--help` still prints usage
+- **Routing:** `bin/atris.js:2703` (`command === 'gmail'`) and `bin/atris.js:2738` (`command === 'slack'`): always `requireAccountBound`; `--help` still prints usage
 - **Help:** `bin/atris.js:884-894` (`showIntegrationsHelp`) and `bin/atris.js:1467-1472` route `integrations --help` before auth/session state or backend status checks
 - **Regression:** `test/commands.test.js:4279-4294` covers integrations help without login errors or `.atris` creation
 - **Value:** Manage external services without leaving the CLI

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -2703,13 +2703,10 @@ if (command === 'init') {
 } else if (command === 'gmail') {
   {
     const raw = process.argv.slice(3);
-    const helpOnly = raw.length === 0 || raw.includes('--help') || raw.includes('-h') || raw[0] === 'help';
     const { gmailCommand, extractGmailMailboxAccount } = require('../commands/integrations');
     const mailbox = extractGmailMailboxAccount(raw);
-    const gateInput = helpOnly
-      ? mailbox.args
-      : (mailbox.mailboxAccountId ? ['--account', ...mailbox.args] : mailbox.args);
-    const gate = helpOnly ? { ok: true, args: mailbox.args } : requireAccountBound(gateInput);
+    const gateInput = mailbox.mailboxAccountId ? ['--account', ...mailbox.args] : mailbox.args;
+    const gate = requireAccountBound(gateInput);
     if (!gate.ok) process.exit(refuseAccountGlobal());
     const subcommand = gate.args[0];
     const args = gate.args.slice(1);

--- a/test/dogfood-pass3-27-28.test.js
+++ b/test/dogfood-pass3-27-28.test.js
@@ -57,7 +57,13 @@ test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumpi
   try {
     for (const args of [
       ['inbox'],
+      ['gmail'],
       ['gmail', 'inbox'],
+      ['gmail', 'list'],
+      ['gmail', 'read'],
+      ['gmail', 'archive'],
+      ['gmail', 'accounts'],
+      ['gmail', 'use'],
       ['slack'],
       ['slack', 'channels'],
       ['slack', 'dms'],
@@ -66,22 +72,56 @@ test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumpi
     ]) {
       const result = runCli(args, {
         cwd: dir,
-        env: { HOME: home, ATRIS_HOME: home, ATRIS_NONINTERACTIVE: '1' },
+        env: {
+          HOME: home,
+          ATRIS_HOME: home,
+          ATRIS_NONINTERACTIVE: '1',
+          ATRIS_API_URL: 'http://127.0.0.1:1',
+        },
       });
       assert.equal(result.status, 2, `${args.join(' ')} status=${result.status}`);
       const out = `${result.stderr}${result.stdout}`;
       assert.match(out, /account-global; pass --account to continue/);
-      assert.doesNotMatch(out, /web-guardian|dogfood@example|Conversations|Channels|payroll|502|Slack commands|Fetching Slack/);
+      assert.doesNotMatch(out, /web-guardian|dogfood@example|Conversations|Channels|payroll|502|Slack commands|Fetching Slack|Gmail commands|Fetching inbox|Fetching message|Archiving |ECONNREFUSED|api\.atris\.ai/);
       assert.equal(out.includes(ACCOUNT_GLOBAL_MESSAGE), true);
     }
 
+    const helpEnv = {
+      HOME: home,
+      ATRIS_HOME: home,
+      ATRIS_NONINTERACTIVE: '1',
+      ATRIS_API_URL: 'http://127.0.0.1:1',
+    };
     const slackHelp = runCli(['slack', '--help'], {
       cwd: dir,
-      env: { HOME: home, ATRIS_HOME: home, ATRIS_NONINTERACTIVE: '1' },
+      env: helpEnv,
     });
     assert.equal(slackHelp.status, 0, slackHelp.stderr + slackHelp.stdout);
     assert.match(slackHelp.stdout, /Slack commands/);
-    assert.doesNotMatch(`${slackHelp.stderr}${slackHelp.stdout}`, /account-global|Fetching Slack/);
+    assert.doesNotMatch(`${slackHelp.stderr}${slackHelp.stdout}`, /account-global|Fetching Slack|ECONNREFUSED|api\.atris\.ai/);
+
+    const gmailHelp = runCli(['gmail', '--help'], {
+      cwd: dir,
+      env: helpEnv,
+    });
+    assert.equal(gmailHelp.status, 0, gmailHelp.stderr + gmailHelp.stdout);
+    assert.match(gmailHelp.stdout, /Gmail commands/);
+    assert.doesNotMatch(`${gmailHelp.stderr}${gmailHelp.stdout}`, /account-global|Fetching inbox|Fetching message|Archiving |ECONNREFUSED|api\.atris\.ai/);
+
+    const bound = path.join(dir, 'bound');
+    fs.mkdirSync(path.join(bound, '.atris'), { recursive: true });
+    fs.mkdirSync(path.join(bound, 'atris'), { recursive: true });
+    fs.writeFileSync(path.join(bound, '.atris', 'business.json'), JSON.stringify({
+      business_id: 'biz_dogfood',
+      slug: 'dogfood-co',
+    }));
+    const boundGmail = runCli(['gmail'], {
+      cwd: bound,
+      env: helpEnv,
+    });
+    assert.equal(boundGmail.status, 0, boundGmail.stderr + boundGmail.stdout);
+    assert.match(boundGmail.stdout, /Gmail commands/);
+    assert.doesNotMatch(`${boundGmail.stderr}${boundGmail.stdout}`, /account-global|Fetching inbox/);
   } finally {
     cleanupTempDir(dir);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bare `atris gmail` from an unbound scratch folder printed the live inbox/read/archive/accounts/use menu and exited 0. That was the remaining half of the Gmail/Slack scratch leak. Slack already refuses. Gmail did not.

This uses the same account-bound lock as slack and inbox. From a scratch folder:

- `atris gmail` refuses with one sentence and exit 2
- `inbox`, `list`, `read`, `archive`, `accounts`, and `use` refuse the same way
- no Gmail network call
- `--help` still prints usage and does not mutate or network
- a bound workspace can still use gmail as today

There is no `mail` alias to lock.

Verify: `node --test test/dogfood-pass3-27-28.test.js test/gmail-account.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4ecd0ee-732b-4f50-9885-3f658a1af087?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4ecd0ee-732b-4f50-9885-3f658a1af087&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

