### PR TITLE
dogfood: do in an empty folder talks like first-minute

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -45,7 +45,7 @@ rg "askCommand|currentMissionCommand|approveCommand|stopCommand|answerCommand|re
 rg "decideCommand|collectOpenDecisions|normalizeHumanAsk|answerMissionHumanAsk" commands/decide.js commands/mission.js lib/mission-human-asks.js lib/self-drive.js test/decide.test.js  # Mission human-decision bridge: list open asks deterministically, route yes/no through mission pings, persist answered metadata, and ignore answered asks in mission/self-drive reads
 rg "starterMembers|team members ready|firstMissionCommand|packed golden path|printedAtrisArgs|golden path e2e|what someone can do now|--minimal|mapStubFromTree" commands/init.js bin/atris.js commands/task.js test/init-non-interactive.test.js test/golden-path-e2e.test.js test/repo-shape.test.js test/dogfood-papercuts.test.js atris/team/customer-lead atris/GOLDEN_PATH_PAPERCUTS.md  # Quiet first-run output plus packed-install zero-knowledge contract: six-member starter team, init --minimal lean scaffold, ready-on-init mission, autoland, durable papercut status; printedAtrisArgs (test/golden-path-e2e.test.js:112) matches Next/next labels; packed path follows init --minimal, then the printed claim/ready/autoland commands
 rg "function planAtris" commands/workflow.js   # Plan command (line 443): first-minute head when a claimed/open/review task exists; factory banner and navigator paste stay on --verbose/--full or a direct request; missing navigator spec after init --minimal does not send you back to init
-rg "function doAtris" commands/workflow.js     # Do command (line 818): PERSONA head reuses buildFirstMinute; executor paste and file dump stay on --verbose/--full; missing executor spec after init --minimal does not send you back to init
+rg "function doAtris" commands/workflow.js     # Do command (line 823): empty folder reuses buildFirstMinute / freshMinuteJson like bare atris; PERSONA head stays first-minute after init; executor paste stays on --verbose/--full; missing executor spec after init --minimal does not send you back to init
 rg "function reviewAtris|renderReviewMinute" commands/workflow.js test/workflow-command.test.js  # Review command: default first-minute spoken screen (certified -> accept; uncertified still being checked); --json/--all/--limit/--group-by keep the queue; --verbose legacy validator prompt; headless never prompts
 rg "Confidence Gate|confidenceGatePrompt" commands/workflow.js test/confidence-gate.test.js  # Plan/do/review loophole gate prompt + regression
 rg "statusAtris|showStatusHelp|status and analytics --help" bin/atris.js commands/status.js test/commands.test.js # Status command + workspace-free help
@@ -646,7 +646,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris task` with no subcommand reuses `lib/first-minute.js` `buildFirstMinute`, the same two-line next as bare `atris`. The full desk stays on `atris task desk` and `atris task --all`; those still refresh `.atris/state/tasks.projection.json`. Desk `next:` still uses `pickNext`/`taskCommand` so certified review names `atris task accept <id>`, claimed names `atris task ready <id>` with no angle-bracket templates, open names claim, and idle boards name `task next` or `task new`. Regression: `test/task-first-minute.test.js`, `test/task-desk-next.test.js`, `test/first-minute.test.js`
 - `atris task new|next|say|finish` are the natural create/pick/talk/complete loop
 - `atris task next` tells the same truth as bare `atris` and the desk via `pickNext`/`taskCommand`: certified review names `atris task accept <id>` (no invented seed), claimed names `atris task ready <id>` with no templates or `step`, open names `claim` and does not auto-claim, and idle boards name `atris task new`. `--create-next` still materializes the Endgame fallback when asked. Regression: `test/task-next-truth.test.js`, `test/first-minute.test.js`
-- First-minute helpers: `lib/first-minute.js` `pickNext` / `taskCommand` / `deskNextCommand` / `taskNextCommand`; desk points idle history at `task next`, and `task next` itself names `task new` when nothing is active
+- First-minute helpers: `lib/first-minute.js` `pickNext` / `taskCommand` / `deskNextCommand` / `taskNextCommand` / `freshMinuteJson`; desk points idle history at `task next`, and `task next` itself names `task new` when nothing is active
 - `atris task delegate "<title>" --to <owner>` creates assigned work without hand-editing TODO.md
 - `atris task delegate "<title>" --to <owner> --via swarlo` prepares a live Swarlo handoff while keeping the task DB canonical
 - `atris task day` shows eight globally ranked active rows with exact hidden task/owner counts; `--full` restores the uncapped owner-grouped text view and `--json` remains complete for headless coordinators
@@ -1195,10 +1195,11 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 2. **`atris do`** - Executor mode
 
-- Entry: `commands/workflow.js:818-1186` (doAtris function)
-- Human head: `lib/first-minute.js` `buildFirstMinute` (same win + next as bare `atris`); never prints `Context: UNKNOWN` or `Backlog tasks: 0` when a claimed/review/open task exists
+- Entry: `commands/workflow.js:823-1197` (doAtris function)
+- Empty folder: `lib/first-minute.js` `buildFirstMinute({ fresh: true })` and `freshMinuteJson` (same two spoken lines and `--json` next as bare `atris`). No `executor.md` bounce.
+- Human head after init: `buildFirstMinute` (same win + next as bare `atris`); never prints `Context: UNKNOWN` or `Backlog tasks: 0` when a claimed/review/open task exists
 - Default stays PROMPT ONLY plus the first-minute two lines; `--verbose`/`--full` prints the executor paste and file dump
-- Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do after init --yes --minimal does not send you back to init`, `do names a claimed task the same way first-minute does`)
+- Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do in an uninitialized folder talks like first-minute`, `do after init --yes --minimal does not send you back to init`, `do names a claimed task the same way first-minute does`), `test/first-minute.test.js` (`atris do in an empty folder talks like first-minute`)
 
 3. **`atris review`** - Human checkpoint, first-minute voice
 
@@ -1526,14 +1527,14 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Purpose:** First `atris` contact asks for human context before planning or agent bootstrap, then persists the answer and creates a starter onboarding task.
 
 - **Entry point:** `bin/atris.js:1335` (`interactiveEntry`)
-- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`) prints one win and one next command for bare `atris`, default `atris task` (`commands/task.js` `cmdFirstMinute`), and the human head of `atris do` (`commands/workflow.js` `doAtris`); empty folders name `atris init --minimal`; `shouldAutoInitFresh` runs `init --minimal` on `--yes`/`-y` even under `ATRIS_NO_INTERACTIVE`, then the post-init screen names the seeded claim; `--json` and headless without `--yes` stay print-only; claimed work names `atris task ready <id>`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
+- **First-minute screen:** `lib/first-minute.js` (`buildFirstMinute`, `freshMinuteJson`) prints one win and one next command for bare `atris`, default `atris task` (`commands/task.js` `cmdFirstMinute`), and `atris do` (`commands/workflow.js` `doAtris`); empty folders, including `atris do` and `atris do --json`, name `atris init --minimal` (JSON adds `--yes`); `shouldAutoInitFresh` runs `init --minimal` on `--yes`/`-y` even under `ATRIS_NO_INTERACTIVE`, then the post-init screen names the seeded claim; `--json` and headless without `--yes` stay print-only; claimed work names `atris task ready <id>`; certified review names `atris task accept <id>`; throwaway names (`tmp`, `temp`, `atris-*`, hashes) stay "this folder"; a real basename like `launch-day` stays even under `/tmp`; person name prefers the saved account first name
 - **Placeholder MAP:** after init, `bin/atris.js` `interactiveEntry` keeps `atris test` and other requests on first-minute when `MAP.md` is placeholder or missing. The generate-map task is already yours or ready to claim. It does not print `BOOTSTRAP REQUIRED` or ask an agent to rewrite MAP as a wall. Empty folders with no `atris/` can still name init. Headless never prompts. Regression: `test/first-minute.test.js`
 - **Task desk next:** `lib/first-minute.js` (`deskNextCommand`) reuses `pickNext`/`taskCommand` for `commands/task.js` `renderTaskDesk` on `atris task desk` and `atris task --all`; claimed desk copy is `atris task ready <id>`
 - **Task next:** `commands/task.js` (`cmdNextTruth`) reuses `pickNext`/`taskCommand`/`taskNextCommand` so `atris task next` names the same accept/ready/claim/new command as bare atris and the desk; `--create-next` still seeds Endgame fallback
 - **Helper:** `lib/context-gatherer.js`
 - **State:** `.atris/state/context_profile.json`
 - **Regression:** `test/first-minute.test.js`, `test/task-first-minute.test.js`, `test/task-desk-next.test.js`, `test/task-next-truth.test.js`, `test/context-gatherer.test.js`, `test/cli-smoke.test.js`, `test/workflow-command.test.js`
-- **Search:** `rg "shouldGatherContext|saveContextProfile|createStarterTask|buildFirstMinute|cmdFirstMinute|deskNextCommand|taskNextCommand|cmdNextTruth|Context gatherer" bin/atris.js lib/context-gatherer.js lib/first-minute.js commands/task.js commands/workflow.js test
+- **Search:** `rg "shouldGatherContext|saveContextProfile|createStarterTask|buildFirstMinute|freshMinuteJson|cmdFirstMinute|deskNextCommand|taskNextCommand|cmdNextTruth|Context gatherer" bin/atris.js lib/context-gatherer.js lib/first-minute.js commands/task.js commands/workflow.js test
 
 ---
 
@@ -1824,7 +1825,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 **Modular commands (in commands/):**
 
 - `planAtris()` → `commands/workflow.js:443-788`
-- `doAtris()` → `commands/workflow.js:790-1158`
+- `doAtris()` → `commands/workflow.js:823-1197`
 - `reviewAtris()` / `renderReviewMinute()` → `commands/workflow.js` (default first-minute screen; --verbose validator prompt)
 - `statusAtris()` → `commands/status.js:124-384`
 - `analyticsAtris()` → `commands/analytics.js:4-147`

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -60,6 +60,7 @@ const {
 } = require('../lib/context-gatherer');
 const {
   buildFirstMinute,
+  freshMinuteJson,
   isBareAtrisFlag,
   shouldAutoInitFresh,
 } = require('../lib/first-minute');
@@ -1338,13 +1339,7 @@ async function interactiveEntry(userInput, options = {}) {
   // Fresh folder is the first-minute product: one next command, no menu.
   if (state.state === 'fresh') {
     if (options.asJson) {
-      console.log(JSON.stringify({
-        schema: 'atris.one_lap.v1',
-        ok: false,
-        status: 'stuck',
-        reason: 'this workspace is not initialized',
-        next_action: 'atris init --minimal --yes',
-      }, null, 2));
+      console.log(JSON.stringify(freshMinuteJson(), null, 2));
       return 2;
     }
     if (shouldAutoInitFresh(process.argv.slice(2))) {

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { getLogPath } = require('../lib/journal');
-const { buildFirstMinute, isCertifiedReview, personName, pickNext, taskCommand } = require('../lib/first-minute');
+const { buildFirstMinute, freshMinuteJson, isCertifiedReview, personName, pickNext, taskCommand } = require('../lib/first-minute');
 const { isNonInteractive } = require('../lib/noninteractive');
 const { buildToolResultBody } = require('../lib/tool-result-encode');
 
@@ -834,19 +834,25 @@ async function doAtris() {
 
   const cwd = process.cwd();
   const targetDir = path.join(cwd, 'atris');
+
+  // Empty folder talks like bare atris. Missing executor.md after
+  // init --minimal is optional context, not a factory bounce.
+  if (!fs.existsSync(targetDir)) {
+    if (args.includes('--json')) {
+      console.log(JSON.stringify(freshMinuteJson(), null, 2));
+      process.exit(2);
+    }
+    const screen = buildFirstMinute({ root: cwd, fresh: true });
+    console.log('');
+    console.log(screen.text);
+    return;
+  }
+
   const memberExecutor = path.join(targetDir, 'team', 'executor', 'MEMBER.md');
   const legacyExecutor = path.join(targetDir, 'team', 'executor.md');
   const executorFile = fs.existsSync(memberExecutor)
     ? memberExecutor
     : (fs.existsSync(legacyExecutor) ? legacyExecutor : null);
-
-  // Prompt-mode do only needs an initialized workspace. The executor spec is
-  // optional context, same as PERSONA.md. A missing spec after init --minimal
-  // must not send the operator back to init.
-  if (!executorFile && !fs.existsSync(targetDir)) {
-    console.log('✗ executor.md not found. Run "atris init" first.');
-    process.exit(1);
-  }
 
   // Load project profile for context
   let context = 'ROOT';

--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -260,6 +260,16 @@ function renderFresh({ person = '', folder = 'this folder' } = {}) {
   ].join('\n');
 }
 
+function freshMinuteJson() {
+  return {
+    schema: 'atris.one_lap.v1',
+    ok: false,
+    status: 'stuck',
+    reason: 'this workspace is not initialized',
+    next_action: `${INIT_COMMAND} --yes`,
+  };
+}
+
 function renderWorkspace({
   person = '',
   folder = 'this folder',
@@ -356,6 +366,7 @@ module.exports = {
   buildFirstMinute,
   deskNextCommand,
   folderName,
+  freshMinuteJson,
   isBareAtrisFlag,
   isCertifiedReview,
   personName,

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -9,6 +9,7 @@ const {
   buildFirstMinute,
   deskNextCommand,
   folderName,
+  freshMinuteJson,
   personName,
   pickNext,
   renderFresh,
@@ -77,6 +78,9 @@ test('fresh first-minute copy names init and stays short', () => {
   assert.match(text, /^next: atris init --minimal$/m);
   assert.equal(spokenLineCount(text), 2);
   assert.ok(text.length < 200);
+  const json = freshMinuteJson();
+  assert.equal(json.next_action, 'atris init --minimal --yes');
+  assert.equal(json.reason, 'this workspace is not initialized');
 });
 
 test('claimed task first-minute names the person or title and one next command', () => {
@@ -522,6 +526,27 @@ test('atris test in an empty folder still names init', () => {
     assert.match(res.stdout, /^next: atris init --minimal$/m);
     assert.doesNotMatch(res.stdout, /BOOTSTRAP REQUIRED|For an agent|generate a complete `atris\/MAP\.md`/);
     assert.doesNotMatch(res.stdout, /Got it\. I saved your first direction|First useful step: test/);
+    assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('atris do in an empty folder talks like first-minute', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  const env = { HOME: home, USER: 'keshav', ATRIS_TASKS_DB: path.join(dir, 'tasks.db') };
+  try {
+    const minute = runCli([], { cwd: dir, env });
+    const doit = runCli(['do'], { cwd: dir, env });
+    assert.equal(minute.status, 0, minute.stderr || minute.stdout);
+    assert.equal(doit.status, 0, doit.stderr || doit.stdout);
+    assert.equal(doit.stdout.trim(), minute.stdout.trim());
+    assert.match(doit.stdout, /this folder is a clean start/);
+    assert.match(doit.stdout, /^next: atris init --minimal$/m);
+    assert.equal(spokenLineCount(doit.stdout), spokenLineCount(minute.stdout));
+    assert.doesNotMatch(doit.stdout, /executor\.md|Run "atris init"/);
     assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
   } finally {
     cleanupTempDir(dir);

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -133,14 +133,35 @@ test('plan in an uninitialized directory gives a plain error, not a stack trace'
   assert.ok(!/at .*workflow\.js:\d+/.test(combined), `stack trace leaked:\n${combined}`);
 });
 
-test('do in an uninitialized directory gives a plain error, not a stack trace', () => {
+test('do in an uninitialized folder talks like first-minute', () => {
   const dir = makeTempDir();
-  const res = runCli(['do'], { cwd: dir });
-  assert.equal(res.status, 1);
-  assert.match(res.stdout, /executor\.md not found/);
-  assert.match(res.stdout, /atris init/);
-  const combined = res.stdout + res.stderr;
+  const env = isolatedDoEnv(dir);
+  const minute = runCli([], { cwd: dir, env });
+  const doit = runCli(['do'], { cwd: dir, env });
+  assert.equal(minute.status, 0, minute.stderr || minute.stdout);
+  assert.equal(doit.status, 0, doit.stderr || doit.stdout);
+  assert.match(doit.stdout, /this folder is a clean start/);
+  assert.match(doit.stdout, /^next: atris init --minimal$/m);
+  assert.equal(nextLine(doit.stdout), nextLine(minute.stdout));
+  assert.equal(doit.stdout.trim(), minute.stdout.trim());
+  assert.equal(spokenLineCount(spokenDoBody(doit.stdout)), 2);
+  assert.doesNotMatch(doit.stdout, /executor\.md|Run "atris init"/);
+  assert.doesNotMatch(doit.stdout, /PROMPT ONLY|Atris Do|What do you want to build/);
+  const combined = doit.stdout + doit.stderr;
   assert.ok(!/at .*workflow\.js:\d+/.test(combined), `stack trace leaked:\n${combined}`);
+  assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+
+  const jsonMinute = runCli(['--json'], { cwd: dir, env });
+  const jsonDo = runCli(['do', '--json'], { cwd: dir, env });
+  assert.equal(jsonDo.status, jsonMinute.status);
+  assert.deepEqual(JSON.parse(jsonDo.stdout), JSON.parse(jsonMinute.stdout));
+  assert.doesNotMatch(jsonDo.stdout, /executor\.md/);
+
+  const help = runCli(['do', '--help'], { cwd: dir, env });
+  assert.equal(help.status, 0, help.stderr || help.stdout);
+  assert.match(help.stdout, /Usage: atris do/);
+  assert.doesNotMatch(help.stdout, /clean start|executor\.md/);
+  assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
 });
 
 test('plan after init --yes --minimal does not send you back to init', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
In an uninitialized folder, `atris do` now talks like bare `atris`. Same two spoken lines. Same next command: `atris init --minimal`.

It no longer names a missing factory file or says run init first.

`atris do --json` matches bare `atris --json`. `--help` stays usage and does not write files.

After `atris init --minimal`, `atris do` still stays in the room. It keeps the first-minute head and does not bounce back to init.

Verify:

```
node --test test/workflow-command.test.js test/first-minute.test.js
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc536956-4a02-4e06-bf9d-028dcd538346?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc536956-4a02-4e06-bf9d-028dcd538346&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

