### PR TITLE
feat(cli): atris gmail connect, one command to link an account

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1492,6 +1492,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 - **Entry point:** `commands/integrations.js`
 - **Commands:**
+- `atris gmail connect [name]` (`commands/integrations.js:269`): starts browser auth and polls for the named account; dispatch near `commands/integrations.js:400`
 - `atris gmail [inbox|read <id>]` (`commands/integrations.js:312`): Email inbox and message reading; unbound scratch folders refuse bare `atris gmail` via `requireAccountBound` before this runs
 - `atris calendar [today|week]` (lines 167-184): Calendar events
 - `atris twitter [post <text>]` (lines 232-246): Twitter posting
@@ -1500,10 +1501,11 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - **Auth:** Uses `getAuthToken()` (line 16) from `~/.atris/credentials.json`
 - **Routing:** `bin/atris.js:2703` (`command === 'gmail'`) and `bin/atris.js:2738` (`command === 'slack'`): always `requireAccountBound`; `--help` still prints usage
 - **Help:** `bin/atris.js:884-894` (`showIntegrationsHelp`) and `bin/atris.js:1467-1472` route `integrations --help` before auth/session state or backend status checks
+- **Gmail connect regression:** `test/gmail-account.test.js:99` (name validation), `test/gmail-account.test.js:129` (poll success), `test/gmail-account.test.js:182` (timeout)
 - **Regression:** `test/commands.test.js:4279-4294` covers integrations help without login errors or `.atris` creation
 - **Value:** Manage external services without leaving the CLI
 
-**Search:** `rg "gmailCommand|calendarCommand|twitterCommand|slackCommand|integrationsStatus|showIntegrationsHelp|integrations --help|--approved|requireAccountBound" bin/atris.js commands/integrations.js lib/account-bound.js test/commands.test.js test/dogfood-pass3-27-28.test.js`
+**Search:** `rg "gmailConnect|gmailCommand|calendarCommand|twitterCommand|slackCommand|integrationsStatus|showIntegrationsHelp|integrations --help|--approved|requireAccountBound" bin/atris.js commands/integrations.js lib/account-bound.js test/gmail-account.test.js test/commands.test.js test/dogfood-pass3-27-28.test.js`
 
 ### Feature: State Detection
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -727,7 +727,7 @@ function showHelpAll() {
   console.log('  supabase  - supabase cli wrapper (doctor, auth, status/db/functions)');
   console.log('  linear    - linear cli wrapper (doctor, auth, issue list/create/view/update)');
   console.log('  stripe    - stripe cli wrapper (doctor, auth, listen/trigger/products)');
-  console.log('  gmail      - Email commands (inbox, read, archive, accounts, use)');
+  console.log('  gmail      - email commands (connect, inbox, read, archive, accounts, use)');
   console.log('  calendar   - Calendar commands (today, week)');
   console.log('  twitter    - Twitter commands (post)');
   console.log('  slack      - Slack commands (channels)');

--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -5,6 +5,7 @@
  *   atris gmail inbox [--account <id>]       - List recent emails
  *   atris gmail read <id> [--account <id>]   - Read specific email
  *   atris gmail archive <id> [...] [--account <id>] - Archive messages
+ *   atris gmail connect [name]              - Connect or reconnect a Gmail account
  *   atris gmail accounts                     - List connected Gmail accounts
  *   atris gmail use [<account_id>]           - Set or show sticky Gmail account
  *   atris calendar today    - Show today's events
@@ -31,6 +32,8 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const CALENDAR_CACHE_PATH = path.join(os.homedir(), '.atris', 'calendar-events-cache.json');
+const GMAIL_CONNECT_POLL_MS = 3000;
+const GMAIL_CONNECT_TIMEOUT_MS = 3 * 60 * 1000;
 
 function gmailAccountStatePath() {
   return process.env.ATRIS_GMAIL_ACCOUNT_FILE
@@ -255,6 +258,73 @@ async function gmailArchive(messageIds, options = {}) {
   console.log(`Archived ${archived} message${archived === 1 ? '' : 's'}. They stay searchable in All Mail.`);
 }
 
+function openGmailAuthUrl(authUrl, deps = {}) {
+  const run = deps.spawnSync || spawnSync;
+  const platform = deps.platform || process.platform;
+  const command = platform === 'darwin' ? 'open' : 'xdg-open';
+  const opened = run(command, [authUrl], { stdio: 'ignore' });
+  return !opened.error && opened.status === 0;
+}
+
+async function gmailConnect(accountName, deps = {}) {
+  const accountId = String(accountName || 'default').trim();
+  if (!/^[a-z0-9-]{1,32}$/.test(accountId)) {
+    console.error('invalid gmail account name. use 1 to 32 lowercase letters, numbers, or hyphens.');
+    process.exit(1);
+  }
+
+  const token = await getAuthToken();
+  const result = await apiRequestJson('/integrations/gmail/start', {
+    method: 'POST',
+    token,
+    body: { account_id: accountId },
+  });
+
+  if (!result.ok) {
+    const detail = String(result.error || 'request failed').toLowerCase();
+    console.error(`could not start gmail connection: ${detail}`);
+    process.exit(1);
+  }
+
+  const authUrl = String(result.data?.auth_url || result.data?.url || '').trim();
+  if (!authUrl) {
+    console.error('could not start gmail connection: the server did not return an auth url.');
+    process.exit(1);
+  }
+
+  const openAuthUrl = deps.openAuthUrl || openGmailAuthUrl;
+  if (!openAuthUrl(authUrl, deps)) {
+    console.log(`open this url in your browser: ${authUrl}`);
+  }
+
+  console.log(`waiting for gmail account ${accountId}...`);
+
+  const pollIntervalMs = deps.pollIntervalMs ?? GMAIL_CONNECT_POLL_MS;
+  const timeoutMs = deps.timeoutMs ?? GMAIL_CONNECT_TIMEOUT_MS;
+  const sleep = deps.sleep || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  const maxPolls = Math.max(1, Math.ceil(timeoutMs / pollIntervalMs));
+
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    await sleep(pollIntervalMs);
+    const accountsResult = await apiRequestJson('/integrations/gmail/accounts', {
+      method: 'GET',
+      token,
+    });
+    const accounts = accountsResult.ok
+      ? (accountsResult.data?.accounts || accountsResult.data || [])
+      : [];
+    const match = Array.isArray(accounts) ? findGmailAccount(accounts, accountId) : null;
+    const email = match ? gmailAccountIdentity(match).email.trim() : '';
+    if (email && email !== 'unknown') {
+      console.log(`connected ${email} as ${accountId}`);
+      return;
+    }
+  }
+
+  console.error(`connection timed out. finish in your browser: ${authUrl}`);
+  process.exit(1);
+}
+
 async function gmailAccounts() {
   const token = await getAuthToken();
   const accounts = await fetchGmailAccounts(token);
@@ -327,6 +397,9 @@ async function gmailCommand(subcommand, ...args) {
       await gmailArchive(parsed.positional, { accountId: parsed.accountId || undefined });
       break;
     }
+    case 'connect':
+      await gmailConnect(args[0]);
+      break;
     case 'accounts':
       await gmailAccounts();
       break;
@@ -334,12 +407,13 @@ async function gmailCommand(subcommand, ...args) {
       await gmailUse(args[0]);
       break;
     default:
-      console.log('Gmail commands:');
-      console.log('  atris gmail inbox [--account <id>]       - List recent emails');
-      console.log('  atris gmail read <id> [--account <id>]   - Read specific email');
-      console.log('  atris gmail archive <id> [...] [--account <id>] - Archive messages (reversible, All Mail keeps them)');
-      console.log('  atris gmail accounts                     - List connected Gmail accounts');
-      console.log('  atris gmail use [<account_id>]           - Set or show sticky Gmail account');
+      console.log('gmail commands:');
+      console.log('  atris gmail inbox [--account <id>]       - list recent emails');
+      console.log('  atris gmail read <id> [--account <id>]   - read specific email');
+      console.log('  atris gmail archive <id> [...] [--account <id>] - archive messages (reversible, all mail keeps them)');
+      console.log('  atris gmail connect [name]               - connect or reconnect a gmail account');
+      console.log('  atris gmail accounts                     - list connected gmail accounts');
+      console.log('  atris gmail use [<account_id>]           - set or show sticky gmail account');
   }
 }
 
@@ -1848,6 +1922,7 @@ async function integrationsStatus(args = []) {
 
 module.exports = {
   gmailCommand,
+  gmailConnect,
   extractGmailMailboxAccount,
   parseGmailArgs,
   gmailAccountStatePath,

--- a/test/gmail-account.test.js
+++ b/test/gmail-account.test.js
@@ -96,6 +96,133 @@ test('parseGmailArgs splits account flag from positional ids', () => {
   });
 });
 
+test('gmail connect rejects invalid names before any network call', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    return { ok: true, status: 200, data: {} };
+  });
+  const errors = [];
+  const originalError = console.error;
+  const originalExit = process.exit;
+  console.error = (line) => errors.push(String(line));
+  process.exit = (code) => {
+    throw new Error(`exit:${code}`);
+  };
+  try {
+    await assert.rejects(
+      () => integrations.gmailCommand('connect', 'Bad Name'),
+      /exit:1/,
+    );
+  } finally {
+    console.error = originalError;
+    process.exit = originalExit;
+    restore();
+  }
+
+  assert.deepEqual(calls, []);
+  assert.deepEqual(errors, [
+    'invalid gmail account name. use 1 to 32 lowercase letters, numbers, or hyphens.',
+  ]);
+});
+
+test('gmail connect polls until the named account has an email address', async () => {
+  const calls = [];
+  let accountPolls = 0;
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    if (pathname === '/integrations/gmail/start') {
+      return { ok: true, status: 200, data: { url: 'https://accounts.example.test/connect' } };
+    }
+    accountPolls += 1;
+    return {
+      ok: true,
+      status: 200,
+      data: {
+        accounts: accountPolls === 1
+          ? [{ account_id: 'research', email_address: '' }]
+          : [{ account_id: 'research', email_address: 'Research@Example.com' }],
+      },
+    };
+  });
+  const lines = [];
+  const sleeps = [];
+  const opened = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await integrations.gmailConnect('research', {
+      openAuthUrl: (url) => { opened.push(url); return true; },
+      sleep: async (milliseconds) => { sleeps.push(milliseconds); },
+      pollIntervalMs: 3,
+      timeoutMs: 9,
+    });
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.deepEqual(opened, ['https://accounts.example.test/connect']);
+  assert.deepEqual(sleeps, [3, 3]);
+  assert.deepEqual(lines, [
+    'waiting for gmail account research...',
+    'connected research@example.com as research',
+  ]);
+  assert.deepEqual(calls[0], {
+    pathname: '/integrations/gmail/start',
+    options: {
+      method: 'POST',
+      token: 'test-token',
+      body: { account_id: 'research' },
+    },
+  });
+  assert.equal(calls.filter((call) => call.pathname === '/integrations/gmail/accounts').length, 2);
+});
+
+test('gmail connect times out with a nonzero exit and browser instructions', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(async (pathname, options) => {
+    calls.push({ pathname, options });
+    if (pathname === '/integrations/gmail/start') {
+      return { ok: true, status: 200, data: { auth_url: 'https://accounts.example.test/finish' } };
+    }
+    return { ok: true, status: 200, data: { accounts: [] } };
+  });
+  const lines = [];
+  const errors = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  console.log = (line) => lines.push(String(line));
+  console.error = (line) => errors.push(String(line));
+  process.exit = (code) => {
+    throw new Error(`exit:${code}`);
+  };
+  try {
+    await assert.rejects(
+      () => integrations.gmailConnect(undefined, {
+        openAuthUrl: () => true,
+        sleep: async () => {},
+        pollIntervalMs: 3,
+        timeoutMs: 6,
+      }),
+      /exit:1/,
+    );
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+    restore();
+  }
+
+  assert.deepEqual(lines, ['waiting for gmail account default...']);
+  assert.deepEqual(errors, [
+    'connection timed out. finish in your browser: https://accounts.example.test/finish',
+  ]);
+  assert.equal(calls[0].options.body.account_id, 'default');
+  assert.equal(calls.filter((call) => call.pathname === '/integrations/gmail/accounts').length, 2);
+});
+
 test('gmailAccountStatePath honors ATRIS_GMAIL_ACCOUNT_FILE', () => {
   const previous = process.env.ATRIS_GMAIL_ACCOUNT_FILE;
   process.env.ATRIS_GMAIL_ACCOUNT_FILE = '/tmp/custom-gmail-account.json';


### PR DESCRIPTION
atris gmail connect [name] starts the Google sign-in in the browser and polls until the account shows up connected, then prints the email. Validates names, times out with a plain hint, zero new dependencies.

Verified: gmail-account tests 16/16 exit 0 after rebase; cli smoke exit 0. Full suite carries 14 pre-existing baseline failures unrelated to this change (known chronic set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)