### PR TITLE
dogfood: gmail connect refuses from a scratch folder

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -150,7 +150,7 @@ rg "addTask|claimTask|doneTask|appendTaskCompletionLogs|listTasks|workspaceRoot|
 rg "missionBlockerTitle|missionXpTaskTitle|Mission XP" lib/self-drive.js commands/mission.js commands/task.js test/self-drive.test.js test/mission-xp.test.js  # Mission-generated task titles stay short and plain while full context remains in task metadata and dialogue
 rg "codexGoalCommand|completed_task_closed|thread_goals" commands/codex-goal.js commands/mission.js test/codex-goal.test.js test/mission-status.test.js  # Native Codex goal boundary: read-only status, completed-task reset refusal, and scheduled-loop stop
 rg "integrationsStatus|--global|scope: 'workspace'" bin/atris.js commands/integrations.js test/dogfood-p1.test.js # Integrations default workspace; --global for account hosts
-rg "requireAccountBound|refuseAccountGlobal|ACCOUNT_GLOBAL_MESSAGE|isBoundBusinessWorkspace|join --help|friends --help|inbox --help|signup help|avail --help" lib/account-bound.js bin/atris.js commands/social.js commands/signup.js commands/avail.js test/dogfood-pass3-27-28.test.js test/dogfood-p0-safety.test.js test/signup.test.js # Unbound folders refuse account-global inbox/gmail/slack/errors; bare atris slack and atris gmail refuse the same way (no send/dm/channels or inbox/read/archive listing); slack/gmail --help still print usage and do not hit the network; join/friends/inbox/signup/avail help prints usage and does not hit the network
+rg "requireAccountBound|refuseAccountGlobal|ACCOUNT_GLOBAL_MESSAGE|isBoundBusinessWorkspace|join --help|friends --help|inbox --help|signup help|avail --help" lib/account-bound.js bin/atris.js commands/social.js commands/signup.js commands/avail.js test/dogfood-pass3-27-28.test.js test/dogfood-p0-safety.test.js test/signup.test.js # Unbound folders refuse account-global inbox/gmail/slack/errors; bare atris slack and atris gmail (including gmail connect) refuse the same way (no send/dm/channels, inbox/read/archive listing, or OAuth/link flow); slack/gmail --help still print usage and do not hit the network; join/friends/inbox/signup/avail help prints usage and does not hit the network
 - Help-before-network: `commands/social.js:173` friends, `commands/social.js:391` join, `commands/social.js:571` friendsCommand, `commands/social.js:581` inboxCommand, `commands/signup.js:53` signup help, `commands/avail.js:385` avail help (before the `--` show path). Regression: `test/dogfood-p0-safety.test.js` (`29:` `31:`) and `test/signup.test.js`.
 - Typo-plus-args: `bin/atris.js:1219` `unknownCommandToken` refuses `taks list` / `misson status` without creating a task. Regression: `test/dogfood-p0-safety.test.js` (`30:`).
 - Lone unknown verbs: `bin/atris.js:1219` also refuses `atris build` / `atris fix` (not in `help --json`) so they cannot mint `First useful step: build`. Quoted `atris "<request>"`, multiword `atris build a thing`, `task new`, and `wish` still create work. Regression: `test/dogfood-pass2.test.js` (`14:`) and `test/one-lap-router.test.js`.
@@ -1495,16 +1495,16 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 - **Entry point:** `commands/integrations.js`
 - **Commands:**
-- `atris gmail connect [name]` (`commands/integrations.js:269`): starts browser auth and polls for the named account; dispatch near `commands/integrations.js:400`
-- `atris gmail [inbox|read <id>]` (`commands/integrations.js:312`): Email inbox and message reading; unbound scratch folders refuse bare `atris gmail` via `requireAccountBound` before this runs
+- `atris gmail connect [name]` (`commands/integrations.js:269`): starts browser auth and polls for the named account; dispatch near `commands/integrations.js:400`; unbound scratch folders refuse `atris gmail connect` via the same `requireAccountBound` lock (exit 2, no Gmail network, no OAuth)
+- `atris gmail [inbox|read <id>]` (`commands/integrations.js:145`): Email inbox and message reading; unbound scratch folders refuse bare `atris gmail` via `requireAccountBound` before this runs
 - `atris calendar [today|week]` (lines 167-184): Calendar events
 - `atris twitter [post <text>]` (lines 232-246): Twitter posting
 - `atris slack [channels]` (`commands/integrations.js:1078`): Slack channel listing; unbound scratch folders refuse bare `atris slack` via `requireAccountBound` before this runs
 - `atris integrations` (lines 298-338): Show status of all integrations
 - **Auth:** Uses `getAuthToken()` (line 16) from `~/.atris/credentials.json`
-- **Routing:** `bin/atris.js:2703` (`command === 'gmail'`) and `bin/atris.js:2738` (`command === 'slack'`): always `requireAccountBound`; `--help` still prints usage
+- **Routing:** `bin/atris.js:2736` (`command === 'gmail'`) and `bin/atris.js:2774` (`command === 'slack'`): always `requireAccountBound`; a refused gmail gate returns before `gmailCommand` so connect cannot fall through to exit 0; `--help` still prints usage
 - **Help:** `bin/atris.js:884-894` (`showIntegrationsHelp`) and `bin/atris.js:1467-1472` route `integrations --help` before auth/session state or backend status checks
-- **Gmail connect regression:** `test/gmail-account.test.js:99` (name validation), `test/gmail-account.test.js:129` (poll success), `test/gmail-account.test.js:182` (timeout)
+- **Gmail connect regression:** `test/gmail-account.test.js:99` (name validation), `test/gmail-account.test.js:129` (poll success), `test/gmail-account.test.js:182` (timeout), `test/dogfood-pass3-27-28.test.js` (unbound scratch `gmail connect` exits 2 with no network or connect flow)
 - **Regression:** `test/commands.test.js:4279-4294` covers integrations help without login errors or `.atris` creation
 - **Value:** Manage external services without leaving the CLI
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -2740,12 +2740,15 @@ if (command === 'init') {
     const mailbox = extractGmailMailboxAccount(raw);
     const gateInput = mailbox.mailboxAccountId ? ['--account', ...mailbox.args] : mailbox.args;
     const gate = requireAccountBound(gateInput);
-    if (!gate.ok) process.exit(refuseAccountGlobal());
+    if (!gate.ok) {
+      process.exit(refuseAccountGlobal());
+      return;
+    }
     const subcommand = gate.args[0];
     const args = gate.args.slice(1);
     if (mailbox.mailboxAccountId) args.push('--account', mailbox.mailboxAccountId);
     gmailCommand(subcommand, ...args)
-      .then(() => process.exit(0))
+      .then(() => process.exit(process.exitCode || 0))
       .catch((err) => { console.error(`✗ Error: ${err.message || err}`); process.exit(1); });
   }
 } else if (command === 'calendar') {

--- a/test/dogfood-pass3-27-28.test.js
+++ b/test/dogfood-pass3-27-28.test.js
@@ -64,6 +64,7 @@ test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumpi
       ['gmail', 'archive'],
       ['gmail', 'accounts'],
       ['gmail', 'use'],
+      ['gmail', 'connect'],
       ['slack'],
       ['slack', 'channels'],
       ['slack', 'dms'],
@@ -82,7 +83,7 @@ test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumpi
       assert.equal(result.status, 2, `${args.join(' ')} status=${result.status}`);
       const out = `${result.stderr}${result.stdout}`;
       assert.match(out, /account-global; pass --account to continue/);
-      assert.doesNotMatch(out, /web-guardian|dogfood@example|Conversations|Channels|payroll|502|Slack commands|Fetching Slack|Gmail commands|Fetching inbox|Fetching message|Archiving |ECONNREFUSED|api\.atris\.ai/);
+      assert.doesNotMatch(out, /web-guardian|dogfood@example|Conversations|Channels|payroll|502|Slack commands|Fetching Slack|Gmail commands|gmail commands|Fetching inbox|Fetching message|Archiving |waiting for gmail|open this url|ECONNREFUSED|api\.atris\.ai|\/integrations\/gmail\/start/);
       assert.equal(out.includes(ACCOUNT_GLOBAL_MESSAGE), true);
     }
 
@@ -105,8 +106,8 @@ test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumpi
       env: helpEnv,
     });
     assert.equal(gmailHelp.status, 0, gmailHelp.stderr + gmailHelp.stdout);
-    assert.match(gmailHelp.stdout, /Gmail commands/);
-    assert.doesNotMatch(`${gmailHelp.stderr}${gmailHelp.stdout}`, /account-global|Fetching inbox|Fetching message|Archiving |ECONNREFUSED|api\.atris\.ai/);
+    assert.match(gmailHelp.stdout, /gmail commands/i);
+    assert.doesNotMatch(`${gmailHelp.stderr}${gmailHelp.stdout}`, /account-global|Fetching inbox|Fetching message|Archiving |waiting for gmail|ECONNREFUSED|api\.atris\.ai/);
 
     const bound = path.join(dir, 'bound');
     fs.mkdirSync(path.join(bound, '.atris'), { recursive: true });
@@ -120,8 +121,56 @@ test('27/28: unbound folder refuses inbox/gmail/slack/errors/truth without dumpi
       env: helpEnv,
     });
     assert.equal(boundGmail.status, 0, boundGmail.stderr + boundGmail.stdout);
-    assert.match(boundGmail.stdout, /Gmail commands/);
+    assert.match(boundGmail.stdout, /gmail commands/i);
     assert.doesNotMatch(`${boundGmail.stderr}${boundGmail.stdout}`, /account-global|Fetching inbox/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('unbound scratch gmail connect refuses with exit 2 and never starts a connect flow', () => {
+  const dir = makeTempDir('atris-gmail-connect-scratch-');
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(path.join(home, '.atris'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.atris', 'credentials.json'), JSON.stringify({
+    token: 'fake-token',
+    email: 'dogfood@example.com',
+  }));
+
+  const env = {
+    HOME: home,
+    ATRIS_HOME: home,
+    ATRIS_NO_INTERACTIVE: '1',
+    ATRIS_NONINTERACTIVE: '1',
+    ATRIS_API_URL: 'http://127.0.0.1:1',
+  };
+
+  try {
+    const result = runCli(['gmail', 'connect'], { cwd: dir, env });
+    assert.equal(result.status, 2, result.stderr + result.stdout);
+    const out = `${result.stderr}${result.stdout}`;
+    assert.equal(out.includes(ACCOUNT_GLOBAL_MESSAGE), true);
+    assert.doesNotMatch(out, /waiting for gmail|connected |open this url|auth url|ECONNREFUSED|api\.atris\.ai|\/integrations\/gmail\/start|invalid gmail account name/i);
+    assert.equal(fs.existsSync(path.join(dir, '.atris')), false);
+
+    const help = runCli(['gmail', '--help'], { cwd: dir, env });
+    assert.equal(help.status, 0, help.stderr + help.stdout);
+    assert.match(help.stdout, /gmail commands/i);
+    assert.match(help.stdout, /connect/);
+    assert.doesNotMatch(`${help.stderr}${help.stdout}`, /account-global|waiting for gmail|ECONNREFUSED|api\.atris\.ai/);
+    assert.equal(fs.existsSync(path.join(dir, '.atris')), false);
+
+    const bound = path.join(dir, 'bound');
+    fs.mkdirSync(path.join(bound, '.atris'), { recursive: true });
+    fs.mkdirSync(path.join(bound, 'atris'), { recursive: true });
+    fs.writeFileSync(path.join(bound, '.atris', 'business.json'), JSON.stringify({
+      business_id: 'biz_dogfood',
+      slug: 'dogfood-co',
+    }));
+    const boundUsage = runCli(['gmail'], { cwd: bound, env });
+    assert.equal(boundUsage.status, 0, boundUsage.stderr + boundUsage.stdout);
+    assert.match(boundUsage.stdout, /gmail connect/);
+    assert.doesNotMatch(`${boundUsage.stderr}${boundUsage.stdout}`, /account-global/);
   } finally {
     cleanupTempDir(dir);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`atris gmail connect` is the new door that links an account. After that command landed, the scratch-folder lock covered inbox, read, archive, accounts, and use, but not connect.

From an unbound scratch folder, connect now uses the same account-bound lock as the rest of gmail:

- `atris gmail connect` refuses with one sentence and exit 2
- no Gmail network call
- no OAuth or link flow
- `--help` still prints usage and does not mutate or network
- a bound workspace can still use `gmail connect` as today

There is no second policy. This is the same lock as slack and inbox.

Verify: `node --test test/dogfood-pass3-27-28.test.js test/gmail-account.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f14645-294d-4cec-814f-558cd8459827?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f14645-294d-4cec-814f-558cd8459827&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

