### PR TITLE
feat(cli): gmail accounts read like a roster, use picks by name

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1495,8 +1495,11 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 - **Entry point:** `commands/integrations.js`
 - **Commands:**
-- `atris gmail connect [name]` (`commands/integrations.js:269`): starts browser auth and polls for the named account; dispatch near `commands/integrations.js:400`; unbound scratch folders refuse `atris gmail connect` via the same `requireAccountBound` lock (exit 2, no Gmail network, no OAuth)
-- `atris gmail [inbox|read <id>]` (`commands/integrations.js:145`): Email inbox and message reading; unbound scratch folders refuse bare `atris gmail` via `requireAccountBound` before this runs
+- `atris gmail inbox [--account <id>]` (`commands/integrations.js:197`, `gmailInbox`): lists messages and names the resolved mailbox when its email is known
+- `atris gmail connect [name]` (`commands/integrations.js:322`, `gmailConnect`): starts browser auth and polls for the named account; unbound scratch folders refuse `atris gmail connect` via the same `requireAccountBound` lock (exit 2, no Gmail network, no OAuth)
+- `atris gmail accounts` (`commands/integrations.js:381`, `gmailAccounts`): prints the default-first, aligned account roster and marks the sticky account
+- `atris gmail use [<account_id|name>]` (`commands/integrations.js:394`, `gmailUse`): picks an account interactively or resolves an id/display name and persists it as sticky
+- Gmail dispatch and help live in `commands/integrations.js:441` (`gmailCommand`); unbound scratch folders refuse bare `atris gmail` via `requireAccountBound` before this runs
 - `atris calendar [today|week]` (lines 167-184): Calendar events
 - `atris twitter [post <text>]` (lines 232-246): Twitter posting
 - `atris slack [channels]` (`commands/integrations.js:1078`): Slack channel listing; unbound scratch folders refuse bare `atris slack` via `requireAccountBound` before this runs
@@ -1504,11 +1507,11 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - **Auth:** Uses `getAuthToken()` (line 16) from `~/.atris/credentials.json`
 - **Routing:** `bin/atris.js:2736` (`command === 'gmail'`) and `bin/atris.js:2774` (`command === 'slack'`): always `requireAccountBound`; a refused gmail gate returns before `gmailCommand` so connect cannot fall through to exit 0; `--help` still prints usage
 - **Help:** `bin/atris.js:884-894` (`showIntegrationsHelp`) and `bin/atris.js:1467-1472` route `integrations --help` before auth/session state or backend status checks
-- **Gmail connect regression:** `test/gmail-account.test.js:99` (name validation), `test/gmail-account.test.js:129` (poll success), `test/gmail-account.test.js:182` (timeout), `test/dogfood-pass3-27-28.test.js` (unbound scratch `gmail connect` exits 2 with no network or connect flow)
+- **Gmail regressions:** `test/gmail-account.test.js:99` (connect validation), `test/gmail-account.test.js:129` (poll success), `test/gmail-account.test.js:182` (timeout), `test/gmail-account.test.js:297` (inbox mailbox header), `test/gmail-account.test.js:385` (account roster), `test/gmail-account.test.js:431` (interactive display-name picker), `test/dogfood-pass3-27-28.test.js` (unbound scratch `gmail connect` exits 2 with no network or connect flow)
 - **Regression:** `test/commands.test.js:4279-4294` covers integrations help without login errors or `.atris` creation
 - **Value:** Manage external services without leaving the CLI
 
-**Search:** `rg "gmailConnect|gmailCommand|calendarCommand|twitterCommand|slackCommand|integrationsStatus|showIntegrationsHelp|integrations --help|--approved|requireAccountBound" bin/atris.js commands/integrations.js lib/account-bound.js test/gmail-account.test.js test/commands.test.js test/dogfood-pass3-27-28.test.js`
+**Search:** `rg "gmailInbox|gmailConnect|gmailAccounts|gmailUse|gmailCommand|calendarCommand|twitterCommand|slackCommand|integrationsStatus|showIntegrationsHelp|integrations --help|--approved|requireAccountBound" bin/atris.js commands/integrations.js lib/account-bound.js test/gmail-account.test.js test/commands.test.js test/dogfood-pass3-27-28.test.js`
 
 ### Feature: State Detection
 

--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -2,12 +2,12 @@
  * Integration commands for Atris CLI
  *
  * Usage:
- *   atris gmail inbox [--account <id>]       - List recent emails
+ *   atris gmail inbox [--account <id>]       - List recent emails for a mailbox
  *   atris gmail read <id> [--account <id>]   - Read specific email
  *   atris gmail archive <id> [...] [--account <id>] - Archive messages
  *   atris gmail connect [name]              - Connect or reconnect a Gmail account
- *   atris gmail accounts                     - List connected Gmail accounts
- *   atris gmail use [<account_id>]           - Set or show sticky Gmail account
+ *   atris gmail accounts                     - List connected Gmail accounts and the active account
+ *   atris gmail use [<account_id|name>]      - Choose or set the active Gmail account
  *   atris calendar today    - Show today's events
  *   atris calendar yesterday - Show yesterday's events
  *   atris calendar week     - Show this week's events
@@ -29,6 +29,7 @@ const {
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const readline = require('readline');
 const { spawnSync } = require('child_process');
 
 const CALENDAR_CACHE_PATH = path.join(os.homedir(), '.atris', 'calendar-events-cache.json');
@@ -66,17 +67,44 @@ function resolveGmailAccountId(explicitId) {
 
 function gmailAccountIdentity(account = {}) {
   const id = String(account.account_id || account.id || 'default').trim() || 'default';
-  const email = String(account.email_address || account.email || 'unknown').toLowerCase();
-  const name = String(account.display_name || account.name || id).toLowerCase();
+  const email = String(account.email_address || account.email || '').trim().toLowerCase();
+  const name = String(account.display_name || account.name || id).trim().toLowerCase() || id.toLowerCase();
   return { id, email, name };
 }
 
-async function fetchGmailAccounts(token) {
+function sortGmailAccounts(accounts) {
+  return [...accounts].sort((left, right) => {
+    const leftIdentity = gmailAccountIdentity(left);
+    const rightIdentity = gmailAccountIdentity(right);
+    const leftDefault = leftIdentity.id.toLowerCase() === 'default';
+    const rightDefault = rightIdentity.id.toLowerCase() === 'default';
+    if (leftDefault !== rightDefault) return leftDefault ? -1 : 1;
+    return leftIdentity.name.localeCompare(rightIdentity.name)
+      || leftIdentity.id.localeCompare(rightIdentity.id);
+  });
+}
+
+function formatGmailAccountRows(accounts, activeId = null) {
+  const rows = sortGmailAccounts(accounts).map((account) => {
+    const identity = gmailAccountIdentity(account);
+    return { ...identity, emailLabel: identity.email || 'email pending' };
+  });
+  const nameWidth = Math.max(...rows.map((row) => row.name.length));
+  const emailWidth = Math.max(...rows.map((row) => row.emailLabel.length));
+  const active = String(activeId || '').toLowerCase();
+  return rows.map((row) => {
+    const marker = row.id.toLowerCase() === active ? '  (active)' : '';
+    return `${row.name.padEnd(nameWidth)}  ${row.emailLabel.padEnd(emailWidth)}${marker}`.trimEnd();
+  });
+}
+
+async function fetchGmailAccounts(token, options = {}) {
   const result = await apiRequestJson('/integrations/gmail/accounts', {
     method: 'GET',
     token,
   });
   if (!result.ok) {
+    if (options.quiet) return [];
     console.error(`Error: ${result.error || 'Failed to fetch accounts'}`);
     process.exit(1);
   }
@@ -87,6 +115,27 @@ async function fetchGmailAccounts(token) {
 function findGmailAccount(accounts, accountId) {
   const wanted = String(accountId || '').trim().toLowerCase();
   return accounts.find((account) => gmailAccountIdentity(account).id.toLowerCase() === wanted) || null;
+}
+
+function findGmailAccountForUse(accounts, selector) {
+  const wanted = String(selector || '').trim().toLowerCase();
+  return findGmailAccount(accounts, wanted)
+    || accounts.find((account) => gmailAccountIdentity(account).name === wanted)
+    || null;
+}
+
+async function promptForGmailAccount(deps = {}) {
+  if (deps.prompt) return deps.prompt('choose account: ');
+  const rl = readline.createInterface({
+    input: deps.input || process.stdin,
+    output: deps.output || process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question('choose account: ', (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
 }
 
 async function getAuth() {
@@ -149,7 +198,11 @@ async function gmailInbox(options = {}) {
   const { token, email } = await getAuth();
   const limit = options.limit || 10;
   const accountId = resolveGmailAccountId(options.accountId);
+  const accounts = await fetchGmailAccounts(token, { quiet: true });
+  const account = findGmailAccount(accounts, accountId);
+  const mailboxEmail = account ? gmailAccountIdentity(account).email : '';
 
+  if (mailboxEmail) console.log(`inbox for ${mailboxEmail} (${accountId.toLowerCase()})`);
   console.log('📬 Fetching inbox...\n');
 
   const path = `/integrations/gmail/messages?max_results=${limit}&account_id=${encodeURIComponent(accountId)}`;
@@ -335,38 +388,44 @@ async function gmailAccounts() {
     return;
   }
 
-  for (const account of accounts) {
-    const { id, email, name } = gmailAccountIdentity(account);
-    const active = id.toLowerCase() === activeId.toLowerCase() ? ' (active)' : '';
-    console.log(`${email}, ${name}${active}`);
-  }
+  for (const line of formatGmailAccountRows(accounts, activeId)) console.log(line);
 }
 
-async function gmailUse(accountId) {
+async function gmailUse(accountId, deps = {}) {
   const token = await getAuthToken();
   const accounts = await fetchGmailAccounts(token);
-  const trimmed = String(accountId || '').trim();
+  let selector = String(accountId || '').trim();
 
-  if (!trimmed) {
-    const effectiveId = resolveGmailAccountId(null);
-    const match = findGmailAccount(accounts, effectiveId);
-    if (match) {
-      const { name, email } = gmailAccountIdentity(match);
-      console.log(`using ${name} (${email})`);
+  if (!selector) {
+    if (!accounts.length) {
+      console.log('no connected accounts.');
       return;
     }
-    console.log(`using ${effectiveId}`);
-    return;
+    if (accounts.length === 1) {
+      const { name, email } = gmailAccountIdentity(accounts[0]);
+      console.log(`${name} (${email || 'email pending'}) is already the only gmail account.`);
+      return;
+    }
+
+    const sortedAccounts = sortGmailAccounts(accounts);
+    const activeId = resolveGmailAccountId(null);
+    const rows = formatGmailAccountRows(sortedAccounts, activeId);
+    rows.forEach((line, index) => console.log(`${index + 1}. ${line}`));
+    const answer = String(await promptForGmailAccount(deps) || '').trim();
+    const number = /^\d+$/.test(answer) ? Number(answer) : 0;
+    selector = number >= 1 && number <= sortedAccounts.length
+      ? gmailAccountIdentity(sortedAccounts[number - 1]).id
+      : answer;
   }
 
-  const match = findGmailAccount(accounts, trimmed);
+  const match = findGmailAccountForUse(accounts, selector);
   if (!match) {
-    console.error(`unknown gmail account "${trimmed}".`);
+    console.error(`unknown gmail account "${selector}".`);
     if (accounts.length) {
       console.error('connected accounts:');
-      for (const account of accounts) {
+      for (const account of sortGmailAccounts(accounts)) {
         const { id, email, name } = gmailAccountIdentity(account);
-        console.error(`  ${id}: ${email}, ${name}`);
+        console.error(`  ${id.toLowerCase()}: ${email || 'email pending'}, ${name}`);
       }
     } else {
       console.error('no connected accounts.');
@@ -376,7 +435,7 @@ async function gmailUse(accountId) {
 
   const { id, name, email } = gmailAccountIdentity(match);
   writeGmailStickyAccount(id);
-  console.log(`now using ${name} (${email})`);
+  console.log(`now using ${name} (${email || 'email pending'})`);
 }
 
 async function gmailCommand(subcommand, ...args) {
@@ -404,16 +463,16 @@ async function gmailCommand(subcommand, ...args) {
       await gmailAccounts();
       break;
     case 'use':
-      await gmailUse(args[0]);
+      await gmailUse(args.join(' '));
       break;
     default:
       console.log('gmail commands:');
-      console.log('  atris gmail inbox [--account <id>]       - list recent emails');
+      console.log('  atris gmail inbox [--account <id>]       - list recent emails for a mailbox');
       console.log('  atris gmail read <id> [--account <id>]   - read specific email');
       console.log('  atris gmail archive <id> [...] [--account <id>] - archive messages (reversible, all mail keeps them)');
       console.log('  atris gmail connect [name]               - connect or reconnect a gmail account');
-      console.log('  atris gmail accounts                     - list connected gmail accounts');
-      console.log('  atris gmail use [<account_id>]           - set or show sticky gmail account');
+      console.log('  atris gmail accounts                     - list connected gmail accounts and the active account');
+      console.log('  atris gmail use [<account_id|name>]      - choose or set the active gmail account');
   }
 }
 
@@ -1923,6 +1982,7 @@ async function integrationsStatus(args = []) {
 module.exports = {
   gmailCommand,
   gmailConnect,
+  gmailUse,
   extractGmailMailboxAccount,
   parseGmailArgs,
   gmailAccountStatePath,

--- a/test/gmail-account.test.js
+++ b/test/gmail-account.test.js
@@ -249,8 +249,9 @@ test('gmail inbox without --account uses default account_id when no sticky accou
     restore();
   }
 
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10&account_id=default');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].pathname, '/integrations/gmail/accounts');
+  assert.equal(calls[1].pathname, '/integrations/gmail/messages?max_results=10&account_id=default');
 });
 
 test('gmail inbox uses sticky account when flag absent', async () => {
@@ -268,8 +269,9 @@ test('gmail inbox uses sticky account when flag absent', async () => {
     restore();
   }
 
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10&account_id=personal');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].pathname, '/integrations/gmail/accounts');
+  assert.equal(calls[1].pathname, '/integrations/gmail/messages?max_results=10&account_id=personal');
 });
 
 test('gmail inbox with --account overrides sticky account', async () => {
@@ -287,8 +289,32 @@ test('gmail inbox with --account overrides sticky account', async () => {
     restore();
   }
 
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10&account_id=work');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].pathname, '/integrations/gmail/accounts');
+  assert.equal(calls[1].pathname, '/integrations/gmail/messages?max_results=10&account_id=work');
+});
+
+test('gmail inbox starts with the resolved mailbox when its email is known', async () => {
+  const calls = [];
+  const { integrations, restore } = withMockedIntegrations(
+    accountsApi(async (pathname, options) => {
+      calls.push({ pathname, options });
+      return { ok: true, status: 200, data: { messages: [] } };
+    }),
+    { stickyAccountId: 'personal' },
+  );
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await integrations.gmailCommand('inbox');
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.equal(lines[0], 'inbox for home@example.com (personal)');
+  assert.equal(calls[0].pathname, '/integrations/gmail/messages?max_results=10&account_id=personal');
 });
 
 test('gmail read with --account adds account_id query param', async () => {
@@ -356,7 +382,7 @@ test('gmail archive with --account adds account_id to json body', async () => {
   });
 });
 
-test('gmail accounts marks the active account and keeps lowercase output', async () => {
+test('gmail accounts aligns display names and marks the active account', async () => {
   const { integrations, restore } = withMockedIntegrations(accountsApi(async () => ({ ok: true, status: 200, data: [] })));
   const lines = [];
   const originalLog = console.log;
@@ -369,28 +395,88 @@ test('gmail accounts marks the active account and keeps lowercase output', async
   }
 
   assert.deepEqual(lines, [
-    'me@example.com, work inbox (active)',
-    'home@example.com, personal',
-    'keshav@research.com, research',
+    'work inbox  me@example.com       (active)',
+    'personal    home@example.com',
+    'research    keshav@research.com',
   ]);
 });
 
-test('gmail use with no arg prints the current sticky account', async () => {
+test('gmail accounts falls back to account ids and shows pending email', async () => {
+  const accounts = [
+    { account_id: 'team', email_address: 'Team@Example.com', display_name: 'Team' },
+    { account_id: 'beta', email_address: null, display_name: null },
+    { account_id: 'default', email_address: 'default@example.com', display_name: null },
+  ];
   const { integrations, restore } = withMockedIntegrations(
-    accountsApi(async () => ({ ok: true, status: 200, data: [] })),
-    { stickyAccountId: 'research' },
+    accountsApi(async () => ({ ok: true, status: 200, data: [] }), accounts),
+    { stickyAccountId: 'beta' },
   );
   const lines = [];
   const originalLog = console.log;
   console.log = (line) => lines.push(String(line));
   try {
-    await integrations.gmailCommand('use');
+    await integrations.gmailCommand('accounts');
   } finally {
     console.log = originalLog;
     restore();
   }
 
-  assert.deepEqual(lines, ['using research (keshav@research.com)']);
+  assert.deepEqual(lines, [
+    'default  default@example.com',
+    'beta     email pending        (active)',
+    'team     team@example.com',
+  ]);
+});
+
+test('gmail use with no arg numbers accounts and resolves a display name', async () => {
+  const { integrations, gmailAccountFile, restore } = withMockedIntegrations(
+    accountsApi(async () => ({ ok: true, status: 200, data: [] })),
+    { stickyAccountId: 'research' },
+  );
+  const lines = [];
+  const prompts = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await integrations.gmailUse(undefined, {
+      prompt: async (prompt) => {
+        prompts.push(prompt);
+        return 'Work Inbox';
+      },
+    });
+    assert.deepEqual(JSON.parse(fs.readFileSync(gmailAccountFile, 'utf8')), { account_id: 'default' });
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.deepEqual(prompts, ['choose account: ']);
+  assert.deepEqual(lines, [
+    '1. work inbox  me@example.com',
+    '2. personal    home@example.com',
+    '3. research    keshav@research.com  (active)',
+    'now using work inbox (me@example.com)',
+  ]);
+});
+
+test('gmail use with one account says it is already the only one', async () => {
+  const { integrations, restore } = withMockedIntegrations(
+    accountsApi(
+      async () => ({ ok: true, status: 200, data: [] }),
+      [{ account_id: 'default', email_address: null, display_name: 'Solo' }],
+    ),
+  );
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await integrations.gmailUse();
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+
+  assert.deepEqual(lines, ['solo (email pending) is already the only gmail account.']);
 });
 
 test('gmail use persists a valid account and prints confirmation', async () => {


### PR DESCRIPTION
atris gmail accounts prints an aligned default-first roster with display names, emails, and the active marker. atris gmail use with no argument offers a numbered picker and accepts display names case-insensitively. atris gmail inbox names the mailbox it is reading when the email is known.

Verified after rebase: gmail-account tests 19/19 exit 0, cli smoke exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)