### PR TITLE
fix(cli): connect timeout also points at the settings deep link

### DIFF
--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -375,6 +375,7 @@ async function gmailConnect(accountName, deps = {}) {
   }
 
   console.error(`connection timed out. finish in your browser: ${authUrl}`);
+  console.error(`or connect from settings: https://atris.ai/dashboard/settings?connect=gmail&account=${accountId}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
When atris gmail connect times out, the hint now includes the settings deep link that opens the naming flow directly (shipped on the web today).

gmail-account tests exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)