### PR TITLE
test(cli): connect timeout expects the settings deep link line

### DIFF
--- a/test/gmail-account.test.js
+++ b/test/gmail-account.test.js
@@ -218,6 +218,7 @@ test('gmail connect times out with a nonzero exit and browser instructions', asy
   assert.deepEqual(lines, ['waiting for gmail account default...']);
   assert.deepEqual(errors, [
     'connection timed out. finish in your browser: https://accounts.example.test/finish',
+    'or connect from settings: https://atris.ai/dashboard/settings?connect=gmail&account=default',
   ]);
   assert.equal(calls[0].options.body.account_id, 'default');
   assert.equal(calls.filter((call) => call.pathname === '/integrations/gmail/accounts').length, 2);


### PR DESCRIPTION
Follow-up to #753, which I landed with this assertion red (my mistake: a chained command merged despite the failing gate). The timeout test now covers both stderr lines. gmail-account tests exit 0 on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)