### PR TITLE
dogfood: do in an inited workspace stays in the room

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1201,17 +1201,16 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 - Entry: `commands/workflow.js:865-1244` (doAtris function)
 - Empty folder: `lib/first-minute.js` `buildFirstMinute({ fresh: true })` and `freshMinuteJson` (same two spoken lines and `--json` next as bare `atris`). No `executor.md` bounce.
-- Human head after init: `buildFirstMinute` (same two spoken lines as bare `atris`); never prints `Context: UNKNOWN` or `Backlog tasks: 0` when a claimed/review/open task exists
-- Default stays the first-minute two lines with no `PROMPT ONLY` banner; `--prompt` / `--verbose` / `--full` prints the executor paste and file dump. `--help` names `--prompt`.
-- Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do in an uninitialized folder talks like first-minute`, `do after init --yes --minimal does not send you back to init`, `do names a claimed task the same way first-minute does`), `test/first-minute.test.js` (`atris do in an empty folder talks like first-minute`, `atris do and plan after init --minimal stay two spoken lines`)
+- After init, including MAP plus a claimed starter: default `do` reprints the same two spoken lines as bare `atris`. No `PROMPT ONLY` and no `executor.md not found`. `--prompt` / `--verbose` / `--full` prints the executor paste and file dump. `--help` names `--prompt`.
+- Missing `team/executor` after `init --minimal` is optional context, not "run init". Regression: `test/workflow-command.test.js` (`do in an uninitialized folder talks like first-minute`, `do after init --yes --minimal does not send you back to init`, `do names a claimed task the same way first-minute does`), `test/first-minute.test.js` (`atris do in an empty folder talks like first-minute`, `atris do after init and claim stays in the room`, `atris do and plan after init --minimal stay two spoken lines`)
 
 3. **`atris review`** - Human checkpoint, first-minute voice
 
 - Entry: `commands/workflow.js:1246` `reviewAtris` / `renderReviewMinute` (`commands/workflow.js:96`)
-- Empty folder: `lib/first-minute.js` `isFreshWorkspace` + `speakFirstMinute` (same two spoken lines and `--json` next as bare `atris`). No `validator.md` bounce and no lone `nothing is waiting on you.`
+- Empty folder: `lib/first-minute.js` `isFreshWorkspace` + `speakFirstMinute` (same two spoken lines and `--json` next as bare `atris`), including `--verbose`. No `validator.md` bounce and no lone `nothing is waiting on you.`
 - After init: stay in the room. If first-minute next is `atris task claim|ready|accept`, review prints those same two spoken lines. Certified leads with the win and `atris task accept <id>`. Uncertified stays "still being checked", not needs-you. `nothing is waiting on you.` only when there is no claim/ready/accept next.
 - `--all` / `--limit` / `--group-by`: certified queue via `task reviews`. After init, `--json` also keeps that queue.
-- `--verbose` / `--full`: legacy Validator prompt
+- `--verbose` / `--full`: legacy Validator prompt. Missing `team/validator` after `init --minimal` is optional context, not "run init"
 - Headless never prompts (`isNonInteractive`)
 - `--help` stays usage
 - Regression: `test/workflow-command.test.js` (`review in an uninitialized folder talks like first-minute`, `review after init --yes --minimal does not send you back to init`, `review talks like first-minute`, `renderReviewMinute names an open claim`), `test/first-minute.test.js` (`atris review in an empty folder talks like first-minute`, `atris review after init --minimal matches bare atris claim next`)

--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -14,6 +14,7 @@ const {
   taskCommand,
 } = require('../lib/first-minute');
 const { isNonInteractive } = require('../lib/noninteractive');
+const { loadContext } = require('../lib/state-detection');
 const { buildToolResultBody } = require('../lib/tool-result-encode');
 
 function wrapWorkflowText(text, width = 76) {
@@ -584,7 +585,6 @@ async function planAtris(userInput = null) {
 
   let firstMinute = null;
   try {
-    const { loadContext } = require('../lib/state-detection');
     firstMinute = buildFirstMinute({
       root: cwd,
       context: loadContext(cwd) || {},
@@ -988,7 +988,6 @@ async function doAtris() {
 
   let workspaceSummary = null;
   try {
-    const { loadContext } = require('../lib/state-detection');
     workspaceSummary = loadContext(cwd);
   } catch {
     workspaceSummary = null;
@@ -1252,22 +1251,24 @@ async function reviewAtris() {
   const executeFlag = args.includes('--execute');
   const showFull = args.includes('--full') || args.includes('--verbose');
   const wantsTaskJson = args.includes('--json');
+  const root = process.cwd();
+  const queueShape = args.some((arg) => arg === '--all' || arg === '--limit' || arg === '--group-by');
+
+  // Empty folder talks like bare atris, including --verbose. After init, stay
+  // in the room. A missing validator spec is optional context, not "run init".
+  if (isFreshWorkspace(root) && !queueShape) {
+    const code = speakFirstMinute({
+      root,
+      fresh: true,
+      asJson: wantsTaskJson,
+    });
+    if (code !== 0) process.exit(code);
+    return;
+  }
 
   if (!executeFlag && !showFull) {
-    const root = process.cwd();
     const forwarded = ['reviews', ...args.filter(arg => !['--execute', '--full', '--verbose'].includes(arg))];
     const { run: runTaskCommand } = require('./task');
-    const queueShape = args.some((arg) => arg === '--all' || arg === '--limit' || arg === '--group-by');
-    // Empty folder talks like bare atris. After init, stay in the room.
-    if (isFreshWorkspace(root) && !queueShape) {
-      const code = speakFirstMinute({
-        root,
-        fresh: true,
-        asJson: wantsTaskJson,
-      });
-      if (code !== 0) process.exit(code);
-      return;
-    }
     if (wantsTaskJson || wantsReviewQueue(args)) {
       await runTaskCommand(forwarded);
       return;
@@ -1280,18 +1281,14 @@ async function reviewAtris() {
   const config = loadConfig();
   const executionMode = executeFlag ? 'agent' : (config.execution_mode || 'prompt');
 
-  const targetDir = path.join(process.cwd(), 'atris');
-  const validatorFile = fs.existsSync(path.join(targetDir, 'team', 'validator', 'MEMBER.md'))
-    ? path.join(targetDir, 'team', 'validator', 'MEMBER.md')
-    : path.join(targetDir, 'team', 'validator.md');
+  const targetDir = path.join(root, 'atris');
+  const memberValidator = path.join(targetDir, 'team', 'validator', 'MEMBER.md');
+  const legacyValidator = path.join(targetDir, 'team', 'validator.md');
+  const validatorFile = fs.existsSync(memberValidator)
+    ? memberValidator
+    : (fs.existsSync(legacyValidator) ? legacyValidator : null);
 
-  if (!fs.existsSync(validatorFile)) {
-    console.log('✗ validator.md not found. Run "atris init" first.');
-    process.exit(1);
-  }
-
-  // Read validator.md
-  const validatorSpec = fs.readFileSync(validatorFile, 'utf8');
+  const validatorSpec = validatorFile ? fs.readFileSync(validatorFile, 'utf8') : '';
 
   // Read project-specific testing guide if it exists (optional - projects can add their own)
   // Checks common locations: root, backend/, atris/ directories
@@ -1370,7 +1367,9 @@ async function reviewAtris() {
     }
   })();
 
-  const validatorPath = path.relative(process.cwd(), validatorFile);
+  const validatorPath = validatorFile
+    ? path.relative(process.cwd(), validatorFile)
+    : 'atris/team/validator/MEMBER.md (missing)';
   const todoPathRef = taskFilePath ? path.relative(process.cwd(), taskFilePath) : null;
   const journalPathRef = path.relative(process.cwd(), logFile);
   const personaPath = path.join(targetDir, 'PERSONA.md');

--- a/test/cli-smoke.test.js
+++ b/test/cli-smoke.test.js
@@ -965,8 +965,8 @@ test('do prints first-minute only by default', () => {
 
     const res = runCli(['do'], { cwd: dir });
     assert.equal(res.status, 0, res.stderr);
-    assert.doesNotMatch(res.stdout, /PROMPT ONLY/);
     assert.match(res.stdout, /^next: /m);
+    assert.doesNotMatch(res.stdout, /PROMPT ONLY|executor\.md not found|Run "atris init"/);
     assert.doesNotMatch(res.stdout, /COPY\/PASTE PROMPT/);
     assert.doesNotMatch(res.stdout, /You are the Executor/);
     assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);

--- a/test/dogfood-p0.test.js
+++ b/test/dogfood-p0.test.js
@@ -196,15 +196,17 @@ test('P0-3: fresh init --yes seeds one task visible to status and task list', fu
   }
 });
 
-test('P0-4: plan/do/ingest start with PROMPT ONLY or ACTION TAKEN', () => {
+test('P0-4: plan/do stay in the room after init; ingest still names the write', () => {
   const dir = makeTempDir();
   try {
     assert.equal(runCli(['init', '--yes'], { cwd: dir, timeout: 60000 }).status, 0);
 
+    const minute = runCli([], { cwd: dir });
     const plan = runCli(['plan'], { cwd: dir });
     assert.equal(plan.status, 0, plan.stderr);
-    assert.notEqual(plan.stdout.trimStart().split(/\r?\n/)[0], 'PROMPT ONLY');
+    assert.equal(plan.stdout.trim(), minute.stdout.trim());
     assert.match(plan.stdout, /^next: /m);
+    assert.doesNotMatch(plan.stdout, /PROMPT ONLY|navigator\.md not found|Run "atris init"/);
 
     const planPrompt = runCli(['plan', '--prompt'], { cwd: dir });
     assert.equal(planPrompt.status, 0, planPrompt.stderr);
@@ -212,8 +214,9 @@ test('P0-4: plan/do/ingest start with PROMPT ONLY or ACTION TAKEN', () => {
 
     const doit = runCli(['do'], { cwd: dir });
     assert.equal(doit.status, 0, doit.stderr);
-    assert.notEqual(doit.stdout.trimStart().split(/\r?\n/)[0], 'PROMPT ONLY');
+    assert.equal(doit.stdout.trim(), minute.stdout.trim());
     assert.match(doit.stdout, /^next: /m);
+    assert.doesNotMatch(doit.stdout, /PROMPT ONLY|executor\.md not found|Run "atris init"/);
 
     const doPrompt = runCli(['do', '--prompt'], { cwd: dir });
     assert.equal(doPrompt.status, 0, doPrompt.stderr);

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -610,6 +610,43 @@ test('atris do in an empty folder talks like first-minute', () => {
   }
 });
 
+test('atris do after init and claim stays in the room', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  const env = { HOME: home, USER: 'keshav', ATRIS_OPERATOR: 'keshav', ATRIS_TASKS_DB: path.join(dir, 'tasks.db') };
+  try {
+    const init = runCli(['init', '--yes', '--minimal'], { cwd: dir, env, timeout: 60000 });
+    assert.equal(init.status, 0, init.stderr || init.stdout);
+    assert.ok(fs.existsSync(path.join(dir, 'atris', 'MAP.md')));
+
+    const before = runCli([], { cwd: dir, env });
+    assert.equal(before.status, 0, before.stderr || before.stdout);
+    const claim = nextLine(before.stdout);
+    assert.match(claim, /^atris task claim \S+ --as keshav$/);
+
+    const claimed = runCli(claim.replace(/^atris /, '').split(' '), { cwd: dir, env });
+    assert.equal(claimed.status, 0, claimed.stderr || claimed.stdout);
+
+    const minute = runCli([], { cwd: dir, env });
+    const doit = runCli(['do'], { cwd: dir, env });
+    const planned = runCli(['plan'], { cwd: dir, env });
+    assert.equal(minute.status, 0, minute.stderr || minute.stdout);
+    assert.equal(doit.status, 0, doit.stderr || doit.stdout);
+    assert.equal(planned.status, 0, planned.stderr || planned.stdout);
+    assert.equal(doit.stdout.trim(), minute.stdout.trim());
+    assert.equal(planned.stdout.trim(), minute.stdout.trim());
+    assert.match(minute.stdout, /already yours/);
+    assert.match(nextLine(doit.stdout), /^atris task ready \S+$/);
+    assert.equal(nextLine(doit.stdout), nextLine(minute.stdout));
+    assert.equal(spokenLineCount(doit.stdout), 2);
+    assert.doesNotMatch(doit.stdout + planned.stdout, /executor\.md not found|navigator\.md not found|Run "atris init"/);
+    assert.doesNotMatch(doit.stdout + planned.stdout, /PROMPT ONLY|What do you want to build/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('atris task next in an empty folder talks like first-minute', () => {
   const dir = makeTempDir();
   const home = path.join(dir, 'home');

--- a/test/workflow-command.test.js
+++ b/test/workflow-command.test.js
@@ -186,6 +186,12 @@ test('review in an uninitialized folder talks like first-minute', () => {
   assert.match(help.stdout, /Usage: atris review/);
   assert.doesNotMatch(help.stdout, /clean start|nothing is waiting on you|validator\.md/);
   assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
+
+  const verbose = runCli(['review', '--verbose'], { cwd: dir, env });
+  assert.equal(verbose.status, 0, verbose.stderr || verbose.stdout);
+  assert.equal(verbose.stdout.trim(), minute.stdout.trim());
+  assert.doesNotMatch(verbose.stdout + verbose.stderr, /validator\.md not found|Run "atris init"/);
+  assert.equal(fs.existsSync(path.join(dir, 'atris')), false);
 });
 
 test('do in an uninitialized folder talks like first-minute', () => {
@@ -237,6 +243,7 @@ test('plan after init --yes --minimal does not send you back to init', () => {
   assert.equal(res.status, 0, combined);
   assert.equal(res.stdout.trim(), minute.stdout.trim());
   assert.equal(spokenLineCount(spokenDoBody(res.stdout)), 2);
+  assert.match(res.stdout, /^next: /m);
   assert.doesNotMatch(res.stdout, /PROMPT ONLY/);
   assert.doesNotMatch(res.stdout, /Atris Plan — Navigator Agent Activated/);
   assert.doesNotMatch(res.stdout, /Navigator spec: atris\/team\/navigator\/MEMBER\.md \(missing\)/);
@@ -278,6 +285,7 @@ test('do after init --yes --minimal does not send you back to init', () => {
   assert.equal(res.status, 0, combined);
   assert.equal(res.stdout.trim(), minute.stdout.trim());
   assert.equal(spokenLineCount(spokenDoBody(res.stdout)), 2);
+  assert.match(res.stdout, /^next: /m);
   assert.doesNotMatch(res.stdout, /PROMPT ONLY/);
   assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
   assert.doesNotMatch(res.stdout, /Context: UNKNOWN/);
@@ -329,12 +337,22 @@ test('review after init --yes --minimal does not send you back to init', () => {
   assert.equal(payload.action, 'review_queue');
   assert.ok(payload.queue);
   assert.doesNotMatch(jsonReview.stdout, /this workspace is not initialized|atris init --minimal/);
+
+  const verbose = runCli(['review', '--verbose'], { cwd: dir, env });
+  const verboseCombined = verbose.stdout + verbose.stderr;
+  assert.equal(verbose.status, 0, verboseCombined);
+  assert.doesNotMatch(verboseCombined, /validator\.md not found|Run "atris init"/);
+  assert.doesNotMatch(verboseCombined, /clean start|atris init --minimal/);
+  assert.match(verbose.stdout, /You are the Validator\./);
+  assert.match(verbose.stdout, /Validator spec: atris\/team\/validator\/MEMBER\.md \(missing\)/);
 });
 
 test('plan on an initialized workspace prints the navigator prompt shape', () => {
   const dir = initializedWorkspace();
+  const minute = runCli([], { cwd: dir });
   const brief = runCli(['plan'], { cwd: dir });
   assert.equal(brief.status, 0, brief.stderr);
+  assert.equal(brief.stdout.trim(), minute.stdout.trim());
   assert.match(brief.stdout, /^next: /m);
   assert.doesNotMatch(brief.stdout, /PROMPT ONLY/);
   assert.doesNotMatch(brief.stdout, /Atris Plan — Navigator Agent Activated/);
@@ -402,8 +420,10 @@ test('do prints the first-minute head; executor paste stays on --verbose', () =>
   fs.mkdirSync(featureDir, { recursive: true });
   fs.writeFileSync(path.join(featureDir, 'build.md'), '# build plan\n');
 
+  const minute = runCli([], { cwd: dir });
   const res = runCli(['do'], { cwd: dir });
   assert.equal(res.status, 0, res.stderr);
+  assert.equal(res.stdout.trim(), minute.stdout.trim());
   assert.match(res.stdout, /^next: /m);
   assert.doesNotMatch(res.stdout, /PROMPT ONLY/);
   assert.doesNotMatch(res.stdout, /Atris Do — Executor Agent Activated/);
@@ -431,10 +451,10 @@ test('plan names a claimed task the same way first-minute does', () => {
   assert.equal(minute.status, 0, minute.stderr || minute.stdout);
   assert.equal(plan.status, 0, plan.stderr || plan.stdout);
   assert.equal(plan.stdout.trim(), minute.stdout.trim());
-  assert.doesNotMatch(plan.stdout, /PROMPT ONLY/);
   assert.match(plan.stdout, /"ship the landing page" is already yours\./);
   assert.equal(nextLine(plan.stdout), nextLine(minute.stdout));
   assert.equal(nextLine(plan.stdout), 'atris task ready CLI-9');
+  assert.doesNotMatch(plan.stdout, /PROMPT ONLY/);
   assert.doesNotMatch(plan.stdout, /Atris Plan — Navigator Agent Activated/);
   assert.doesNotMatch(plan.stdout, /CONTEXT FILES \(agent should read\)/);
   assert.doesNotMatch(plan.stdout, /COPY\/PASTE PROMPT|You are the Navigator\./);
@@ -460,11 +480,11 @@ test('do names a claimed task the same way first-minute does', () => {
   assert.equal(minute.status, 0, minute.stderr || minute.stdout);
   assert.equal(doit.status, 0, doit.stderr || doit.stdout);
   assert.equal(doit.stdout.trim(), minute.stdout.trim());
-  assert.doesNotMatch(doit.stdout, /PROMPT ONLY/);
   assert.match(doit.stdout, /"ship the landing page" is already yours\./);
   assert.equal(nextLine(doit.stdout), nextLine(minute.stdout));
   assert.equal(nextLine(doit.stdout), 'atris task ready CLI-9');
   assert.equal(spokenLineCount(spokenDoBody(doit.stdout)), 2);
+  assert.doesNotMatch(doit.stdout, /PROMPT ONLY/);
   assert.doesNotMatch(doit.stdout, /Atris Do — Executor Agent Activated/);
   assert.doesNotMatch(doit.stdout, /Context: UNKNOWN/);
   assert.doesNotMatch(doit.stdout, /Backlog tasks: 0/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto current master after #758 landed.

#758 already made default `do` / `plan` two spoken first-minute lines, with factory chrome on `--prompt`. This keeps that contract.

What this still adds, after MAP exists and the starter is claimed:

```
hey keshav, "generate map.md — scan codebase" is already yours.

next: atris task ready DPL-1
```

Same two lines as bare `atris`. The next line pastes. No factory chrome. No bounce to init.

`review --verbose` after `init --minimal` still does not say `validator.md not found`. Empty-folder `--verbose` still talks like first-minute.

**Verify**
```
node --test test/workflow-command.test.js test/first-minute.test.js test/dogfood-p0.test.js
```

Local run after rebase: 70/70 passed, including `atris do after init and claim stays in the room` and `atris do and plan after init --minimal stay two spoken lines`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-189ff69d-cc14-4002-aa8c-eeb7a86d7b09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-189ff69d-cc14-4002-aa8c-eeb7a86d7b09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

