### PR TITLE
fix(wish): a cloud wish skips the empty-folder gate

### DIFF
--- a/commands/wish.js
+++ b/commands/wish.js
@@ -420,8 +420,10 @@ function wishCommand(args = [], deps = {}) {
   }
   const root = process.cwd();
   // Empty folder talks like bare atris. A leftover sentence is not a
-  // wish desk. After init, a plain sentence still files.
-  if (!first || (isFreshWorkspace(root) && !isWishDeskVerb(first))) {
+  // wish desk. After init, a plain sentence still files. A cloud wish
+  // runs remotely and needs no local workspace, so it skips the gate.
+  const wantsCloud = args.includes('--cloud');
+  if (!first || (isFreshWorkspace(root) && !isWishDeskVerb(first) && !wantsCloud)) {
     return printWishReceptionist(root);
   }
   if (first === 'show') {


### PR DESCRIPTION
The first-minute guard added in #759 was swallowing wish --cloud in fresh folders, which broke the cloud enqueue path its own contract said stays intact. Cloud wishes run remotely and need no local workspace, so --cloud bypasses the gate.

Verified bare: wish-cloud, first-minute, and wish test files all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)