### PR TITLE
fix(wish): cloud grants stop asking for a local builder

### DIFF
--- a/lib/wish-audit.js
+++ b/lib/wish-audit.js
@@ -1047,13 +1047,13 @@ function auditWish(text, root = process.cwd(), options = {}) {
   } catch {
     validator = null;
   }
-  if (!executor) {
+  if (!executor && !options.cloudRun) {
     const question = 'Which working builder should handle this?';
     const answered = answeredRepeatedQuestionValue(text, root, question, 'builder');
     if (answered) executor = { id: slugify(answered), name: answered };
     else questions.push(question);
   }
-  if (!validator) {
+  if (!validator && !options.cloudRun) {
     const question = 'Which working reviewer should validate it?';
     const answered = answeredRepeatedQuestionValue(text, root, question, 'reviewer');
     if (answered) validator = { id: slugify(answered), name: answered };

--- a/lib/wish-delegate.js
+++ b/lib/wish-delegate.js
@@ -1639,7 +1639,10 @@ function applyAnswer(wish, answer, root, options = {}) {
     answers: [...(wish.answers || []), answer],
   };
   const auditText = [wish.text, ...(answeredWish.answers || [])].join(' ');
-  const audited = auditWish(auditText, root, { engineOverride, originalText: wish.text });
+  // A cloud grant runs on the backend, so it never needs a local builder or
+  // reviewer; only clarity questions still apply.
+  const cloudRun = typeof options.cloudDispatch === 'function';
+  const audited = auditWish(auditText, root, { engineOverride, originalText: wish.text, cloudRun });
   const audit = bestGuessAfterRepeatedQuestion(answeredWish, audited, root);
   if (!audit.ok) return askForInput(answeredWish, audit, root, asJson);
   // --cloud grants hand the answered wish to the backend instead of a local


### PR DESCRIPTION
wish grant --cloud failed only in CI: with no local engines installed, the audit asked 'which working builder should handle this' and exited 1. Cloud grants run on the backend, so the audit now skips the builder/reviewer questions when a cloud dispatcher is attached; clarity questions still apply.

Local verify bare, all exit 0: cloud-mission, wish-audit, wish-cloud, wish-intake, wish. CI on this merge is the true regression check since only CI reproduces the engine-free environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)