### PR TITLE
publish gate: acknowledge the intentional _start removal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,10 @@ jobs:
         # Focused subset deliberately replaced the full "npm test" gate in
         # be0c484a: the full suite has known-flaky subprocess tests locally.
         # Run the full suite (marker-free env) before pushing a v* tag.
+        env:
+          # _start was removed on purpose in #690 (leftover _start no longer
+          # spawns runners). Any other command removal still blocks publish.
+          ATRIS_ALLOW_COMMAND_REMOVALS: "_start"
         run: |
           node -c commands/mission.js
           node --test test/mission-status.test.js test/check-command-regression.test.js test/repo-shape.test.js


### PR DESCRIPTION
v3.55.0 publish was refused because _start exists in atris@3.53.0 but not here. That removal was deliberate (#690: leftover _start no longer spawns runners), so the gate env now allows exactly that one name; any other removal still blocks. Verified locally: check-command-regression exits 0 with the allowance, 177 published vs 195 local commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)