### PR TITLE
release: 3.56.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atris",
-  "version": "3.55.0",
+  "version": "3.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atris",
-      "version": "3.55.0",
+      "version": "3.56.0",
       "license": "MIT",
       "bin": {
         "atris": "bin/atris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atris",
-  "version": "3.55.0",
+  "version": "3.56.0",
   "description": "you say what you want in plain words. atris builds it, checks it, and shows you proof.",
   "main": "bin/atris.js",
   "bin": {


### PR DESCRIPTION
Minor bump for the terminal features landed since 3.55.0 was tagged: atris gmail send and atris gmail voice (#766).

🤖 Generated with [Claude Code](https://claude.com/claude-code)