### PR TITLE
hygiene: gmailSend stays internal, nothing imports it

### DIFF
--- a/commands/integrations.js
+++ b/commands/integrations.js
@@ -2148,7 +2148,6 @@ async function integrationsStatus(args = []) {
 module.exports = {
   gmailCommand,
   gmailConnect,
-  gmailSend,
   gmailVoice,
   gmailUse,
   extractGmailMailboxAccount,


### PR DESCRIPTION
The hygiene ratchet caught gmailSend as an orphaned export from #766; the command dispatch calls it in-file, so the export goes. repo-hygiene, gmail-account, and cli-smoke all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)