### PR TITLE
test: task tests get an atris folder after the empty-folder gate

### DIFF
--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -13991,6 +13991,7 @@ test('task status resolves goal_id display refs to parent task objectives', () =
 test('task status treats reviewed failures as closed task health', () => {
   if (!hasNodeSqlite()) return;
   const dir = makeTempDir();
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
   const dbPath = path.join(dir, 'tasks.db');
   const env = { ATRIS_TASKS_DB: dbPath, NODE_NO_WARNINGS: '1' };
   try {
@@ -14021,6 +14022,7 @@ test('task status treats reviewed failures as closed task health', () => {
 test('task status keeps failed blockers out of review handoff', () => {
   if (!hasNodeSqlite()) return;
   const dir = makeTempDir();
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
   const dbPath = path.join(dir, 'tasks.db');
   const env = { ATRIS_TASKS_DB: dbPath, NODE_NO_WARNINGS: '1' };
   try {

--- a/test/falsifier-probe.test.js
+++ b/test/falsifier-probe.test.js
@@ -61,6 +61,7 @@ test('a command that cannot start is reported, not counted as a verdict', () => 
 
 test('task ready refuses a verifier that cannot fail, and takes the same work with a real one', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-falsify-cli-'));
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
   try {
     const env = {
       ...process.env,

--- a/test/policy-lessons.test.js
+++ b/test/policy-lessons.test.js
@@ -220,6 +220,7 @@ test('atris lesson mine --json writes the policy state file and lessons.md', () 
 
 test('task ready surfaces policy hints on evidence-less proof and stays quiet on receipt-backed proof', () => {
   const dir = makeTempDir();
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
   try {
     writePolicyLessons(dir, mineProofPolicy(fixtureHistory()));
 


### PR DESCRIPTION
#764 made task new in an empty folder speak first-minute instead of minting, and updated three test files, but four task status/ready tests still ran in bare temp dirs and broke CI. They now mkdir atris/ first, same adaptation #764 used elsewhere. All four pass bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)