### PR TITLE
dogfood: atris log captures inbox without a live business

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -62,7 +62,7 @@ rg "compactErrorPayload|printCliJson|wantsFull|cli-json|withMissionFullJson|stri
 rg "stream --once|ATRIS_NONINTERACTIVE|orb --json|orb --pick|isNonInteractive" commands/stream.js commands/orb.js lib/noninteractive.js test/dogfood-pass2.test.js  # Watch-loop --once / non-TTY exit; orb --json moves + pick
 rg "Plan only|refuseBrainWriteWithoutYes|--yes" commands/sync.js commands/brain.js bin/atris.js test/dogfood-pass2.test.js  # update/brain default plan-only; writes require --yes; non-TTY without --yes exits 2
 rg "syncCheckoutCommand|checkoutBehindMessage|trackedTreeIsClean" commands/sync-checkout.js lib/checkout-sync.js bin/atris.js commands/status.js test/sync-checkout.test.js  # Clean current-branch fetch + fast-forward command and boot/status upstream-behind warning
-rg "logAtris|logsDigest|addInboxIdea|--repl" commands/log.js bin/atris.js test/logs-digest.test.js test/dogfood-papercuts.test.js test/dogfood-p0.test.js  # `atris log \"note\"` inbox write, optional --repl editor, and read-only daily digest
+rg "logAtris|logsDigest|addInboxIdea|--repl|inbox_capture" commands/log.js bin/atris.js test/log-inbox.test.js test/logs-digest.test.js test/dogfood-papercuts.test.js test/dogfood-p0.test.js  # `atris log \"note\"` local inbox write, one-word notes included, --json capture, optional --repl editor, and read-only daily digest
 rg "logSyncAtris" commands/log-sync.js      # Log sync command
 rg "experimentsCommand" commands/experiments.js  # Experiments CLI command
 rg "loginAtris|mintAgentToken|mintScopedAgentToken|ensureBilledCommandAuth|parseAgentTokenArgs|--agent|agent-token|showAuthHelp|--global|scope" bin/atris.js commands/auth.js lib/cli-scope.js test/auth-agent-token.test.js test/billed-command-auth.test.js test/dogfood-p1.test.js # Auth/account commands, scoped agent-token mint from stored JWT (`atris login --agent`), billed-command auto-mint via ensureBilledCommandAuth, and workspace vs --global account list
@@ -746,18 +746,19 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 ### Feature: Daily Logging (`atris log`)
 
-**Purpose:** Add ideas to inbox in today's journal
+**Purpose:** Add ideas to inbox in today's journal without a live business
 
-- **Entry point:** `commands/log.js:4-56` (logAtris function)
+- **Entry point:** `commands/log.js:71` (logAtris), router `bin/atris.js` `command === 'log'`
 - **Creates:** `atris/logs/YYYY/YYYY-MM-DD.md` files
 - **Logic:**
-- Uses `lib/journal.js` for file operations
-- Interactive readline session
-- Appends to `## Inbox` section
-- Type "exit" to quit
-- **Value:** Quick brain dump without context switching
+- `atris log "note"` and one-word `atris log text` append to `## Inbox` locally
+- `--json` emits `{ ok, action: inbox_capture, id, note, journal, next_command }`
+- One slug-like word is never a live business lookup
+- Optional `--repl` editor; headless never opens a prompt
+- Type "exit" to quit the REPL
+- **Value:** First-minute capture works in a workspace with no business slug
 
-**Search:** `rg "logAtris" commands/log.js`
+**Search:** `rg "logAtris|inbox_capture" commands/log.js test/log-inbox.test.js`
 
 ### Feature: Journal Sync (`atris log sync`)
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -506,7 +506,7 @@ function helpCatalog() {
     { name: 'review', summary: 'validate work and capture learnings', json: false, interactive_risk: 'low' },
     { name: 'recap', summary: 'spoken recap of what your team did', json: true, interactive_risk: 'low' },
     { name: 'mission', summary: 'durable goal + owner + verifier + tick', json: true, interactive_risk: 'medium' },
-    { name: 'log', summary: 'append an idea to today inbox (or --repl)', json: false, interactive_risk: 'medium' },
+    { name: 'log', summary: 'append an idea to today inbox (or --repl)', json: true, interactive_risk: 'low' },
     { name: 'wish', summary: 'headless inbox / mission intake', json: true, interactive_risk: 'low' },
     { name: 'learn', summary: 'structured project learnings', json: false, interactive_risk: 'low' },
     { name: 'activate', summary: 'load atris context for this session', json: false, interactive_risk: 'low' },
@@ -2035,7 +2035,6 @@ if (command === 'init') {
 } else if (command === 'log') {
   const logArgs = process.argv.slice(3);
   const subcommand = logArgs[0];
-  const positional = logArgs.filter((arg) => !String(arg).startsWith('-'));
   if (subcommand === 'sync') {
     require('../commands/log-sync').logSyncAtris()
       .then(() => process.exit(0))
@@ -2044,24 +2043,16 @@ if (command === 'init') {
         process.exit(1);
       });
   } else if (subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
-    console.log('Usage: atris log ["note"] | --repl | sync | <business-slug> | help');
+    console.log('Usage: atris log ["note"] [--json] | --repl | sync | help');
     console.log('');
     console.log('  atris log "an idea"      Append a note to today\'s ## Inbox');
+    console.log('  atris log text           One word still lands in Inbox. No live business required');
+    console.log('  atris log "an idea" --json');
     console.log('  atris log --repl         Open today\'s journal REPL');
     console.log('  atris log                Open the REPL (needs a terminal)');
     console.log('  atris log sync           Sync the local journal to cloud');
-    console.log('  atris log <slug>         Show business log history (single slug token)');
     console.log('  atris wish "..."         Headless inbox write; add --json --no-mission for agents');
     process.exit(0);
-  } else if (
-    positional.length === 1
-    && !logArgs.includes('--repl')
-    && /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(positional[0])
-  ) {
-    // Business log: atris log <business-slug> (single slug token only)
-    require('../commands/context-sync').businessLog(positional[0])
-      .then(() => process.exit(0))
-      .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
   } else {
     logCmd();
   }

--- a/commands/log.js
+++ b/commands/log.js
@@ -12,11 +12,82 @@ function readPipedStdin() {
   }
 }
 
+function journalRel(logFile) {
+  return (path.relative(process.cwd(), logFile) || logFile).split(path.sep).join('/');
+}
+
+function printLogJson(payload) {
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+function printReplNeeded(asJson, dateFormatted, rel) {
+  const error = `Daily log REPL needs a terminal (${dateFormatted}).`;
+  if (asJson) {
+    printLogJson({
+      ok: false,
+      error,
+      journal: rel,
+      next_command: 'atris log "note"',
+    });
+    return;
+  }
+  console.log(error);
+  console.log(`journal: ${rel}`);
+  console.log('Next: atris log --repl   # in a terminal, or atris log "note" / atris wish --json --no-mission');
+}
+
+function captureNotes(logFile, notes) {
+  return notes.map((note) => addInboxIdea(logFile, note));
+}
+
+function printCapture(asJson, ids, notes, rel) {
+  if (asJson) {
+    const payload = {
+      ok: true,
+      action: 'inbox_capture',
+      journal: rel,
+      next_command: 'atris logs',
+    };
+    if (notes.length === 1) {
+      payload.id = `I${ids[0]}`;
+      payload.note = notes[0];
+    } else {
+      payload.count = notes.length;
+      payload.ids = ids.map((id) => `I${id}`);
+      payload.notes = notes;
+    }
+    printLogJson(payload);
+    return;
+  }
+  if (notes.length === 1) {
+    console.log(`captured I${ids[0]}: ${notes[0]}`);
+    console.log(`journal: ${rel}`);
+    console.log('Next: atris logs');
+    return;
+  }
+  console.log(`captured ${notes.length} note${notes.length === 1 ? '' : 's'} in ${rel}`);
+}
+
 function logAtris() {
   const targetDir = path.join(process.cwd(), 'atris');
+  const args = process.argv.slice(3);
+  const asJson = args.includes('--json');
+  const forced = isForcedNonInteractive(args);
+  const wantsRepl = args.includes('--repl');
+  const positional = args.filter((arg) => !String(arg).startsWith('-'));
+  const note = positional.join(' ').trim();
 
   if (!fs.existsSync(targetDir)) {
-    console.error('✗ Error: atris/ folder not found. Run "atris init" first.');
+    const message = 'atris/ folder not found. Run "atris init" first.';
+    if (asJson) {
+      printLogJson({
+        ok: false,
+        error: message,
+        next_command: 'atris init --yes --minimal',
+      });
+    } else {
+      console.error(`✗ Error: ${message}`);
+    }
     process.exit(1);
   }
 
@@ -27,27 +98,11 @@ function logAtris() {
     createLogFile(logFile, dateFormatted);
   }
 
-  const args = process.argv.slice(3);
-  const rel = path.relative(process.cwd(), logFile) || logFile;
-  const forced = isForcedNonInteractive(args);
-  const wantsRepl = args.includes('--repl');
-  const positional = args.filter((arg) => !String(arg).startsWith('-'));
-  const note = positional.join(' ').trim();
+  const rel = journalRel(logFile);
 
-  // `atris log "sentence"` (or multi-word args) appends to today's Inbox.
+  // `atris log "sentence"` (or one slug-like word) appends to today's Inbox.
   if (note && !wantsRepl) {
-    const id = addInboxIdea(logFile, note);
-    console.log(`captured I${id}: ${note}`);
-    console.log(`journal: ${rel}`);
-    console.log('Next: atris logs');
-    return;
-  }
-
-  // Forced headless: never open a REPL.
-  if (forced) {
-    console.log(`Daily log REPL needs a terminal (${dateFormatted}).`);
-    console.log(`journal: ${rel}`);
-    console.log('Next: atris log --repl   # in a terminal, or atris log "note" / atris wish --json --no-mission');
+    printCapture(asJson, captureNotes(logFile, [note]), [note], rel);
     return;
   }
 
@@ -56,16 +111,17 @@ function logAtris() {
     const piped = readPipedStdin();
     const lines = piped.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
     const notes = lines.filter((line) => line.toLowerCase() !== 'exit');
-    if (notes.length === 0) {
-      console.log(`Daily log REPL needs a terminal (${dateFormatted}).`);
-      console.log(`journal: ${rel}`);
-      console.log('Next: atris log --repl   # in a terminal, or atris log "note" / atris logs --json');
+    if (notes.length > 0 && !wantsRepl) {
+      printCapture(asJson, captureNotes(logFile, notes), notes, rel);
       return;
     }
-    for (const noteLine of notes) {
-      addInboxIdea(logFile, noteLine);
-    }
-    console.log(`captured ${notes.length} note${notes.length === 1 ? '' : 's'} in ${rel}`);
+    printReplNeeded(asJson, dateFormatted, rel);
+    return;
+  }
+
+  // Forced headless: never open a REPL.
+  if (forced) {
+    printReplNeeded(asJson, dateFormatted, rel);
     return;
   }
 

--- a/test/dogfood-papercuts.test.js
+++ b/test/dogfood-papercuts.test.js
@@ -65,6 +65,7 @@ test('default help is short; help --all is long; help --json lists commands', ()
   assert.equal(payload.ok, true);
   assert.ok(Array.isArray(payload.commands));
   assert.ok(payload.commands.some((row) => row.name === 'task' && row.json === true));
+  assert.ok(payload.commands.some((row) => row.name === 'log' && row.json === true));
 });
 
 test('engine --help prints usage, not the roster', () => {
@@ -92,6 +93,16 @@ test('log "an idea" lands in today Inbox without business lookup', () => {
     const journal = fs.readFileSync(todayJournal(dir), 'utf8');
     assert.match(journal, /## Inbox/);
     assert.match(journal, /an idea for later/);
+
+    const oneWord = runCli(['log', 'friction'], {
+      cwd: dir,
+      env: { ATRIS_NONINTERACTIVE: '1' },
+      input: '',
+    });
+    assert.equal(oneWord.status, 0, oneWord.stderr || oneWord.stdout);
+    assert.match(oneWord.stdout, /captured I\d+: friction/);
+    assert.doesNotMatch(oneWord.stdout + oneWord.stderr, /Business not found/i);
+    assert.match(fs.readFileSync(todayJournal(dir), 'utf8'), /friction/);
   } finally {
     cleanupTempDir(dir);
   }

--- a/test/log-inbox.test.js
+++ b/test/log-inbox.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+const TIMEOUT_MS = 15000;
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-log-inbox-'));
+}
+
+function cleanupTempDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function seedWorkspace(dir) {
+  fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+}
+
+function localJournal(dir) {
+  const now = new Date();
+  const year = String(now.getFullYear());
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return path.join(dir, 'atris', 'logs', year, `${year}-${month}-${day}.md`);
+}
+
+function runCli(args, { cwd, env, timeout = TIMEOUT_MS, input = '' } = {}) {
+  const home = env && env.HOME ? env.HOME : makeTempDir();
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    input,
+    encoding: 'utf8',
+    timeout,
+    env: {
+      ...process.env,
+      HOME: home,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ATRIS_NO_INTERACTIVE: '1',
+      ATRIS_NONINTERACTIVE: '1',
+      ...(env || {}),
+    },
+  });
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    assert.fail(`cli hung past ${timeout}ms (args: ${args.join(' ')})`);
+  }
+  if (result.error) throw result.error;
+  return result;
+}
+
+function writeFakeLogin(home) {
+  const credDir = path.join(home, '.atris');
+  fs.mkdirSync(credDir, { recursive: true });
+  fs.writeFileSync(path.join(credDir, 'credentials.json'), JSON.stringify({
+    token: 'test-token',
+    email: 'dogfood@example.com',
+    user_id: 'u-1',
+    provider: 'manual',
+  }));
+}
+
+test('atris log text captures a one-word idea locally', () => {
+  const dir = makeTempDir();
+  const home = makeTempDir();
+  try {
+    seedWorkspace(dir);
+    writeFakeLogin(home);
+    const res = runCli(['log', 'friction'], { cwd: dir, env: { HOME: home } });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /captured I1: friction/);
+    assert.doesNotMatch(`${res.stdout}\n${res.stderr}`, /Business .*not found/i);
+    assert.doesNotMatch(`${res.stdout}\n${res.stderr}`, /Not logged in/i);
+
+    const journal = fs.readFileSync(localJournal(dir), 'utf8');
+    assert.match(journal, /## Inbox/);
+    assert.match(journal, /- \*\*I1:\*\* friction/);
+  } finally {
+    cleanupTempDir(dir);
+    cleanupTempDir(home);
+  }
+});
+
+test('atris log text --json emits real JSON and writes inbox', () => {
+  const dir = makeTempDir();
+  const home = makeTempDir();
+  try {
+    seedWorkspace(dir);
+    writeFakeLogin(home);
+    const res = runCli(['log', 'capture', '--json'], { cwd: dir, env: { HOME: home } });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, 'inbox_capture');
+    assert.equal(payload.id, 'I1');
+    assert.equal(payload.note, 'capture');
+    assert.equal(payload.next_command, 'atris logs');
+    assert.match(String(payload.journal), /atris\/logs\/\d{4}\/\d{4}-\d{2}-\d{2}\.md/);
+    assert.doesNotMatch(`${res.stdout}\n${res.stderr}`, /Business .*not found/i);
+
+    const journal = fs.readFileSync(localJournal(dir), 'utf8');
+    assert.match(journal, /- \*\*I1:\*\* capture/);
+  } finally {
+    cleanupTempDir(dir);
+    cleanupTempDir(home);
+  }
+});
+
+test('atris log --json without a note is real JSON', () => {
+  const dir = makeTempDir();
+  try {
+    seedWorkspace(dir);
+    const res = runCli(['log', '--json'], { cwd: dir, input: '' });
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Daily log REPL needs a terminal/);
+    assert.equal(payload.next_command, 'atris log "note"');
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('log help names local inbox, not a live business slug', () => {
+  const res = runCli(['log', '--help'], { cwd: makeTempDir() });
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /Usage: atris log/);
+  assert.match(res.stdout, /--json/);
+  assert.match(res.stdout, /No live business required/);
+  assert.doesNotMatch(res.stdout, /business-slug|business log history/i);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A one-word `atris log "text"` was documented as add-an-idea-to-inbox. Actual: it treated the word as a live business slug, printed `Business not found`, and exited 1. First-minute capture was broken.

`atris log "text"` now writes the idea to today's local Inbox. One word is still an idea. No live business is required. Headless. No wizard.

`atris log "text" --json` returns real JSON:

```
{ "ok": true, "action": "inbox_capture", "id": "I1", "note": "text", "journal": "atris/logs/...", "next_command": "atris logs" }
```

`atris log --json` without a note is also JSON, not prose. `log sync` is unchanged.

**Verify**

```
node --test test/log-inbox.test.js test/dogfood-papercuts.test.js test/dogfood-p0.test.js test/logs-digest.test.js
```

Local run: 29 tests passed. Live one-word `atris log friction --json` wrote `I1` to the workspace journal and exited 0.

Does not touch the first-minute, task-new, do, autopilot, or unbound-live-write surfaces.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e20e3674-2a01-499d-a9d8-75a7f238e334?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e20e3674-2a01-499d-a9d8-75a7f238e334&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

