### PR TITLE
dogfood: autopilot from scratch must not mint a room

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1063,7 +1063,7 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 - **Goal-selection rank:** `commands/mission.js` `missionGoalSelectionRank` — fresh goal selection in `selectAtrisGoalMission`/`selectCodexGoalMission` ranks running < planning < ready before recency, so review-parked missions never outrank moving work
 - **Native Codex goal runner boundary:** `commands/mission.js` `selectCodexGoalMission` selects only `codex_goal` runners, matching the fail-closed `ackMissionGoal` contract; `caller_session` and `current_agent` missions stay executable through their own loop without emitting an impossible native-goal create/ack request. Regression: `test/mission-status.test.js` (`mission goal skips caller-session missions that cannot use the native Codex ack`).
 - **Stop/status:** `atris autopilot stop` / `atris autopilot status`; state in `.atris/state/autopilot.json`, stop marker `.atris/state/autopilot.stop`
-- **Dispatch:** `bin/atris.js` `command === 'run'` and `command === 'autopilot'` branches — default routes to the fronts, `--legacy` routes to the old loops below
+- **Dispatch:** `bin/atris.js` `command === 'run'` and `command === 'autopilot'` branches — default routes to the fronts, `--legacy` routes to the old loops below; autopilot skips `applyRunnerFlags` on help and unbound scratch so engine registry seed cannot mint `.atris/state`
 - **Regression:** `test/front-doors.test.js`
 
 **Search:** `rg "runMissionFront|autopilotFront|legPlan" commands/run-front.js commands/autopilot-front.js`

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -2454,7 +2454,20 @@ if (command === 'init') {
   process.exit(code);
 } else if (command === 'autopilot') {
   const args = process.argv.slice(3);
-  applyRunnerFlags(args);
+  const { isUnboundScratchFolder, refuseUnboundScratch } = require('../lib/scratch-root');
+  const { resolveWorkspaceRoot } = require('../lib/mission-root');
+  const autopilotRoot = resolveWorkspaceRoot(process.cwd());
+  const autopilotHelp = argsWantHelp(args) || args[0] === 'help';
+  const autopilotControl = args[0] === 'stop' || args[0] === 'status';
+  const autopilotJsonPlan = args.includes('--json') && !args.includes('--yes') && !args.includes('-y');
+  // applyRunnerFlags seeds .atris/state/engines.json. Help, stop/status, JSON
+  // plan, and an unbound scratch start must not mint a room. --yes is not an unlock.
+  if (!autopilotHelp && !autopilotControl && !autopilotJsonPlan && isUnboundScratchFolder(autopilotRoot)) {
+    process.exit(refuseUnboundScratch());
+  }
+  if (!autopilotHelp && !isUnboundScratchFolder(autopilotRoot)) {
+    applyRunnerFlags(args);
+  }
 
   if (args.includes('--legacy')) {
     const legacyArgs = args.filter(a => a !== '--legacy');

--- a/test/dogfood-spaceship-scratch.test.js
+++ b/test/dogfood-spaceship-scratch.test.js
@@ -111,6 +111,24 @@ test('unbound scratch spaceship without --yes still prints the plan only', () =>
   }
 });
 
+test('unbound scratch autopilot --json still JSON and does not start', () => {
+  const dir = makeScratch();
+  const env = isolatedEnv(dir);
+  try {
+    const res = runCli(['autopilot', '--json'], { cwd: dir, env });
+    assert.equal(res.status, 2, res.stdout + res.stderr);
+    const body = JSON.parse(res.stdout);
+    assert.equal(body.ok, false);
+    assert.equal(body.command, 'autopilot');
+    assert.equal(body.running, false);
+    assert.match(String(body.error || ''), /--yes|usage/i);
+    assert.doesNotMatch(combined(res), /this folder is not a room|Autopilot on|Takeoff/i);
+    assertNoMint(dir);
+  } finally {
+    cleanup(dir);
+  }
+});
+
 test('unbound scratch spaceship --json still JSON and does not start', () => {
   const dir = makeScratch();
   const env = isolatedEnv(dir);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The start-path lock from the previous change already refuses overnight work from an empty scratch folder. Autopilot still wrote `.atris/state` first, because engine setup ran before the room check.

Help and yes from an unbound scratch folder now skip that engine seed, so they exit without creating `.atris/` or starting a loop. JSON without yes still prints JSON. A folder that already has `atris/` can still start.

Verify: `node --test test/dogfood-spaceship-scratch.test.js test/scratch-root-room.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0355de12-e1b9-40ee-98ab-18e39c7ea8d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0355de12-e1b9-40ee-98ab-18e39c7ea8d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

