### PR TITLE
hygiene: hasWorkspaceRoom stays internal, nothing imports it

### DIFF
--- a/lib/scratch-root.js
+++ b/lib/scratch-root.js
@@ -85,7 +85,6 @@ function refuseUnboundScratch(write = console.error) {
 
 module.exports = {
   UNBOUND_SCRATCH_MESSAGE,
-  hasWorkspaceRoom,
   isGenericScratchRoot,
   isUnboundScratchFolder,
   isUnderGenericScratchRoot,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The hygiene ratchet caught `hasWorkspaceRoom` as an orphaned export after #777. The helper still runs the room check inside `lib/scratch-root.js`; only the unused export is gone.

Verify: `node --test test/repo-hygiene.test.js`

Do not merge until CI is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f833bc-8b5b-423e-a618-e465a47734d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f833bc-8b5b-423e-a618-e465a47734d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

