### PR TITLE
dogfood: first-minute accept tests match the spoken line

### DIFF
--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -1221,8 +1221,8 @@ test('bare mission in a live room speaks the desk next, not the archive', () => 
     assert.equal(minute.status, 0, minute.stderr || minute.stdout);
     assert.equal(mission.status, 0, mission.stderr || mission.stdout);
     assert.equal(mission.stdout.trim(), minute.stdout.trim());
-    assert.match(mission.stdout, /write a feature map for/i);
     assert.match(mission.stdout, /waiting for your ok/);
+    assert.match(mission.stdout, /CLI-193/);
     assert.equal(nextLine(mission.stdout), nextLine(minute.stdout));
     assert.match(nextLine(mission.stdout), /^atris task accept CLI-193$/);
     assert.equal((mission.stdout.match(/^Mission:/mg) || []).length, 0, mission.stdout);
@@ -1313,8 +1313,8 @@ test('bare mission yields the desk next when a ready mission is stalled', () => 
     assert.equal(minute.status, 0, minute.stderr || minute.stdout);
     assert.equal(mission.status, 0, mission.stderr || mission.stdout);
     assert.equal(mission.stdout.trim(), minute.stdout.trim());
-    assert.match(mission.stdout, /write a feature map for/i);
     assert.match(mission.stdout, /waiting for your ok/);
+    assert.match(mission.stdout, /CLI-193/);
     assert.equal(nextLine(mission.stdout), nextLine(minute.stdout));
     assert.match(nextLine(mission.stdout), /^atris task accept CLI-193$/);
     assert.equal((mission.stdout.match(/^Mission:/mg) || []).length, 0, mission.stdout);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #788.

The picker fix is on master. The new stalled-ready regression still quoted the old title line (`"write a feature map for"`), which first-minute no longer speaks for a review row.

This keeps the real contract: bare `atris mission` matches bare `atris`, names `atris task accept CLI-193`, and does not print `Mission:`.

```
node --test --test-name-pattern='bare mission|ask and mission' test/first-minute.test.js
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64060f2a-1beb-484a-a548-011656ec6176?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64060f2a-1beb-484a-a548-011656ec6176&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

