### PR TITLE
test: referee fable override expects claude-fable-5

### DIFF
--- a/test/engine-validate.test.js
+++ b/test/engine-validate.test.js
@@ -212,7 +212,7 @@ test('referee engine override reaches the ask machinery', async () => {
     });
     assert.equal(code, 0);
     assert.equal(launchedJob.engine, 'fable');
-    assert.equal(launchedJob.model, 'claude-opus-4-8');
+    assert.equal(launchedJob.model, 'claude-fable-5');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Master CI is red on one inherited test after the Fable routing change.

`referee engine override reaches the ask machinery` still expected `claude-opus-4-8`. Current master maps Fable to `claude-fable-5`, and that is the product mapping from the Fable routing work.

This PR updates only that assertion. No engine routing, youtube, wish, mission, or golden-path changes.

Verify: `node --test test/engine-validate.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3b831c8-dc43-4790-83e8-efa46bebfda1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3b831c8-dc43-4790-83e8-efa46bebfda1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

