### PR TITLE
dogfood: recap first-minute only when the folder is empty

### DIFF
--- a/commands/recap.js
+++ b/commands/recap.js
@@ -320,8 +320,12 @@ function recapAtris(args = []) {
     return;
   }
   const root = process.cwd();
+  const daysIdx = args.indexOf('--days');
+  const days = daysIdx !== -1 ? Number(args[daysIdx + 1]) : DEFAULT_DAYS;
+  const data = buildRecapData(root, { days });
   if (
-    isFreshWorkspace(root)
+    data.empty
+    && isFreshWorkspace(root)
     && !args.includes('--verbose')
     && !args.includes('--full')
     && !args.includes('--share')
@@ -331,9 +335,6 @@ function recapAtris(args = []) {
       asJson: args.includes('--json'),
     });
   }
-  const daysIdx = args.indexOf('--days');
-  const days = daysIdx !== -1 ? Number(args[daysIdx + 1]) : DEFAULT_DAYS;
-  const data = buildRecapData(root, { days });
   if (args.includes('--json')) {
     console.log(JSON.stringify(data, null, 2));
     return;

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -597,7 +597,7 @@ test('first talk files the user sentence and names it as the win', () => {
 
     const after = runCli([], { cwd: dir, env });
     assert.equal(after.status, 0, after.stderr || after.stdout);
-    assert.match(after.stdout, /a notes app for keshav is ready to claim/);
+    assert.match(after.stdout, /"a notes app for keshav" is ready to claim/);
     assert.doesNotMatch(after.stdout, /first useful step/i);
   } finally {
     cleanupTempDir(dir);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the first-talk win change.

Empty-folder recap still matches bare atris. Folders that already have task history keep their recap, even when `atris/` is missing.

Also tightens the first-talk claim line so it matches the quoted title first-minute already speaks.

Verify:

```
node --test test/first-minute.test.js test/recap.test.js
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0642d128-c959-433c-a40d-abebec8c1916?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0642d128-c959-433c-a40d-abebec8c1916&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

