### PR TITLE
dogfood: keep the clipped commit subject readable

### DIFF
--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -354,7 +354,9 @@ function spokenVisibleNames(files) {
 }
 
 function spokenCommitSubject(value) {
-  return clip(value, 72).replace(/[.,;:!?]+$/g, '');
+  const text = clip(value, 72);
+  if (text.endsWith('...')) return text;
+  return text.replace(/[.,;:!?]+$/g, '');
 }
 
 function headCommitSubject(root = process.cwd()) {

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -151,7 +151,7 @@ test('fresh first-minute names a git commit already here instead of files', () =
   });
   assert.equal(json.reason, 'add notes app is already here');
   assert.equal(json.next_action, 'atris do');
-  const long = 'add a notes app that remembers every idea keshav ever wrote down and then some';
+  const long = 'add a notes app that remembers every idea keshav ever wrote down plus backups sharing and a home screen';
   const clipped = renderFresh({
     person: 'keshav',
     folder: 'this folder',
@@ -159,7 +159,7 @@ test('fresh first-minute names a git commit already here instead of files', () =
     commit: long,
   });
   assert.match(clipped, /hey keshav, .+\.\.\. is already here\./);
-  assert.doesNotMatch(clipped, /then some|git log|master|[0-9a-f]{7,}/);
+  assert.doesNotMatch(clipped, /home screen|git log|master|[0-9a-f]{7,}/);
   assert.match(clipped, /^next: atris do$/m);
   const hiddenOnly = renderFresh({
     person: 'keshav',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A long last commit was getting cut, then losing the clip mark, so the spoken line looked unfinished.

This keeps the last words on a full word and leaves the clip mark in place. Short subjects, file-only folders, empty repos, first-talk, and do-from-files stay the same.

Verify: `node --test test/first-minute.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b75a93c6-40e4-46a1-a19b-2d3dc7491d57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b75a93c6-40e4-46a1-a19b-2d3dc7491d57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

