### PR TITLE
dogfood: land in an empty folder is one sentence

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -541,15 +541,16 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 **Purpose:** Work is merged or reaped, never limbo — the board shows every unlanded branch/worktree; `--reap` salvages then deletes anything landed or past TTL
 
-- **Implementation:** `commands/land.js` (collectBoard, printBoard, reap, landSummary); the board orders overdue, active, then landed residue, labels aging active rows `stale`, and keeps fresh rows `in the air`; counts separate tracked, stale, overdue, and landed work
-- **Router:** `bin/atris.js` (`command === 'land'` dispatch)
+- **Implementation:** `commands/land.js` (collectBoard, printBoard, reap, landSummary, printEmptyLand); the board orders overdue, active, then landed residue, labels aging active rows `stale`, and keeps fresh rows `in the air`; counts separate tracked, stale, overdue, and landed work
+- **Empty / unborn repo:** `printEmptyLand` (`commands/land.js`) prints one human sentence on stdout and exits 2; `--json` is a compact refuse receipt; never a stack or wizard. `landSummary` returns null when there is no git history.
+- **Router:** `bin/atris.js` (`command === 'land'` dispatch); leftover throws print one line and exit 2
 - **Boot visibility:** `bin/atris.js` boot status (`landing` row via `landSummary`)
 - **Doctrine:** `atris.md` operating rules ("land or reap"), `AGENTS.md` agent contract table
 - **Salvage:** bundles + dirty patches under `.atris/salvage/<date>/` — a reap never loses work
-- **Regression:** `test/land.test.js` (board classification, category-specific cleanup guidance, reap, dry-run, worktree patch salvage)
+- **Regression:** `test/land.test.js` (board classification, empty folder, init-with-no-commits, category-specific cleanup guidance, reap, dry-run, worktree patch salvage); `test/dogfood-p1.test.js` (`land in empty repo prints one-line error without stack`)
 - **Value:** hundreds of agents can fan out without work silently dying in branches nobody merges
 
-**Search:** `rg "collectBoard|landCommand|hasCommits|no commits yet" commands/land.js bin/atris.js test/dogfood-p1.test.js`
+**Search:** `rg "collectBoard|landCommand|printEmptyLand|hasCommits|no commits" commands/land.js bin/atris.js test/land.test.js test/dogfood-p1.test.js`
 
 ### Feature: Member Worktrees (`atris worktree`)
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -1944,18 +1944,14 @@ if (command === 'init') {
     .catch((err) => { console.error(`\n✗ Error: ${err.message || err}`); process.exit(1); });
 } else if (command === 'land') {
   // landCommand can throw synchronously on empty repos; wrap so callers get a
-  // one-line error instead of an uncaught stack from Promise.resolve(fn()).
+  // one-line sentence instead of an uncaught stack from Promise.resolve(fn()).
   Promise.resolve()
     .then(() => require('../commands/land').landCommand(process.argv.slice(3)))
-    .then((code) => process.exit(code || 0))
+    .then((code) => process.exit(typeof code === 'number' ? code : 0))
     .catch((err) => {
-      const msg = String(err && err.message || err || '');
-      if (/no master\/main|no commits|not a git/i.test(msg)) {
-        console.error(msg);
-      } else {
-        console.error(`land: ${msg}`);
-      }
-      process.exit(1);
+      const msg = String(err && err.message || err || 'land could not run').split('\n')[0];
+      console.log(msg);
+      process.exit(2);
     });
 } else if (command === 'caretaker') {
   Promise.resolve(require('../commands/caretaker').caretakerCommand(process.argv.slice(3)))

--- a/commands/land.js
+++ b/commands/land.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { runGit } = require('../lib/git-spawn');
+const { compactErrorPayload, printCliJson } = require('../lib/cli-json');
 const { listWorktrees, statusCounts } = require('./worktree');
 
 const DEFAULT_TTL_DAYS = 7;
@@ -236,14 +237,18 @@ function collectBoard(root, { ttlDays = DEFAULT_TTL_DAYS, staleHours = DEFAULT_S
 // merged branch residue.
 function landSummary(cwd = process.cwd(), ttlDays = DEFAULT_TTL_DAYS) {
   const root = repoRoot(cwd);
-  if (!root) return null;
-  const board = collectBoard(root, { ttlDays, light: true });
-  return {
-    branches: board.summary.active + board.summary.due,
-    due: board.summary.due,
-    stale: board.summary.stale,
-    ttlDays,
-  };
+  if (!root || !hasCommits(root)) return null;
+  try {
+    const board = collectBoard(root, { ttlDays, light: true });
+    return {
+      branches: board.summary.active + board.summary.due,
+      due: board.summary.due,
+      stale: board.summary.stale,
+      ttlDays,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function salvageDir(root) {
@@ -636,6 +641,40 @@ function readFollowingFlag(args, name, fallback = '') {
   return args[idx + 1] || fallback;
 }
 
+const EMPTY_LAND = {
+  not_a_git_repo: 'this folder is not a git repo yet, so there is nothing to land.',
+  no_commits: 'nothing is in the air yet because this folder has no commits.',
+  no_base: 'no master or main branch yet, so there is nothing to land.',
+};
+
+function emptyLandKindFromError(err) {
+  if (err && err.code === 'LAND_NO_BASE') return 'no_base';
+  const msg = String(err && err.message || err || '');
+  if (/not a git/i.test(msg)) return 'not_a_git_repo';
+  if (/no commits/i.test(msg)) return 'no_commits';
+  if (/no master\/main/i.test(msg)) return 'no_base';
+  return '';
+}
+
+function printEmptyLand(kind, json) {
+  const reason = EMPTY_LAND[kind] ? kind : 'no_base';
+  const detail = EMPTY_LAND[reason];
+  if (json) {
+    const payload = compactErrorPayload({ reason, detail });
+    printCliJson(payload, payload, ['--json']);
+  } else {
+    console.log(detail);
+  }
+  return 2;
+}
+
+function finishLandError(err, json) {
+  const kind = emptyLandKindFromError(err);
+  if (kind) return printEmptyLand(kind, json);
+  console.error(String(err && err.message || err).split('\n')[0]);
+  return 2;
+}
+
 function showHelp() {
   console.log('');
   console.log('atris land: the landing, what is actually done vs still in the air');
@@ -666,20 +705,14 @@ function landCommand(args = []) {
     showHelp();
     return 0;
   }
+  const json = args.includes('--json');
   const root = repoRoot();
-  if (!root) {
-    console.error('not a git repository. fix: git init -b main');
-    return 1;
-  }
-  if (!hasCommits(root)) {
-    console.error('no commits yet. fix: git commit --allow-empty -m init');
-    return 1;
-  }
+  if (!root) return printEmptyLand('not_a_git_repo', json);
+  if (!hasCommits(root)) return printEmptyLand('no_commits', json);
   const ttlRaw = readFollowingFlag(args, '--ttl', '');
   const ttlParsed = Number(ttlRaw);
   const ttlDays = ttlRaw !== '' && Number.isFinite(ttlParsed) && ttlParsed >= 0 ? ttlParsed : DEFAULT_TTL_DAYS;
   const base = readFollowingFlag(args, '--base', '');
-  const json = args.includes('--json');
 
   if (args.includes('--reap')) {
     try {
@@ -688,8 +721,7 @@ function landCommand(args = []) {
       else printReceipt(receipt);
       return 0;
     } catch (err) {
-      console.error(String(err && err.message || err));
-      return 1;
+      return finishLandError(err, json);
     }
   }
 
@@ -706,8 +738,7 @@ function landCommand(args = []) {
       else printStory(story);
       return 0;
     } catch (err) {
-      console.error(String(err && err.message || err));
-      return 1;
+      return finishLandError(err, json);
     }
   }
 
@@ -717,8 +748,7 @@ function landCommand(args = []) {
     else printBoard(board);
     return 0;
   } catch (err) {
-    console.error(String(err && err.message || err));
-    return 1;
+    return finishLandError(err, json);
   }
 }
 

--- a/test/dogfood-p1.test.js
+++ b/test/dogfood-p1.test.js
@@ -115,11 +115,13 @@ test('land in empty repo prints one-line error without stack', () => {
   try {
     spawnSync('git', ['init', '-b', 'main', '-q'], { cwd: dir });
     const result = run(['land'], dir);
-    assert.equal(result.status, 1);
+    assert.equal(result.status, 2);
     const err = `${result.stderr || ''}${result.stdout || ''}`;
-    assert.match(err, /no commits yet/i);
+    assert.match(err, /no commits/i);
     assert.doesNotMatch(err, /at Object\.landCommand|Error: no master/);
     assert.doesNotMatch(err, /node:internal/);
+    const spoken = err.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    assert.equal(spoken.length, 1, err);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/land.test.js
+++ b/test/land.test.js
@@ -381,3 +381,71 @@ test('countLabel uses singular nouns for a count of one', () => {
   assert.equal(countLabel(0, 'day'), '0 days');
   assert.equal(countLabel(2, 'change'), '2 changes');
 });
+
+function spokenLines(result) {
+  return `${result.stdout || ''}\n${result.stderr || ''}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function assertCalmLandEmpty(result, pattern) {
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  const spoken = spokenLines(result);
+  assert.equal(spoken.length, 1, spoken.join('\n'));
+  assert.match(spoken[0], pattern);
+  assert.doesNotMatch(spoken[0], /—/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, /at Object\.|Error: no master|node:internal|Describe the desired|what do you want/i);
+}
+
+test('land in an empty folder prints one sentence and no stack', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-land-empty-folder-'));
+  try {
+    const result = runCli(['land'], dir);
+    assertCalmLandEmpty(result, /not a git repo yet/);
+
+    const json = runCli(['land', '--json'], dir);
+    assert.equal(json.status, 2, json.stderr || json.stdout);
+    const payload = JSON.parse(json.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.reason, 'not_a_git_repo');
+    assert.match(payload.detail, /not a git repo yet/);
+    assert.doesNotMatch(`${json.stdout}${json.stderr}`, /at Object\.|node:internal/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('land after git init with no commits prints one sentence and no stack', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-land-init-empty-'));
+  try {
+    spawnSync('git', ['init', '-b', 'main', '-q'], { cwd: dir, encoding: 'utf8' });
+    const result = runCli(['land'], dir);
+    assertCalmLandEmpty(result, /no commits/);
+
+    const json = runCli(['land', '--json'], dir);
+    assert.equal(json.status, 2, json.stderr || json.stdout);
+    const payload = JSON.parse(json.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.reason, 'no_commits');
+    assert.match(payload.detail, /no commits/);
+    assert.doesNotMatch(`${json.stdout}${json.stderr}`, /at Object\.|node:internal|fix: git/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('land with commits but no master or main prints one sentence and no stack', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-land-no-base-'));
+  try {
+    runGit(['init', '-b', 'develop'], dir);
+    runGit(['config', 'user.email', 'test@example.com'], dir);
+    runGit(['config', 'user.name', 'Test'], dir);
+    runGit(['commit', '--allow-empty', '-m', 'init'], dir);
+    const result = runCli(['land'], dir);
+    assertCalmLandEmpty(result, /no master or main/);
+    assert.doesNotMatch(`${result.stdout}${result.stderr}`, /fix: git checkout/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});

--- a/test/land.test.js
+++ b/test/land.test.js
@@ -15,6 +15,7 @@ function makeTempRepo() {
   runGit(['init', '-b', 'master'], repo);
   runGit(['config', 'user.email', 'test@example.com'], repo);
   runGit(['config', 'user.name', 'Test'], repo);
+  runGit(['config', 'commit.gpgsign', 'false'], repo);
   fs.writeFileSync(path.join(repo, 'README.md'), '# fixture\n');
   runGit(['add', '.'], repo);
   runGit(['commit', '-m', 'init'], repo);
@@ -441,6 +442,7 @@ test('land with commits but no master or main prints one sentence and no stack',
     runGit(['init', '-b', 'develop'], dir);
     runGit(['config', 'user.email', 'test@example.com'], dir);
     runGit(['config', 'user.name', 'Test'], dir);
+    runGit(['config', 'commit.gpgsign', 'false'], dir);
     runGit(['commit', '--allow-empty', '-m', 'init'], dir);
     const result = runCli(['land'], dir);
     assertCalmLandEmpty(result, /no master or main/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Empty or brand-new repos made `atris land` look like a crash (`no master/main branch found`, or a one-line error on stderr with exit 1).

`atris land` now prints one human sentence on stdout and exits 2. `--json` is a compact refuse receipt. No stack, no wizard.

Covered:
- empty folder (not a git repo)
- `git init -b main` with zero commits
- commits on a branch that is not master/main

Verify: `node --test test/land.test.js test/dogfood-p1.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13aa9911-a9d9-434d-b431-2f1725ce28bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13aa9911-a9d9-434d-b431-2f1725ce28bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

