### PR TITLE
dogfood: atris next is first-minute talk

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -28,7 +28,7 @@ For details, read `atris/wiki/concepts/owner-computer-model.md` before changing 
 
 ```bash
 # Core CLI logic
-rg "async function interactiveEntry|shouldGatherContext|renderContextGathererPrompt|buildFirstMinute|listUserVisibleWork|visibleWorkTitle|headCommitSubject|headBranchName|listDirtyWork|startFirstTalk|freshWinLine|freshNextCommand|laterNotePath|writeLaterNote|shouldAutoInitFresh|isTaskNextLook|isLeftoverVerbLook|isFirstTalkLine" bin/atris.js lib/context-gatherer.js lib/first-minute.js commands/later.js    # Main entry points: cold-start dispatcher, first-minute bare atris screen, first-contact context gatherer, leftover task next and leftover words after brainstorm/wish/log/plan/do/later/mission are a look not first-talk, pasted talk line is first-talk not overview, a folder with user-visible files is named not empty, a git repo with a HEAD commit names that subject instead of the file listing, a named feature branch names the branch instead of the commit, a dirty tree names one or two open files or this folder still has open work, atris later remembers words in .atris-later without minting, atris do starts from those files, legacy natural-language mode
+rg "async function interactiveEntry|shouldGatherContext|renderContextGathererPrompt|buildFirstMinute|listUserVisibleWork|visibleWorkTitle|headCommitSubject|headBranchName|listDirtyWork|startFirstTalk|freshWinLine|freshNextCommand|laterNotePath|writeLaterNote|shouldAutoInitFresh|isTaskNextLook|isLeftoverVerbLook|isFirstTalkLine" bin/atris.js lib/context-gatherer.js lib/first-minute.js commands/later.js    # Main entry points: cold-start dispatcher, first-minute bare atris screen, first-contact context gatherer, leftover task next and leftover words after brainstorm/wish/log/plan/do/later/mission/next are a look not first-talk, pasted talk line is first-talk not overview, a folder with user-visible files is named not empty, a git repo with a HEAD commit names that subject instead of the file listing, a named feature branch names the branch instead of the commit, a dirty tree names one or two open files or this folder still has open work, atris later remembers words in .atris-later without minting, atris do starts from those files, legacy natural-language mode
 rg "pickLane|loadOverrides|routerCommand|promotionCandidates|autoLaneForMessage|appendAutoOutcome|modelForMode|buildPayload|connectorTurnPolicy|formatApprovalReceipt|formatTaskPreviewRows|resolveRoute|formatUsage|normalizeChatCommandArgs|CHAT_COMMANDS|filterChatCommands|attachSlashMenu|attachChatCtrlC|runChatSlash|async function chat|postTurn|runAxSpawnCommand|runAxYoutubeCommand|runChatDogfood|extractYoutubeUrl|AX Cloud-First Standard|verify-ax-cloud-standard" ax lib/ax-auto-lane.js commands/router.js test/ax-auto-lane.test.js test/router-promote.test.js test/cli-smoke.test.js test/ax.test.js scripts/verify-ax-cloud-standard.js atris/team/codex-executor/MEMBER.md  # ax Atris2 local coding-agent CLI: deterministic explainable auto lane selection, local outcome traces, reflex overrides, gated promotion, cloud-first by default, explicit --local workspace opt-in, Fast/Pro/Max/Code Fast modes, SSE streaming, workspace_path, readline slash menu and Ctrl-C conventions, chat history, connector turn isolation, Gmail approval previews, doctor/help, durable worker spawn aliases, local YouTube URL routing, and safe 25-loop --dogfood-chat checklist
 rg "atrisFastChat|atrisFastOnce|streamProChat|text_delta|Usage: atris fast" bin/atris.js utils/api.js test/commands.test.js test/api-stream.test.js  # Atris2 Fast one-shot chat CLI and SSE text_delta streaming
 rg "brainstormAtris|Usage: atris brainstorm|brainstorm help|addInboxIdea|speakFirstMinute|Describe the desired outcome" commands/brainstorm.js lib/first-minute.js test/brainstorm-headless.test.js test/first-minute.test.js test/commands.test.js test/dogfood-p0.test.js  # Brainstorm: empty folder reuses speakFirstMinute (no mint); after init a named idea captures inbox and exits; no wizard; --json is a receipt or first-minute refuse
@@ -1415,15 +1415,16 @@ rg "printRoster|registryPayload|--global" commands/engine.js test/engine.test.js
 
 ### Feature: Auto-Advance (`atris next`)
 
-**Purpose:** Auto-advance to next workflow step based on journal state
+**Purpose:** First-minute talk for the next pasteable command. Two spoken lines. No fake yes/no.
 
-- **Entry point:** `bin/atris.js:1182` (interactiveEntry function)
-- **Help:** `bin/atris.js:769-779` (`showNextHelp`) and `bin/atris.js:1366-1373` route `next --help` before `interactiveEntry`
-- **Regression:** `test/commands.test.js:4310-4324` covers next help without context panels or temp state creation
-- **Logic:** Same as natural language entry - loads context, detects state, advances
-- **Value:** Single-command workflow progression without typing a description
+- **Command:** `commands/next.js:190` (`nextCommand`) speaks first-minute via `speakNext` (`commands/next.js:81`)
+- **Help:** `commands/next.js:21` prints `Usage: atris next [--json]`. `bin/atris.js:2541` routes `next` to that command. `bin/atris.js:880` (`showNextHelp`) stays for `atris atris --help`
+- **Look:** empty folder and inited rooms reuse `buildFirstMinute` / `freshMinuteJson`. `--json` is `atris.one_lap.v1` with `next_action`. Exit 0. Headless. `ATRIS_NO_INTERACTIVE=1` never prompts
+- **Explicit verbs:** `yes` / `no` / `skip` still act on a next-moves card. Skip talks first-minute (`speakCard`). No `Do it?` line
+- **Leftover:** quoted `next hi` is a look (`lib/first-minute.js` `LEFTOVER_LOOK_VERBS`)
+- **Regression:** `test/next-card.test.js`, `test/dream.test.js` (`next ranker deals and consumes a dream card`), `test/commands.test.js` (`activate and next --help`)
 
-**Search:** `rg "command === 'next'|showNextHelp|activate and next --help" bin/atris.js test/commands.test.js`
+**Search:** `rg "nextCommand|speakNext|Do it\\?|atris next --json" commands/next.js test/next-card.test.js bin/atris.js`
 
 ### Feature: github cli integration (`atris github`)
 

--- a/commands/next.js
+++ b/commands/next.js
@@ -1,5 +1,14 @@
 'use strict';
 
+const { argsWantHelp, wantsJson } = require('../lib/noninteractive');
+const {
+  buildFirstMinute,
+  folderName,
+  freshMinuteJson,
+  isFreshWorkspace,
+  listUserVisibleWork,
+} = require('../lib/first-minute');
+const { loadContext } = require('../lib/state-detection');
 const {
   claimRoadmapItem,
   nextCards,
@@ -9,70 +18,146 @@ const {
   seedInboxFromMove,
 } = require('../lib/next-moves');
 
-function showHelp() {
-  console.log('');
-  console.log('Usage: atris next [yes|no|skip]');
-  console.log('');
-  console.log('Shows one next move card.');
-  console.log('');
+function showHelp(log = console.log) {
+  log('Usage: atris next [--json]');
   return 0;
+}
+
+function spokenWin(text) {
+  return String(text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean) || '';
+}
+
+function minuteText(screen) {
+  const win = spokenWin(screen && screen.text);
+  const next = String(screen && screen.nextCommand || '').trim();
+  if (!next) return win || 'nothing is waiting.';
+  return `${win}\n\nnext: ${next}`;
+}
+
+function minuteJson(screen, extra = {}) {
+  const reason = spokenWin(screen && screen.text).replace(/\.$/, '');
+  const next = String((screen && screen.nextCommand) || extra.next_action || '').trim();
+  const fresh = extra.fresh === true;
+  return {
+    schema: 'atris.one_lap.v1',
+    ok: Boolean(next) && !fresh,
+    status: fresh ? 'stuck' : (next ? 'ok' : 'stuck'),
+    reason,
+    next_action: next,
+  };
+}
+
+function printMinute(screen, { asJson = false, log = console.log, fresh = false } = {}) {
+  if (asJson) {
+    log(JSON.stringify(minuteJson(screen, { fresh }), null, 2));
+    return 0;
+  }
+  log('');
+  log(minuteText(screen));
+  return 0;
+}
+
+function nextScreen(root) {
+  const fresh = isFreshWorkspace(root);
+  if (fresh) {
+    return {
+      fresh: true,
+      screen: buildFirstMinute({ root, fresh: true }),
+    };
+  }
+  return {
+    fresh: false,
+    screen: buildFirstMinute({
+      root,
+      fresh: false,
+      context: loadContext(root),
+    }),
+  };
+}
+
+function speakNext(root, { asJson = false, log = console.log } = {}) {
+  const { fresh, screen } = nextScreen(root);
+  if (asJson && fresh) {
+    log(JSON.stringify(freshMinuteJson(folderName(root), listUserVisibleWork(root), { root }), null, 2));
+    return 0;
+  }
+  return printMinute(screen, { asJson, log, fresh });
 }
 
 function cardLabel(card) {
   return String(card?.label || card?.title || '').trim();
 }
 
-function cardWhy(card) {
-  const why = String(card?.why || '').trim();
-  if (why) return why;
-  const status = String(card?.status || '').trim();
-  if (status) return status;
-  if (card?.source === 'task' || card?.source === 'mission') return 'working';
-  return 'new';
+function cardNextCommand(card) {
+  if (!card) return '';
+  const action = card.next_action || {};
+  const prompt = String(action.prompt || '').trim();
+  if (/^(atris|ax)\b/i.test(prompt)) return prompt;
+  if (action.type === 'mission_complete' && action.mission_id) {
+    if (action.proof_path) {
+      return `atris mission complete ${action.mission_id} --proof ${action.proof_path}`;
+    }
+    return `atris mission status ${action.mission_id}`;
+  }
+  if (action.type === 'mission_review_prompt' && action.mission_id) {
+    return `atris mission status ${action.mission_id}`;
+  }
+  if (action.type === 'wish_answer_prompt') return 'atris wish answer "your words"';
+  if (card.source === 'inbox') return 'atris plan';
+  if (card.source === 'task' || card.source === 'roadmap' || card.source === 'endgame') {
+    return 'atris do';
+  }
+  if (card.source === 'mission') {
+    const id = action.mission_id || card.ref;
+    return id ? `atris mission status ${id}` : 'atris mission status --status active';
+  }
+  return '';
 }
 
-function renderCard(card) {
-  if (!card) return 'Nothing to do. Rest or wish.';
-  return [
-    cardLabel(card),
-    `Why now: ${cardWhy(card)}`,
-    'Do it? yes / no / skip',
-  ].join('\n');
-}
-
-function printCard(card) {
-  console.log(renderCard(card));
+function speakCard(card, { asJson = false, log = console.log } = {}) {
+  if (!card) {
+    return printMinute({ text: 'nothing is waiting.', nextCommand: '' }, { asJson, log });
+  }
+  const next = cardNextCommand(card);
+  const label = cardLabel(card) || 'this';
+  return printMinute({
+    text: `${label} is waiting.`,
+    nextCommand: next,
+  }, { asJson, log });
 }
 
 function wishPromptTitle(label) {
   return String(label || 'this').replace(/^(#\d+)\s+/, '$1: ');
 }
 
-function printWishAnswerPrompt(card) {
+function printWishAnswerPrompt(card, log = console.log) {
   const action = card.next_action || {};
-  console.log(`Got it, wish ${wishPromptTitle(action.label || cardLabel(card))}.`);
-  console.log(String(action.question || 'What should be different when this wish comes true?'));
-  console.log('Answer with: atris wish answer "your words"');
+  log(`Got it, wish ${wishPromptTitle(action.label || cardLabel(card))}.`);
+  log(String(action.question || 'What should be different when this wish comes true?'));
+  log('Answer with: atris wish answer "your words"');
   return 0;
 }
 
-function approveMove(card, root) {
+function approveMove(card, root, log = console.log) {
   recordDecision(root, card, 'approve', new Date().toISOString());
   if (['roadmap', 'inbox', 'endgame'].includes(card.source)) {
     seedInboxFromMove(root, card);
     if (card.source === 'roadmap') claimRoadmapItem(root, card.title);
-    console.log(`${cardLabel(card)} is working.`);
+    log(`${cardLabel(card)} is working.`);
     return 0;
   }
   const prompt = card.next_action && card.next_action.prompt;
-  console.log(prompt || `${cardLabel(card)} is working.`);
+  log(prompt || `${cardLabel(card)} is working.`);
   return 0;
 }
 
-function completeMissionFromCard(card) {
+function completeMissionFromCard(card, log = console.log) {
   const action = card.next_action || {};
   if (!action.mission_id || !action.proof_path) {
-    console.log('Review the proof, then complete this mission.');
+    log('Review the proof, then complete this mission.');
     return 0;
   }
   const { completeMission } = require('./mission');
@@ -80,57 +165,65 @@ function completeMissionFromCard(card) {
   return 0;
 }
 
-function executeCard(card, root) {
+function executeCard(card, root, log = console.log) {
   const action = card && card.next_action;
-  if (!card) {
-    printCard(null);
-    return 0;
-  }
-  if (action?.type === 'wish_answer_prompt') return printWishAnswerPrompt(card);
-  if (action?.type === 'mission_complete') return completeMissionFromCard(card);
+  if (!card) return speakCard(null, { log });
+  if (action?.type === 'wish_answer_prompt') return printWishAnswerPrompt(card, log);
+  if (action?.type === 'mission_complete') return completeMissionFromCard(card, log);
   if (action?.type === 'wish_review_prompt' || action?.type === 'mission_review_prompt') {
-    console.log(action.prompt || 'Review the proof, then choose done or stuck.');
+    log(action.prompt || 'Review the proof, then choose done or stuck.');
     return 0;
   }
-  return approveMove(card, root);
+  return approveMove(card, root, log);
 }
 
-function nextCommand(args = [], root = process.cwd()) {
-  const action = String(args[0] || '').trim().toLowerCase();
-  if (action === 'help' || action === '--help' || action === '-h') return showHelp();
+function actionToken(args = []) {
+  const list = Array.isArray(args) ? args : [];
+  const token = list.find((arg) => {
+    const text = String(arg || '').trim();
+    if (!text || text.startsWith('-')) return false;
+    return true;
+  });
+  return String(token || '').trim().toLowerCase();
+}
+
+function nextCommand(args = [], root = process.cwd(), { log = console.log } = {}) {
+  const list = Array.isArray(args) ? args : [];
+  if (argsWantHelp(list)) return showHelp(log);
+
+  const asJson = wantsJson(list);
+  const action = actionToken(list);
+
+  if (!action || action === 'json') return speakNext(root, { asJson, log });
 
   const current = nextCards(root, 1)[0] || null;
-  if (!action) {
-    printCard(current);
-    if (current?.source === 'dream') markDreamCardConsumed(root, current, new Date().toISOString(), 'dealt');
-    return 0;
-  }
 
   if (action === 'skip') {
     const following = current ? nextCards(root, 1, { skipIds: [current.id] })[0] : null;
-    if (current?.source === 'dream') markDreamCardConsumed(root, current, new Date().toISOString(), 'skipped');
-    printCard(following);
-    if (following?.source === 'dream') markDreamCardConsumed(root, following, new Date().toISOString(), 'dealt');
-    return 0;
+    if (current?.source === 'dream') {
+      markDreamCardConsumed(root, current, new Date().toISOString(), 'skipped');
+    }
+    if (following?.source === 'dream') {
+      markDreamCardConsumed(root, following, new Date().toISOString(), 'dealt');
+    }
+    return speakCard(following, { asJson, log });
   }
 
   if (action === 'no') {
-    if (!current) {
-      printCard(null);
-      return 0;
-    }
+    if (!current) return speakCard(null, { asJson, log });
     parkNextCard(root, current);
-    console.log(`Parked ${cardLabel(current)}.`);
+    log(`Parked ${cardLabel(current)}.`);
     return 0;
   }
 
-  if (action === 'yes') return executeCard(current, root);
+  if (action === 'yes') return executeCard(current, root, log);
 
-  console.log('Say yes, no, or skip.');
-  return 2;
+  return speakNext(root, { asJson, log });
 }
 
 module.exports = {
+  cardNextCommand,
+  minuteJson,
+  minuteText,
   nextCommand,
-  renderCard,
 };

--- a/lib/first-minute.js
+++ b/lib/first-minute.js
@@ -773,11 +773,11 @@ function isTaskNextLook(value) {
   return /^task\s+next\b/i.test(String(value || '').trim());
 }
 
-const LEFTOVER_LOOK_VERBS = new Set(['brainstorm', 'wish', 'log', 'plan', 'do', 'later', 'mission']);
+const LEFTOVER_LOOK_VERBS = new Set(['brainstorm', 'wish', 'log', 'plan', 'do', 'later', 'mission', 'next']);
 
 // Leftover words after a known verb are not first-talk. A quoted
-// `brainstorm hi` / `wish hi` / `later hi` / `mission hi` must not
-// init a room or write a later note in an empty folder.
+// `brainstorm hi` / `wish hi` / `later hi` / `mission hi` / `next hi`
+// must not init a room or write a later note in an empty folder.
 function isLeftoverVerbLook(value) {
   const text = String(value || '').replace(/\s+/g, ' ').trim();
   if (!text) return false;

--- a/test/dream.test.js
+++ b/test/dream.test.js
@@ -100,18 +100,16 @@ test('next ranker deals and consumes a dream card', () => {
     assert.equal(cards[0].source, 'dream');
     assert.equal(cards[0].kind, 'dream');
 
-    const oldLog = console.log;
-    const lines = [];
-    console.log = (line) => lines.push(String(line));
-    try {
-      nextCommand([], root);
-    } finally {
-      console.log = oldLog;
-    }
+    const lookLines = [];
+    nextCommand([], root, { log: (line) => lookLines.push(String(line)) });
+    assert.doesNotMatch(lookLines.join('\n'), /Do it\?/);
+    assert.equal(readDreamRows(root)[0].consumed_at, undefined);
 
-    assert.match(lines.join('\n'), /Check open wishes/);
+    const yesLines = [];
+    nextCommand(['yes'], root, { log: (line) => yesLines.push(String(line)) });
+    assert.match(yesLines.join('\n'), /Check open wishes|Open atris next/);
     const rows = readDreamRows(root);
-    assert.equal(rows[0].consumed_reason, 'dealt');
+    assert.equal(rows[0].consumed_reason, 'approve');
     assert.ok(rows[0].consumed_at);
     assert.equal(nextMoves.nextCards(root, 3).some((card) => card.source === 'dream'), false);
   } finally {

--- a/test/first-minute.test.js
+++ b/test/first-minute.test.js
@@ -557,12 +557,14 @@ test('leftover words after known verbs are a look, not first talk', () => {
   assert.equal(isLeftoverVerbLook('do hi'), true);
   assert.equal(isLeftoverVerbLook('later hi'), true);
   assert.equal(isLeftoverVerbLook('mission hi'), true);
+  assert.equal(isLeftoverVerbLook('next hi'), true);
   assert.equal(isLeftoverVerbLook('BRAINSTORM HI'), true);
   assert.equal(isLeftoverVerbLook('task next'), true);
   assert.equal(isLeftoverVerbLook('task next --json'), true);
   assert.equal(isLeftoverVerbLook('brainstorm'), false);
   assert.equal(isLeftoverVerbLook('wish'), false);
   assert.equal(isLeftoverVerbLook('later'), false);
+  assert.equal(isLeftoverVerbLook('next'), false);
   assert.equal(isLeftoverVerbLook('what do you want here?'), false);
   assert.equal(isLeftoverVerbLook('count the words'), false);
   assert.equal(isLeftoverVerbLook('task new count words'), false);

--- a/test/next-card.test.js
+++ b/test/next-card.test.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const nextMoves = require('../lib/next-moves');
+const { spokenLineCount } = require('../lib/first-minute');
 const { scrubAgentEnv } = require('./helpers/agent-env');
 
 const repoRoot = path.resolve(__dirname, '..');
@@ -22,16 +23,32 @@ function cleanup(root) {
 }
 
 function runCli(args, cwd) {
+  const home = path.join(cwd, '.home');
+  fs.mkdirSync(home, { recursive: true });
   return spawnSync(process.execPath, [cliPath, ...args], {
     cwd,
     encoding: 'utf8',
     timeout: 20000,
     env: {
       ...scrubAgentEnv(),
+      HOME: home,
+      USER: 'ubuntu',
+      LOGNAME: 'ubuntu',
       ATRIS_SKIP_UPDATE_CHECK: '1',
+      ATRIS_NO_INTERACTIVE: '1',
+      ATRIS_NONINTERACTIVE: '1',
       NODE_NO_WARNINGS: '1',
     },
   });
+}
+
+function spoken(stdout) {
+  return String(stdout || '').replace(/^\n+/, '').trimEnd();
+}
+
+function nextLine(stdout) {
+  const match = String(stdout || '').match(/^next: (.+)$/m);
+  return match ? match[1] : '';
 }
 
 function appendJsonl(root, relative, rows) {
@@ -50,10 +67,20 @@ function writeTaskProjection(root, tasks) {
   fs.writeFileSync(file, JSON.stringify({ tasks }), 'utf8');
 }
 
-function writeLatestInbox(root, title) {
-  const dir = path.join(root, 'atris', 'logs', '2099');
+function writeTodayInbox(root, title) {
+  const now = new Date();
+  const year = String(now.getFullYear());
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const dir = path.join(root, 'atris', 'logs', year);
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, '2099-01-01.md'), `# Log 2099-01-01\n\n## Inbox\n\n- **I1:** ${title}\n`, 'utf8');
+  fs.writeFileSync(path.join(dir, `${year}-${month}-${day}.md`), `# Log ${year}-${month}-${day}\n\n## Inbox\n\n- **I1:** ${title}\n`, 'utf8');
+}
+
+function writeReadyRoom(root) {
+  fs.mkdirSync(path.join(root, 'atris'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'atris', 'MAP.md'), '# MAP.md\n\n## By-Feature\n- example: bin/atris.js:1\n', 'utf8');
+  fs.writeFileSync(path.join(root, 'atris', 'TODO.md'), '# TODO.md\n\n## Backlog\n\n(Empty)\n', 'utf8');
 }
 
 test('next cards rank waiting wishes, ready missions, old moves, and shipped wish reviews', () => {
@@ -63,7 +90,7 @@ test('next cards rank waiting wishes, ready missions, old moves, and shipped wis
     writeTaskProjection(root, [
       { id: 'task-1', display_id: 'CLI-1', title: 'task move', status: 'claimed', claimed_by: 'codex' },
     ]);
-    writeLatestInbox(root, 'inbox move');
+    writeTodayInbox(root, 'inbox move');
     appendJsonl(root, '.atris/state/wishes.jsonl', [
       { id: 'wish-7', n: 7, ts: '2099-01-01T00:00:00.000Z', text: 'haiku loop', status: 'needs_input', questions: ['Which kind of haiku loop?'] },
       { id: 'wish-8', n: 8, ts: '2099-01-01T00:01:00.000Z', text: 'shipped wish', status: 'complete' },
@@ -86,6 +113,70 @@ test('next cards rank waiting wishes, ready missions, old moves, and shipped wis
     assert.equal(cards[0].label, '#7 haiku loop');
     assert.equal(cards[0].status, 'waiting on you');
     assert.equal(cards.at(-1).label, '#8 shipped wish');
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('atris next is first-minute talk, not a fake yes/no', () => {
+  const root = tmp();
+  try {
+    const inboxTitle = 'already-known inbox line';
+    writeReadyRoom(root);
+    writeTodayInbox(root, inboxTitle);
+
+    const res = runCli(['next'], root);
+    assert.equal(res.status, 0, res.stderr);
+    const text = spoken(res.stdout);
+    assert.ok(spokenLineCount(text) <= 2, text);
+    assert.match(text, /^next: atris plan$/m);
+    assert.doesNotMatch(text, /Do it\?/);
+    assert.doesNotMatch(text, /yes \/ no \/ skip/);
+    assert.doesNotMatch(text, new RegExp(inboxTitle));
+    assert.match(nextLine(text), /^atris /);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('atris next --json is real JSON with a next command', () => {
+  const root = tmp();
+  try {
+    const empty = runCli(['next', '--json'], root);
+    assert.equal(empty.status, 0, empty.stderr);
+    const fresh = JSON.parse(empty.stdout);
+    assert.equal(fresh.schema, 'atris.one_lap.v1');
+    assert.equal(typeof fresh.next_action, 'string');
+    assert.match(fresh.next_action, /^atris /);
+    assert.doesNotMatch(empty.stdout, /Do it\?/);
+
+    writeReadyRoom(root);
+    writeTaskProjection(root, [
+      { id: 'task-1', display_id: 'CLI-1', title: 'claimed move', status: 'claimed', claimed_by: 'codex' },
+    ]);
+    const room = runCli(['next', '--json'], root);
+    assert.equal(room.status, 0, room.stderr);
+    const body = JSON.parse(room.stdout);
+    assert.equal(body.schema, 'atris.one_lap.v1');
+    assert.equal(body.next_action, 'atris do');
+    assert.equal(body.ok, true);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('atris next empty folder is two first-minute lines', () => {
+  const root = tmp();
+  try {
+    const res = runCli(['next'], root);
+    assert.equal(res.status, 0, res.stderr);
+    const text = spoken(res.stdout);
+    assert.equal(spokenLineCount(text), 2);
+    assert.match(text, /this folder is empty\./);
+    assert.match(text, /^next: atris "what do you want here\?"$/m);
+    assert.doesNotMatch(text, /Nothing to do/);
+    assert.doesNotMatch(text, /Do it\?/);
+    assert.equal(fs.existsSync(path.join(root, 'atris')), false);
   } finally {
     cleanup(root);
   }
@@ -127,7 +218,24 @@ test('atris next no parks the current card', () => {
     assert.equal(rows[0].label, '#1 park me');
 
     const again = runCli(['next'], root);
-    assert.equal(again.stdout.trim(), 'Nothing to do. Rest or wish.');
+    assert.doesNotMatch(again.stdout, /Do it\?/);
+    assert.match(again.stdout, /^next: /m);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('leftover words after next talk first-minute and do not mint', () => {
+  const root = tmp();
+  try {
+    const res = runCli(['next', 'hi'], root);
+    assert.equal(res.status, 0, res.stderr);
+    const text = spoken(res.stdout);
+    assert.equal(spokenLineCount(text), 2);
+    assert.match(text, /this folder is empty\./);
+    assert.doesNotMatch(text, /Do it\?/);
+    assert.doesNotMatch(text, /Say yes, no, or skip/);
+    assert.equal(fs.existsSync(path.join(root, 'atris')), false);
   } finally {
     cleanup(root);
   }
@@ -145,19 +253,12 @@ test('atris next skip deals the following card without parking', () => {
 
     const res = runCli(['next', 'skip'], root);
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /^#2 second mission\nWhy now: proof passed and needs your review\nDo it\? yes \/ no \/ skip\n$/);
+    const text = spoken(res.stdout);
+    assert.ok(spokenLineCount(text) <= 2, text);
+    assert.match(text, /#2 second mission is waiting\./);
+    assert.match(text, /^next: atris mission complete mission-2 --proof atris\/runs\/mission-2\.json$/m);
+    assert.doesNotMatch(text, /Do it\?/);
     assert.equal(fs.existsSync(path.join(root, '.atris', 'state', 'next_parked.jsonl')), false);
-  } finally {
-    cleanup(root);
-  }
-});
-
-test('atris next empty state is plain', () => {
-  const root = tmp();
-  try {
-    const res = runCli(['next'], root);
-    assert.equal(res.status, 0, res.stderr);
-    assert.equal(res.stdout.trim(), 'Nothing to do. Rest or wish.');
   } finally {
     cleanup(root);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`atris next` used to reprint an inbox line, ask `Do it? yes / no / skip`, then exit 0 without waiting. It looked interactive and was not.

It now talks like the first minute: two spoken lines, a pasteable next command, then exit 0. No fake prompt. Headless. `--json` is real JSON with `next_action`.

Explicit `yes` / `no` / `skip` still act on a card if you type them. Skip talks the same way. Looking does not consume a dream card.

Verify:

```
node --test test/next-card.test.js test/dream.test.js test/first-minute.test.js
```

All 79 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7580acde-865f-4423-b216-20b4fcb3832c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7580acde-865f-4423-b216-20b4fcb3832c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

