### PR TITLE
experiments: keep a minted pack only when measure.py moves 0 to 1

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -336,8 +336,8 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 
 - **Entry point:** `bin/atris.js` command routing for `experiments`
 - **Handler:** `commands/experiments.js`
-- **Core functions:** `commands/experiments.js:55` (`ensureExperimentsFramework`), `commands/experiments.js:310` (`buildBenchmarkArtifact`), `commands/experiments.js:409` (`experimentsRun`), `commands/experiments.js:469` (`experimentsCompare`), `commands/experiments.js:501` (`experimentsReplay`)
-- **Daily loop:** `commands/experiments.js:524` (`experimentsDaily`), `commands/experiments.js:530` (`experimentsQueue`), `commands/experiments.js:543` (`experimentsCommand` routes `daily` and `queue`)
+- **Core functions:** `commands/experiments.js:55` (`ensureExperimentsFramework`), `commands/experiments.js:141` (`parseMeasureScore`), `commands/experiments.js:154` (`runMeasureJson`), `commands/experiments.js:182` (`experimentsKeep`), `commands/experiments.js:398` (`buildBenchmarkArtifact`), `commands/experiments.js:509` (`experimentsRun`), `commands/experiments.js:571` (`experimentsCompare`), `commands/experiments.js:603` (`experimentsReplay`)
+- **Daily loop:** `commands/experiments.js:625` (`experimentsDaily`), `commands/experiments.js:631` (`experimentsQueue`), `commands/experiments.js:644` (`experimentsCommand` routes `daily`, `queue`, and `keep`)
 - **Daily engine:** `lib/experiments/daily.js:18` (`queuePath`), `lib/experiments/daily.js:53` (`readQueue`), `lib/experiments/daily.js:69` (`appendQueueEntry`), `lib/experiments/daily.js:227` (`evaluateKeepRule`), `lib/experiments/daily.js:259` (`runApplyScript`), `lib/experiments/daily.js:394` (`runDaily`), `lib/experiments/daily.js:584` (`queueAdd`), `lib/experiments/daily.js:604` (`queueList`)
 - **Autoland hook:** `commands/autoland.js:577` runs `atris experiments daily --json` during `autoland tick` when policy `daily_experiment` is not false
 - **How it works:**
@@ -345,6 +345,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris experiments init [slug]` scaffolds a new bounded experiment pack
 - `atris experiments validate` runs structural checks and context-bloat validation
 - `atris experiments run <slug>` executes a pack; Endstate packs also emit JSON receipts + append `results.tsv`
+- `atris experiments keep <slug>` runs `atris/experiments/<slug>/measure.py` against the current working tree and prints a keep line only when the score is 1 (minted packs start at 0). Score 0 prints a revert/refuse line and exits 1 without deleting the pack. Missing slug, pack, or measure.py exits 2.
 - `atris experiments compare endstate` reads the latest baseline + stack receipts, prints the side-by-side scorecard, and declares `stack wins` or `no winner yet` from the Level 1 rule
 - `atris experiments replay endstate` validates both packs, emits fresh dry-run receipts, then compares the latest result in one command
 - Endstate packs pin runner profiles in `runner.json` (`baseline-single` vs `stack-coordinated`) so baseline and stack resolve different live prompt strategies
@@ -365,10 +366,10 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris/experiments/taste-loop/` - Frozen writing, website, and video-prompt references with an independent scorer and all-modality keep/revert gate
 - `atris/experiments/sessionstart-plant/` - keep/revert metric for SessionStart plant via pack PreToolUse/config-guard; score 1 only when Write and Bash `cat >>` both deny, hash unchanged, disableAllHooks stays false, and voice-card UserPromptSubmit is still allowed (`measure.py`, `probe.js`)
 - `atris/experiments/teach-thin-save/` - keep/revert metric for `atris youtube teach --save` on a fixture thin chapter; score 1 only when the live command prints the thin refuse, writes no `atris/wiki/briefs` file, and exits 2 (`measure.py`, `probe.js`)
-- `atris/experiments/teach-<videoid>-s<n>/` - minted by rich `atris youtube teach --save`; `measure.py` is derived from that chapter's printed fail-able check and scores 1 only when the fixture contains the number-with-units or named mechanism (`loop.py` keep-0-to-1). The apply sidecar and journal Inbox claim name this pack path and the keep rule, and the sidecar omits those check tokens so baseline stays 0.
+- `atris/experiments/teach-<videoid>-s<n>/` - minted by rich `atris youtube teach --save`; `measure.py` is derived from that chapter's printed fail-able check and scores 1 only when the fixture contains the number-with-units or named mechanism (`loop.py` keep-0-to-1). The apply sidecar and journal Inbox claim name this pack path and the keep rule, and the sidecar omits those check tokens so baseline stays 0. `atris experiments keep <slug>` is the CLI gate for that rule.
 - **Value:** Makes self-improvement loops and scoreable benchmark runs first-class Atris CLI concepts instead of repo-local convention
 
-**Search:** `rg "experimentsCommand|experimentsRun|experimentsCompare|experimentsReplay|buildBenchmarkArtifact|ensureExperimentsFramework|experimentsDaily|experimentsQueue|sessionstart-plant|teach-thin-save|fileTeachExperiment|ensureTeachApply|teachExperimentSlug" commands/experiments.js commands/init.js lib/experiments/daily.js commands/autoland.js commands/youtube.js atris/experiments/sessionstart-plant atris/experiments/teach-thin-save`
+**Search:** `rg "experimentsCommand|experimentsKeep|runMeasureJson|experimentsRun|experimentsCompare|experimentsReplay|buildBenchmarkArtifact|ensureExperimentsFramework|experimentsDaily|experimentsQueue|sessionstart-plant|teach-thin-save|fileTeachExperiment|ensureTeachApply|teachExperimentSlug" commands/experiments.js commands/init.js lib/experiments/daily.js commands/autoland.js commands/youtube.js atris/experiments/sessionstart-plant atris/experiments/teach-thin-save`
 
 ### Feature: Receipts (`atris receipt`)
 

--- a/bin/atris.js
+++ b/bin/atris.js
@@ -635,6 +635,7 @@ function showHelpAll() {
   console.log('  experiments init [slug]     - Prepare atris/experiments/ or scaffold a pack');
   console.log('  experiments validate        - Validate experiment packs');
   console.log('  experiments run <slug>      - Execute a pack or record an Endstate receipt');
+  console.log('  experiments keep <slug>     - Keep a pack only when measure.py moves 0 to 1');
   console.log('  experiments benchmark [m]   - Run validate/runtime experiment benchmarks');
   console.log('  bench      - run core benchmark gates');
   console.log('');

--- a/commands/experiments.js
+++ b/commands/experiments.js
@@ -138,6 +138,93 @@ function runPython(scriptPath, args = [], cwd = process.cwd()) {
   }
 }
 
+function parseMeasureScore(stdout) {
+  const line = String(stdout || '').trim().split(/\r?\n/).filter(Boolean).pop();
+  if (!line) return { ok: false, error: 'measure.py printed no score' };
+  try {
+    const payload = JSON.parse(line);
+    const score = Number(payload.score);
+    if (!Number.isFinite(score)) return { ok: false, error: 'measure.py printed no score' };
+    return { ok: true, score, payload };
+  } catch {
+    return { ok: false, error: 'measure.py printed no score' };
+  }
+}
+
+function runMeasureJson(scriptPath, workspaceDir = process.cwd()) {
+  const python = resolvePython();
+  if (!python) {
+    return { ok: false, error: 'python not found. set ATRIS_EXPERIMENTS_PYTHON or install python3.' };
+  }
+
+  const result = spawnSync(python, [scriptPath], {
+    cwd: workspaceDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PYTHONDONTWRITEBYTECODE: '1',
+      ATRIS_REPO_ROOT: workspaceDir,
+    },
+  });
+
+  if (result.error) {
+    return { ok: false, error: result.error.message || 'measure.py failed to start' };
+  }
+
+  const parsed = parseMeasureScore(result.stdout);
+  if (!parsed.ok) {
+    const detail = String(result.stderr || '').trim().split(/\r?\n/).filter(Boolean).pop();
+    return { ok: false, error: detail || parsed.error };
+  }
+  return parsed;
+}
+
+function experimentsKeep(name) {
+  const token = String(name || '').trim();
+  if (!token || token === '--help' || token === '-h' || token === 'help') {
+    console.error('usage: atris experiments keep <slug>');
+    process.exit(2);
+  }
+  if (!SLUG_RE.test(token)) {
+    console.error('invalid experiment name. use a lowercase-hyphen slug.');
+    process.exit(2);
+  }
+
+  const workspaceDir = process.cwd();
+  if (!fs.existsSync(path.join(workspaceDir, 'atris'))) {
+    console.error('atris/ folder not found. run "atris init" first.');
+    process.exit(2);
+  }
+
+  const packDir = path.join(workspaceDir, 'atris', 'experiments', token);
+  if (!fs.existsSync(packDir) || !fs.statSync(packDir).isDirectory()) {
+    console.error(`experiment "${token}" not found.`);
+    process.exit(2);
+  }
+
+  const measurePath = path.join(packDir, 'measure.py');
+  if (!fs.existsSync(measurePath)) {
+    console.error(`experiment "${token}" has no measure.py.`);
+    process.exit(2);
+  }
+
+  // Change is already on disk. Minted packs start at 0; keep only if current score is 1.
+  const measured = runMeasureJson(measurePath, workspaceDir);
+  if (!measured.ok) {
+    console.error(`revert ${token}: ${measured.error}. refuse keep.`);
+    process.exit(1);
+  }
+
+  if (measured.score === 1) {
+    console.log(`keep ${token}: measure.py moved 0→1`);
+    return;
+  }
+
+  const stayed = measured.score === 0 ? '0' : String(measured.score);
+  console.error(`revert ${token}: measure.py stayed ${stayed}. refuse keep.`);
+  process.exit(1);
+}
+
 function experimentsInit(name) {
   const { experimentsDir } = ensureExperimentsFramework();
 
@@ -573,6 +660,8 @@ function experimentsCommand(subcommand, ...args) {
       return experimentsReplay(args[0] || 'endstate');
     case 'run':
       return experimentsRun(args[0], ...args.slice(1));
+    case 'keep':
+      return experimentsKeep(args[0]);
     default:
       console.log('');
       console.log('Usage: atris experiments <subcommand> [name]');
@@ -581,6 +670,7 @@ function experimentsCommand(subcommand, ...args) {
       console.log('  init [slug]          Prepare atris/experiments/ or scaffold a new pack');
       console.log('  validate [path|slug] Run structural validation on packs or a single pack');
       console.log('  run <slug>           Execute a pack or record an Endstate benchmark receipt');
+      console.log('  keep <slug>          Keep a pack only when measure.py moves 0 to 1');
       console.log('  compare endstate     Compare the latest baseline and stack receipts');
       console.log('  replay endstate      Validate, dry-run, and compare the public benchmark flow');
       console.log('  benchmark [mode]     Run validate/runtime/all benchmark harness');
@@ -592,6 +682,7 @@ function experimentsCommand(subcommand, ...args) {
       console.log('  atris experiments init self-heal');
       console.log('  atris experiments validate');
       console.log('  atris experiments run endstate-baseline --dry-run');
+      console.log('  atris experiments keep teach-teach01-s1');
       console.log('  atris experiments compare endstate');
       console.log('  atris experiments replay endstate');
       console.log('  atris experiments benchmark runtime');

--- a/test/experiments.test.js
+++ b/test/experiments.test.js
@@ -341,6 +341,103 @@ test('experiments compare endstate summarizes the latest receipts', { skip: !pyt
   }
 });
 
+function writeTokenMeasurePack(dir, slug, fixtureRel, token) {
+  const packDir = path.join(dir, 'atris', 'experiments', slug);
+  fs.mkdirSync(packDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packDir, 'measure.py'),
+    [
+      'import json, os',
+      'from pathlib import Path',
+      `TOKEN = ${JSON.stringify(token)}`,
+      `FIXTURE = ${JSON.stringify(fixtureRel)}`,
+      'root = Path(os.environ.get("ATRIS_REPO_ROOT") or ".").resolve()',
+      'path = root / FIXTURE',
+      'text = path.read_text(encoding="utf-8") if path.is_file() else ""',
+      'score = 1 if TOKEN.lower() in text.lower() else 0',
+      'print(json.dumps({"score": score, "passed": score, "total": 1, "status": "pass" if score == 1 else "fail"}))',
+      '',
+    ].join('\n')
+  );
+  return packDir;
+}
+
+test('experiments keep without a slug fails cleanly', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris'), { recursive: true });
+    const result = runCli(['experiments', 'keep'], { cwd: dir });
+    assert.equal(result.status, 2, result.stderr || result.stdout);
+    assert.match(`${result.stdout}\n${result.stderr}`, /usage: atris experiments keep <slug>/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('experiments keep fails cleanly when the pack is missing', () => {
+  const dir = makeTempDir();
+  try {
+    fs.mkdirSync(path.join(dir, 'atris', 'experiments'), { recursive: true });
+    const result = runCli(['experiments', 'keep', 'teach-missing-s1'], { cwd: dir });
+    assert.equal(result.status, 2, result.stderr || result.stdout);
+    assert.match(`${result.stdout}\n${result.stderr}`, /experiment "teach-missing-s1" not found/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('experiments keep fails cleanly when measure.py is missing', () => {
+  const dir = makeTempDir();
+  try {
+    const packDir = path.join(dir, 'atris', 'experiments', 'teach-nometric-s1');
+    fs.mkdirSync(packDir, { recursive: true });
+    fs.writeFileSync(path.join(packDir, 'program.md'), '# Program\n');
+    const result = runCli(['experiments', 'keep', 'teach-nometric-s1'], { cwd: dir });
+    assert.equal(result.status, 2, result.stderr || result.stdout);
+    assert.match(`${result.stdout}\n${result.stderr}`, /has no measure\.py/);
+    assert.equal(fs.existsSync(packDir), true);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('experiments keep refuses when measure.py stays at baseline 0', { skip: !pythonCmd }, () => {
+  const dir = makeTempDir();
+  try {
+    const fixtureRel = 'atris/wiki/briefs/keep-target.apply.md';
+    fs.mkdirSync(path.join(dir, 'atris', 'wiki', 'briefs'), { recursive: true });
+    fs.writeFileSync(path.join(dir, fixtureRel), 'change: apply atris/experiments/teach-keep01-s1\n');
+    const packDir = writeTokenMeasurePack(dir, 'teach-keep01-s1', fixtureRel, 'omakase model');
+    const result = runCli(['experiments', 'keep', 'teach-keep01-s1'], { cwd: dir });
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    assert.match(`${result.stdout}\n${result.stderr}`, /revert teach-keep01-s1: measure\.py stayed 0\. refuse keep\./);
+    assert.equal(fs.existsSync(path.join(packDir, 'measure.py')), true);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('experiments keep succeeds only after the fixture contains check tokens', { skip: !pythonCmd }, () => {
+  const dir = makeTempDir();
+  try {
+    const fixtureRel = 'atris/wiki/briefs/keep-target.apply.md';
+    const fixturePath = path.join(dir, fixtureRel);
+    fs.mkdirSync(path.join(dir, 'atris', 'wiki', 'briefs'), { recursive: true });
+    fs.writeFileSync(fixturePath, 'change: apply atris/experiments/teach-keep01-s1\n');
+    writeTokenMeasurePack(dir, 'teach-keep01-s1', fixtureRel, 'omakase model');
+
+    const refused = runCli(['experiments', 'keep', 'teach-keep01-s1'], { cwd: dir });
+    assert.equal(refused.status, 1, refused.stderr || refused.stdout);
+
+    fs.appendFileSync(fixturePath, 'keep the omakase model as the default stack\n');
+    const kept = runCli(['experiments', 'keep', 'teach-keep01-s1'], { cwd: dir });
+    assert.equal(kept.status, 0, kept.stderr || kept.stdout);
+    assert.match(kept.stdout, /keep teach-keep01-s1: measure\.py moved 0→1/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
 test('experiments replay endstate runs the public rehearsal flow', { skip: !pythonCmd }, () => {
   const dir = makeTempDir();
   try {

--- a/test/youtube-teach.test.js
+++ b/test/youtube-teach.test.js
@@ -23,6 +23,7 @@ const {
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const VALIDATE_PY = path.join(REPO_ROOT, 'atris', 'experiments', 'validate.py');
+const CLI_PATH = path.join(REPO_ROOT, 'bin', 'atris.js');
 
 function findPython() {
   for (const candidate of ['python3', 'python']) {
@@ -143,6 +144,19 @@ function collect() {
 
 function escapeRe(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function runExperimentsKeep(cwd, slug) {
+  return spawnSync(process.execPath, [CLI_PATH, 'experiments', 'keep', slug], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ...(pythonCmd ? { ATRIS_EXPERIMENTS_PYTHON: pythonCmd } : {}),
+    },
+  });
 }
 
 function assertTeachApplyClaimable(cwd, { id, section, tokens = [], date = '2026-08-27' } = {}) {
@@ -572,6 +586,34 @@ test('youtube teach rich --save apply sidecar omits check tokens so measure.py s
   const payload = JSON.parse(measured.stdout.trim().split('\n').pop());
   assert.equal(payload.score, 0);
   assert.equal(payload.status, 'fail');
+});
+
+test('experiments keep refuses a minted teach pack at 0 and keeps after check tokens', async () => {
+  assert.ok(pythonCmd, 'python3 is required to score the minted pack');
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-yt-teach-keep-'));
+  fs.mkdirSync(path.join(cwd, 'atris', 'wiki'), { recursive: true });
+  const out = collect();
+  const status = await youtubeCommand(['teach', TEACH_URL, '--save'], {
+    cwd,
+    now: '2026-08-27',
+    output: out.output,
+    extractTeachSource: async () => fixtureSource(),
+  });
+
+  assert.equal(status, 0);
+  const packDir = path.join(cwd, 'atris', 'experiments', 'teach-teach01-s1');
+  const applyPath = path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-teach01-s1.apply.md');
+  assert.equal(fs.existsSync(path.join(packDir, 'measure.py')), true);
+
+  const refused = runExperimentsKeep(cwd, 'teach-teach01-s1');
+  assert.equal(refused.status, 1, refused.stderr || refused.stdout);
+  assert.match(`${refused.stdout}\n${refused.stderr}`, /revert teach-teach01-s1: measure\.py stayed 0\. refuse keep\./);
+  assert.equal(fs.existsSync(path.join(packDir, 'measure.py')), true);
+
+  fs.appendFileSync(applyPath, '\nkeep the omakase model as the default stack\n');
+  const kept = runExperimentsKeep(cwd, 'teach-teach01-s1');
+  assert.equal(kept.status, 0, kept.stderr || kept.stdout);
+  assert.match(kept.stdout, /keep teach-teach01-s1: measure\.py moved 0→1/);
 });
 
 test('youtube teach thin chapter without --save still writes no atris files', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rich `atris youtube teach --save` already mints `atris/experiments/teach-<videoid>-sN/` with a `measure.py` that scores 0 on the fresh apply sidecar. Nothing enforced the keep rule.

`atris experiments keep <slug>` is that gate. It requires the pack and `measure.py`, scores the current working tree, prints a keep line and exits 0 only when the score is 1 (minted packs start at 0), and otherwise exits non-zero with a revert/refuse line. The pack is not deleted.

Thin `--save` still refuses (exit 2, no pack). Teach without `--save` still writes nothing. No apply engine, no paid YouTube or x-search.

## Proof

```
node --test test/experiments.test.js test/youtube-teach.test.js test/map-refs-accurate.test.js test/map-refs-fresh.test.js test/repo-hygiene.test.js
```

Local run: 44 passed, 0 failed.

Covers:
- missing slug / missing pack / missing `measure.py` exit 2
- baseline 0 keep refused, pack stays
- after the fixture contains check tokens, keep succeeds 0→1
- minted teach pack: keep refuses at 0, then keeps after the sidecar gets the chapter token

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59bbf74e-1a96-474f-9a21-8aa0d3bc34f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59bbf74e-1a96-474f-9a21-8aa0d3bc34f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

