### PR TITLE
Use backend-placed agent keys

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -1256,13 +1256,14 @@ rg "printRoster|registryPayload|canPersistEngineRegistry|speakFirstMinute|--glob
 - **Regression:** `test/commands.test.js:4249-4294` covers auth/account help without login prompts, status output, `.atris` creation, session/profile dir creation, or credential deletion
 - JWT helpers: `decodeJwtClaims` (bin:59-74), `shouldRefreshToken` (bin:85-92)
 - **Credentials storage:** `~/.atris/credentials.json` (chmod 0o600 on save)
+- **Placed agent key:** `utils/auth.js:165-206,376-414` reads `~/.atris/agent-token.json` or `ATRIS_AGENT_TOKEN_FILE` after `ATRIS_TOKEN` and before profiles, with the narrow fresh-file override for a different stale environment token; `test/auth-placed-token.test.js` covers precedence, expiry fallback, silent ignores, and the re-mint error
 - **Login flow:**
   1. Browser OAuth: opens `{APP_BASE}/auth/cli`, user pastes code, CLI exchanges via `POST /auth/cli/exchange`
   2. Manual token: user pastes raw token, saved + validated
   3. Non-interactive: `--token <t>` flag for CI/scripts
-- **Token refresh:** `utils/auth.js:456-541` (`performTokenRefresh`) — saves new access token, optionally rotates refresh token, re-validates, updates user metadata. Profile-sourced creds write back to the profile file. `refreshAccessToken` (`:423`) sends `refresh_token` and omits `provider=google` unless the token is a Google OAuth refresh (`1//...`); that hint makes `/auth/refresh` skip app-JWT refresh and return `google_refresh_failed`.
-- **Credential guard:** `utils/auth.js:543-608` (`ensureValidCredentials`) — proactive refresh if within 5-min buffer, validate, fallback refresh
-- **Wake auth abort:** `utils/auth.js:438-454` (`isAuthFailure` / `abortOnAuthFailure`) — status/wake 401/403 stop polling and print login guidance instead of a computer timeout. Used by `commands/terminal.js:35`, `commands/computer.js:2259`, `commands/aeo.js:98`, `commands/pull.js:361`, `commands/push.js:530`, `commands/align.js:180`.
+- **Token refresh:** `utils/auth.js:518-603` (`performTokenRefresh`) saves new access token, optionally rotates refresh token, re-validates, updates user metadata. Profile-sourced creds write back to the profile file. `refreshAccessToken` (`:485`) sends `refresh_token` and omits `provider=google` unless the token is a Google OAuth refresh (`1//...`); that hint makes `/auth/refresh` skip app-JWT refresh and return `google_refresh_failed`.
+- **Credential guard:** `utils/auth.js:605-678` (`ensureValidCredentials`) checks selected-source and agent-JWT expiry, proactively refreshes within the 5-minute buffer, validates, then falls back to refresh
+- **Wake auth abort:** `utils/auth.js:500-516` (`isAuthFailure` / `abortOnAuthFailure`) stops status/wake polling on 401/403 and prints login guidance instead of a computer timeout. Used by `commands/terminal.js:35`, `commands/computer.js:2259`, `commands/aeo.js:98`, `commands/pull.js:361`, `commands/push.js:530`, `commands/align.js:180`.
 - **Dependencies:** `utils/auth.js` for token management, `utils/api.js` for HTTP
 - **Consumers:**
   - `commands/auth.js` (login/logout/whoami) — uses modular `utils/auth.js`

--- a/commands/auth.js
+++ b/commands/auth.js
@@ -1,4 +1,4 @@
-const { loadCredentials, saveCredentials, deleteCredentials, getCredentialsPath, openBrowser, promptUser, displayAccountSummary, ensureValidCredentials, loadProfile, listProfiles, profileNameFromEmail, deleteProfile, saveProfile, getTokenExpiryEpochSeconds, getTerminalSessionId, setSessionProfile, getSessionProfile, clearSessionProfile, cleanStaleSessions, getSessionsDir } = require('../utils/auth');
+const { AGENT_TOKEN_EXPIRED_DETAIL, loadCredentials, saveCredentials, deleteCredentials, getCredentialsPath, openBrowser, promptUser, displayAccountSummary, ensureValidCredentials, loadProfile, listProfiles, profileNameFromEmail, deleteProfile, saveProfile, getTokenExpiryEpochSeconds, getTerminalSessionId, setSessionProfile, getSessionProfile, clearSessionProfile, cleanStaleSessions, getSessionsDir } = require('../utils/auth');
 const { getAppBaseUrl, apiRequestJson } = require('../utils/api');
 const { isNonInteractive, wantsJson } = require('../lib/noninteractive');
 const { hasFlag, readFlag } = require('../lib/arg-parser');
@@ -281,6 +281,11 @@ async function mintAgentToken(args = [], deps = {}) {
 async function printWhoamiPayload(asJson) {
   const ensured = await ensureValidCredentials(apiRequestJson);
   if (ensured.error) {
+    if (!asJson && ensured.detail === AGENT_TOKEN_EXPIRED_DETAIL) {
+      console.error('the agent key expired.');
+      console.error('atris login --agent');
+      process.exit(1);
+    }
     if (asJson) {
       console.log(JSON.stringify({
         ok: false,

--- a/test/auth-placed-token.test.js
+++ b/test/auth-placed-token.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { loadCredentials } = require('../utils/auth');
+
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'atris.js');
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'atris-placed-token-'));
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value));
+}
+
+function withEnv(updates, fn) {
+  const previous = {};
+  for (const [name, value] of Object.entries(updates)) {
+    previous[name] = process.env[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+
+test('fresh placed token wins over a different stale environment token', () => {
+  const dir = makeTempDir();
+  const tokenFile = path.join(dir, 'backend', 'agent-token.json');
+  const expiresAt = new Date(Date.now() + 60_000).toISOString();
+  writeJson(tokenFile, {
+    token: 'fresh-placed-token',
+    expires_at: expiresAt,
+    scopes: ['x-search'],
+  });
+
+  try {
+    withEnv({
+      ATRIS_TOKEN: 'stale-baked-token',
+      ATRIS_AGENT_TOKEN_FILE: tokenFile,
+      ATRIS_PROFILE: undefined,
+    }, () => {
+      assert.deepEqual(loadCredentials(), {
+        token: 'fresh-placed-token',
+        expires_at: expiresAt,
+        scopes: ['x-search'],
+        provider: null,
+        source: 'agent_token_file',
+      });
+
+      process.env.ATRIS_TOKEN = 'fresh-placed-token';
+      assert.deepEqual(loadCredentials(), {
+        token: 'fresh-placed-token',
+        provider: null,
+        source: 'env',
+      });
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('expired placed token falls through to the next credential source', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  const tokenFile = path.join(home, '.atris', 'agent-token.json');
+  const profileFile = path.join(home, '.atris', 'profiles', 'cloud.json');
+  writeJson(tokenFile, {
+    token: 'expired-placed-token',
+    expires_at: new Date(Date.now() - 60_000).toISOString(),
+    scopes: ['x-search'],
+  });
+  writeJson(profileFile, { token: 'profile-token', provider: 'atris' });
+
+  try {
+    withEnv({
+      HOME: home,
+      ATRIS_TOKEN: undefined,
+      ATRIS_AGENT_TOKEN_FILE: undefined,
+      ATRIS_PROFILE: 'cloud',
+    }, () => {
+      const credentials = loadCredentials();
+      assert.equal(credentials.token, 'profile-token');
+      assert.equal(credentials.source_profile, 'cloud');
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('missing and corrupt placed token files are ignored silently', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  const credentialsFile = path.join(home, '.atris', 'credentials.json');
+  const tokenFile = path.join(dir, 'alternate-agent-token.json');
+  writeJson(credentialsFile, { token: 'saved-token', provider: 'atris' });
+  const errors = [];
+  const originalError = console.error;
+
+  try {
+    console.error = (...args) => errors.push(args.join(' '));
+    withEnv({
+      HOME: home,
+      ATRIS_TOKEN: undefined,
+      ATRIS_AGENT_TOKEN_FILE: tokenFile,
+      ATRIS_PROFILE: undefined,
+    }, () => {
+      assert.equal(loadCredentials().token, 'saved-token');
+      fs.writeFileSync(tokenFile, '{not json');
+      assert.equal(loadCredentials().token, 'saved-token');
+    });
+    assert.deepEqual(errors, []);
+  } finally {
+    console.error = originalError;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('expired selected token prints one error and the agent re-mint command', () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  writeJson(path.join(home, '.atris', 'credentials.json'), {
+    token: 'expired-selected-token',
+    expires_at: new Date(Date.now() - 60_000).toISOString(),
+  });
+
+  try {
+    const result = spawnSync(process.execPath, [cliPath, 'whoami'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: home,
+        ATRIS_SKIP_UPDATE_CHECK: '1',
+        ATRIS_NONINTERACTIVE: '1',
+        ATRIS_TOKEN: '',
+        ATRIS_PROFILE: '',
+        ATRIS_AGENT_TOKEN_FILE: path.join(dir, 'missing-agent-token.json'),
+      },
+    });
+    if (result.error) throw result.error;
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'the agent key expired.\natris login --agent\n');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/auth-placed-token.test.js
+++ b/test/auth-placed-token.test.js
@@ -140,7 +140,7 @@ test('expired selected token prints one error and the agent re-mint command', ()
 
   try {
     const result = spawnSync(process.execPath, [cliPath, 'whoami'], {
-      cwd: repoRoot,
+      cwd: dir,
       encoding: 'utf8',
       env: {
         ...process.env,

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -86,6 +86,7 @@ function promptUser(question) {
 }
 
 const TOKEN_REFRESH_BUFFER_SECONDS = 300;
+const AGENT_TOKEN_EXPIRED_DETAIL = 'Agent token expired. Mint a new one: atris login --agent';
 
 /**
  * Decode and parse the claims from a JWT token.
@@ -162,6 +163,48 @@ function getAtrisDir() {
 
 function getCredentialsPath() {
   return path.join(getAtrisDir(), 'credentials.json');
+}
+
+function getPlacedAgentTokenPath() {
+  const override = process.env.ATRIS_AGENT_TOKEN_FILE;
+  if (override && override.trim()) return override.trim();
+  return path.join(os.homedir(), '.atris', 'agent-token.json');
+}
+
+function expiryTimeMs(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 1e12 ? value : value * 1000;
+  }
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const trimmed = value.trim();
+  if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) return numeric > 1e12 ? numeric : numeric * 1000;
+  }
+  const parsed = Date.parse(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function loadPlacedAgentToken() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(getPlacedAgentTokenPath(), 'utf8'));
+    const token = typeof parsed?.token === 'string' ? parsed.token.trim() : '';
+    if (!token || expiryTimeMs(parsed?.expires_at) === null) return null;
+    return {
+      token,
+      expires_at: parsed.expires_at,
+      scopes: Array.isArray(parsed.scopes) ? parsed.scopes : [],
+      provider: null,
+      source: 'agent_token_file',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isUnexpiredCredential(credentials) {
+  const expiresAt = expiryTimeMs(credentials?.expires_at);
+  return expiresAt !== null && expiresAt > Date.now();
 }
 
 function getSessionsDir() {
@@ -332,17 +375,36 @@ function saveCredentials(token, refreshToken, email, userId, provider) {
 }
 
 function loadCredentials() {
-  // Priority: ATRIS_TOKEN env var → ATRIS_PROFILE env var → per-terminal session file → global credentials.json
+  // Priority: ATRIS_TOKEN env var → placed agent token → ATRIS_PROFILE env var
+  // → per-terminal session file → global credentials.json. A fresh placed token
+  // overrides a different env token because cloud images can carry a stale one.
 
   // 0. Raw token injection. Headless boxes (cloud business computers) have no
   //    browser for `atris login`; the runner injects a scoped token as env
   //    instead, so no credentials file ever lands on disk.
   const envToken = process.env.ATRIS_TOKEN;
-  if (envToken && envToken.trim()) {
-    return { token: envToken.trim(), provider: null, source: 'env' };
+  const normalizedEnvToken = envToken && envToken.trim();
+  const placedAgentToken = loadPlacedAgentToken();
+  if (
+    normalizedEnvToken &&
+    placedAgentToken &&
+    placedAgentToken.token !== normalizedEnvToken &&
+    isUnexpiredCredential(placedAgentToken)
+  ) {
+    return placedAgentToken;
+  }
+  if (normalizedEnvToken) {
+    return { token: normalizedEnvToken, provider: null, source: 'env' };
   }
 
-  // 1. Explicit env var override
+  // 1. Backend-placed key for per-user cloud computers. Missing, malformed,
+  //    incomplete, and expired files are ignored so later sources keep their
+  //    existing order.
+  if (placedAgentToken && isUnexpiredCredential(placedAgentToken)) {
+    return placedAgentToken;
+  }
+
+  // 2. Explicit env var override
   const profileOverride = process.env.ATRIS_PROFILE;
   if (profileOverride) {
     const profile = loadProfile(profileOverride);
@@ -358,14 +420,14 @@ function loadCredentials() {
     }
   }
 
-  // 2. Per-terminal session override (set by atris switch)
+  // 3. Per-terminal session override (set by atris switch)
   const sessionProfile = getSessionProfile();
   if (sessionProfile) {
     const profile = loadProfile(sessionProfile);
     if (profile) return { ...profile, source_profile: sessionProfile };
   }
 
-  // 3. Global credentials.json
+  // 4. Global credentials.json
   const credentialsPath = getCredentialsPath();
 
   if (!fs.existsSync(credentialsPath)) {
@@ -546,10 +608,15 @@ async function ensureValidCredentials(apiRequestJson, options = {}) {
     return { error: 'not_logged_in' };
   }
 
+  const selectedExpiry = expiryTimeMs(credentials.expires_at);
+  if (selectedExpiry !== null && selectedExpiry <= Date.now()) {
+    return { error: 'token_invalid', detail: AGENT_TOKEN_EXPIRED_DETAIL };
+  }
+
   const claims = decodeJwtClaims(credentials.token);
   if (claims?.type === 'agent_access') {
     if (typeof claims.exp === 'number' && claims.exp <= Math.floor(Date.now() / 1000)) {
-      return { error: 'token_invalid', detail: 'Agent token expired. Mint a new one: atris login --agent' };
+      return { error: 'token_invalid', detail: AGENT_TOKEN_EXPIRED_DETAIL };
     }
     // Server-side scope enforcement on every real request is unchanged and remains the actual security boundary.
     return { credentials, user: null, source: 'agent_token' };
@@ -572,6 +639,7 @@ async function ensureValidCredentials(apiRequestJson, options = {}) {
 
     if (
       credentials.source !== 'env' &&
+      credentials.source !== 'agent_token_file' &&
       (updatedEmail !== credentials.email ||
         updatedProvider !== credentials.provider ||
         updatedUserId !== credentials.user_id)
@@ -680,6 +748,7 @@ async function displayAccountSummary(apiRequestJson) {
 }
 
 module.exports = {
+  AGENT_TOKEN_EXPIRED_DETAIL,
   decodeJwtClaims,
   getTokenExpiryEpochSeconds,
   shouldRefreshToken,


### PR DESCRIPTION
## Summary

- read the backend-placed agent key from the default user path or an environment override
- prefer a fresh placed key over a different stale environment token while preserving all other credential precedence
- skip expired or unreadable placed files and print a clear agent key renewal command for an expired selected token
- keep placed keys read-only and never print their values

## Verification

- node --test test/auth-placed-token.test.js test/auth-agent-token.test.js test/auth-profile-refresh.test.js
- exit 0, 25 passed