### PR TITLE
receipt: carry the dollars a mission made

### DIFF
--- a/lib/receipt-block.js
+++ b/lib/receipt-block.js
@@ -149,6 +149,25 @@ function checkText(receipt) {
   return '';
 }
 
+// Dollars a mission actually brought in. Read from the landing (or result)
+// so a member can write it next to what happened; the backend sums the same
+// field into the member rating. Junk and negatives count as zero.
+function earnedUsd(receipt) {
+  const land = landing(receipt);
+  const res = result(receipt);
+  for (const value of [land.earned_usd, res.earned_usd, res.tick?.earned_usd]) {
+    if (value === undefined || value === null || value === '') continue;
+    const amount = Number(value);
+    return Number.isFinite(amount) && amount > 0 ? Math.round(amount * 100) / 100 : 0;
+  }
+  return 0;
+}
+
+function usdText(amount) {
+  const whole = Number.isInteger(amount);
+  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: whole ? 0 : 2, maximumFractionDigits: 2 })}`;
+}
+
 function nextText(receipt) {
   const text = landing(receipt).next || result(receipt).next || '';
   return lowerLine(text);
@@ -185,6 +204,8 @@ function renderPageSection(receipt) {
   if (check) lines.push(check);
   if (next) lines.push(`Next: ${sentence(truncateLine(next, 160))}`);
   const details = [scaleText(receipt), `status ${statusText(receipt)}`];
+  const earned = earnedUsd(receipt);
+  if (earned > 0) details.push(`earned ${usdText(earned)}`);
   if (receipt?.mission_id) details.push(`mission ${lowerLine(receipt.mission_id)}`);
   lines.push('', `details: ${details.join('; ')}`);
   return lines.join('\n');
@@ -206,6 +227,7 @@ function renderCard(receipt) {
 }
 
 module.exports = {
+  earnedUsd,
   renderCard,
   renderPageSection,
   renderEmailLine,

--- a/test/receipt-block.test.js
+++ b/test/receipt-block.test.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+  earnedUsd,
   renderCard,
   renderPageSection,
   renderEmailLine,
@@ -167,4 +168,29 @@ test('morning card shows mission receipt rows through the receipt block renderer
   } finally {
     cleanup(dir);
   }
+});
+
+test('a receipt can carry the dollars it made, and the details line shows it', () => {
+  const receipt = fixtureReceipt();
+  assert.equal(earnedUsd(receipt), 0);
+  assert.doesNotMatch(renderPageSection(receipt), /earned/);
+
+  receipt.result.landing.earned_usd = '12000';
+  assert.equal(earnedUsd(receipt), 12000);
+  assert.match(renderPageSection(receipt), /^details: .*; earned \$12,000; mission mission-receipt-block$/m);
+
+  receipt.result.landing.earned_usd = 4500.5;
+  assert.match(renderPageSection(receipt), /earned \$4,500\.50/);
+
+  // Junk and negatives never move the number, and never reach the surface.
+  for (const junk of ['lots', -40, null, '']) {
+    receipt.result.landing.earned_usd = junk;
+    assert.equal(earnedUsd(receipt), 0);
+    assert.doesNotMatch(renderEmailLine(receipt), /earned|\$/);
+  }
+
+  // result.earned_usd works when the landing has none.
+  delete receipt.result.landing.earned_usd;
+  receipt.result.earned_usd = 250;
+  assert.equal(earnedUsd(receipt), 250);
 });


### PR DESCRIPTION
## What changed

Stacked on #892. A mission landing (or result) can now carry `earned_usd`. The receipt page shows it under `details:` as `earned $12,000`, and `earnedUsd(receipt)` is exported so whatever syncs receipts upstream can hand the same number to the member rating (atrisos-backend #2839 reads `tasks.metadata.earned_usd`).

- Reads `landing.earned_usd`, then `result.earned_usd`, then `result.tick.earned_usd`.
- Junk, blanks, and negatives count as zero and never reach the surface.
- The sentence is still where money gets said ("DoorDash paid invoice 7. $12,000 landed."). Details is where it gets counted.

## Proof

- `node --test test/receipt-block.test.js`: 7 pass (one new).
- Full suite: 4372 pass, 0 fail.
- Two files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9GkmyefDtxohnxT12mjJo
