### PR TITLE
Print pasteable keep next-step after rich learner --save

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -351,7 +351,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris experiments init [slug]` scaffolds a new bounded experiment pack
 - `atris experiments validate` runs structural checks and context-bloat validation
 - `atris experiments run <slug>` executes a pack; Endstate packs also emit JSON receipts + append `results.tsv`
-- `atris experiments keep <slug>` runs `atris/experiments/<slug>/measure.py` against the current working tree and prints a keep line only when the score is 1 (minted packs start at 0). Score 0 prints a revert/refuse line and exits 1 without deleting the pack. Missing slug, pack, or measure.py exits 2.
+- `atris experiments keep <slug>` runs `atris/experiments/<slug>/measure.py` against the current working tree and prints a keep line only when the score is 1 (minted packs start at 0). Score 0 prints a revert/refuse line and exits 1 without deleting the pack. Missing slug, pack, or measure.py exits 2. Rich notes, teach, and x-search `--save` print one `next: atris experiments keep <slug>` (folder name, not the pack path).
 - `atris experiments revert <slug>` runs `atris/experiments/<slug>/reset.py` from the workspace root with the same Python resolution as keep. Success prints a revert line and exits 0. Reset failure exits nonzero with a refuse line. Missing slug, pack, or reset.py exits 2. If measure.py exists after reset, the line also names that score.
 - `atris experiments compare endstate` reads the latest baseline + stack receipts, prints the side-by-side scorecard, and declares `stack wins` or `no winner yet` from the Level 1 rule
 - `atris experiments replay endstate` validates both packs, emits fresh dry-run receipts, then compares the latest result in one command

--- a/commands/x-search.js
+++ b/commands/x-search.js
@@ -535,14 +535,15 @@ function saveRichXSearch({ cwd, source, text, now } = {}) {
 
 function ensureXSearchApply({ cwd, source, packRel, now, output } = {}) {
   const pack = packRel || (source ? xSearchExperimentRel(source) : null);
+  const slug = pack ? path.basename(pack) : null;
   return applyGate.ensureApply({
     cwd,
     source,
     rel: source ? xSearchApplyRel(source) : null,
     now,
     output,
-    incompleteMessage: pack
-      ? `next: apply ${pack}. keep only if measure.py moves 0→1`
+    incompleteMessage: slug
+      ? `next: atris experiments keep ${slug}`
       : APPLY_NEXT_MESSAGE,
     required: false,
     change: pack ? `apply ${pack}` : undefined,

--- a/commands/youtube.js
+++ b/commands/youtube.js
@@ -704,14 +704,15 @@ function saveRichNotes(url, deps = {}) {
 function ensureNotesApply({ cwd, url, packRel, now, output } = {}) {
   const id = videoIdFromUrl(url);
   const pack = packRel || (id ? notesExperimentRel(id) : null);
+  const slug = pack ? path.basename(pack) : null;
   return applyGate.ensureApply({
     cwd,
     source: url,
     rel: id ? applySidecarRel(id) : null,
     now,
     output,
-    incompleteMessage: pack
-      ? `next: apply ${pack}. keep only if measure.py moves 0→1`
+    incompleteMessage: slug
+      ? `next: atris experiments keep ${slug}`
       : APPLY_NEXT_MESSAGE,
     required: false,
     change: pack ? `apply ${pack}` : undefined,
@@ -2948,14 +2949,15 @@ function fileTeachBrief({ cwd, url, section, lesson, now } = {}) {
 function ensureTeachApply({ cwd, url, section, packRel, now, output } = {}) {
   const id = videoIdFromUrl(url);
   const pack = packRel || (id ? teachExperimentRel(id, section) : null);
+  const slug = pack ? path.basename(pack) : null;
   return applyGate.ensureApply({
     cwd,
     source: url,
     rel: id ? applySidecarRel(`${id}-s${section}`) : null,
     now,
     output,
-    incompleteMessage: pack
-      ? `next: apply ${pack}. keep only if measure.py moves 0→1`
+    incompleteMessage: slug
+      ? `next: atris experiments keep ${slug}`
       : TEACH_APPLY_NEXT_MESSAGE,
     required: false,
     change: pack ? `apply ${pack}` : undefined,

--- a/test/x-search-save.test.js
+++ b/test/x-search-save.test.js
@@ -176,7 +176,7 @@ test('x-search rich --save mints a measure.py that validate.py accepts', async (
   assert.equal(status, 0);
   assert.equal(out.lines.filter((line) => line === ephemeralApplyMessage('x-search')).length, 0);
   assert.doesNotMatch(out.text(), /next: atris youtube search/);
-  assert.match(out.text(), /next: apply atris\/experiments\/x-search-mcp-agents\. keep only if measure\.py moves 0→1/);
+  assert.match(out.text(), /next: atris experiments keep x-search-mcp-agents/);
   const packDir = path.join(cwd, 'atris', 'experiments', 'x-search-mcp-agents');
   for (const name of ['program.md', 'measure.py', 'loop.py', 'reset.py', 'results.tsv']) {
     assert.equal(fs.existsSync(path.join(packDir, name)), true, name);
@@ -271,7 +271,7 @@ test('x-search person rich --save mints the same keep/revert pack', async () => 
 
   assert.equal(status, 0);
   assert.doesNotMatch(out.text(), /next: atris youtube search/);
-  assert.match(out.text(), /next: apply atris\/experiments\/x-search-leah-bonvissuto\. keep only if measure\.py moves 0→1/);
+  assert.match(out.text(), /next: atris experiments keep x-search-leah-bonvissuto/);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'x-search-leah-bonvissuto', 'measure.py')), true);
   assertXSearchApplyClaimable(cwd, {
     source: 'Leah Bonvissuto',

--- a/test/youtube-notes-save.test.js
+++ b/test/youtube-notes-save.test.js
@@ -159,7 +159,7 @@ test('youtube notes rich --save mints a measure.py that validate.py accepts', as
   assert.equal(status, 0);
   assert.equal(out.lines.filter((line) => line === ephemeralApplyMessage('notes')).length, 0);
   assert.doesNotMatch(out.text(), /next: atris youtube teach/);
-  assert.match(out.text(), /next: apply atris\/experiments\/notes-notes01\. keep only if measure\.py moves 0→1/);
+  assert.match(out.text(), /next: atris experiments keep notes-notes01/);
   const packDir = path.join(cwd, 'atris', 'experiments', 'notes-notes01');
   for (const name of ['program.md', 'measure.py', 'loop.py', 'reset.py', 'results.tsv']) {
     assert.equal(fs.existsSync(path.join(packDir, name)), true, name);

--- a/test/youtube-teach.test.js
+++ b/test/youtube-teach.test.js
@@ -505,7 +505,7 @@ test('youtube teach --save writes one pack-named apply claimable', async () => {
 
   assert.equal(status, 0);
   assert.equal(out.lines.filter((line) => line === ephemeralApplyMessage('teach')).length, 0);
-  assert.match(out.text(), /next: apply atris\/experiments\/teach-teach01-s1\. keep only if measure\.py moves 0→1/);
+  assert.match(out.text(), /next: atris experiments keep teach-teach01-s1/);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-teach01-s1.md')), true);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'teach-teach01-s1', 'measure.py')), true);
   const claim = assertTeachApplyClaimable(cwd, {
@@ -589,7 +589,7 @@ test('youtube teach --save on lex highlight files the brief and a pack-named app
   assert.equal(status, 0);
   assert.match(out.text(), /60 seconds to install/);
   assert.match(out.text(), /overton window/);
-  assert.match(out.text(), /next: apply atris\/experiments\/teach-nyfgcesmika-s1\. keep only if measure\.py moves 0→1/);
+  assert.match(out.text(), /next: atris experiments keep teach-nyfgcesmika-s1/);
   assert.doesNotMatch(out.text(), /thin: no number or named mechanism/);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-NYFGCESmikA-s1.md')), true);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'teach-nyfgcesmika-s1', 'measure.py')), true);
@@ -1064,7 +1064,7 @@ test('youtube teach --save path stays unchanged after a recap unlock', async () 
   assert.equal(status, 0);
   assert.equal(out.lines.filter((line) => line === ephemeralApplyMessage('teach')).length, 0);
   assert.doesNotMatch(out.text(), /next: last section/);
-  assert.match(out.text(), /next: apply atris\/experiments\/teach-teach01-s2\. keep only if measure\.py moves 0→1/);
+  assert.match(out.text(), /next: atris experiments keep teach-teach01-s2/);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-teach01-s1.md')), true);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-teach01-s2.md')), true);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'teach-teach01-s2', 'measure.py')), true);

--- a/test/youtube.test.js
+++ b/test/youtube.test.js
@@ -506,7 +506,7 @@ test('youtube notes --save writes a pack-named apply and a next-line', async () 
   assert.equal(status, 0);
   assert.equal(output.includes(ephemeralApplyMessage('notes')), false);
   assert.doesNotMatch(output.join('\n'), /next: atris youtube teach/);
-  assert.match(output.join('\n'), /next: apply atris\/experiments\/notes-apply01\. keep only if measure\.py moves 0→1/);
+  assert.match(output.join('\n'), /next: atris experiments keep notes-apply01/);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-apply01.md')), true);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'notes-apply01', 'measure.py')), true);
   const stub = fs.readFileSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-apply01.apply.md'), 'utf8');
@@ -563,7 +563,7 @@ test('youtube notes --save without wiki still exits 0 when apply is missing', as
   });
 
   assert.equal(status, 0);
-  assert.match(output.join('\n'), /next: apply atris\/experiments\/notes-apply03\. keep only if measure\.py moves 0→1/);
+  assert.match(output.join('\n'), /next: atris experiments keep notes-apply03/);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki')), false);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'notes-apply03', 'measure.py')), true);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'logs')), false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rich notes, teach, and x-search `--save` printed a prose next-step that you cannot paste:

`next: apply atris/experiments/<slug>. keep only if measure.py moves 0→1`

The rest of the YouTube/X rail already prints one pasteable CLI next-step. After a minted pack, the real next command is `atris experiments keep <slug>`.

This change prints exactly that on rich `--save` only, using the experiment folder name (not the full `atris/experiments/…` path). Sidecar `receipt:` and journal `[claimable]` lines still carry the keep rule. Thin `--save`, ephemeral, empty/failed, `--json`, and help stay unchanged.

## Test plan
- `node --test test/youtube-notes-save.test.js test/youtube-teach.test.js test/x-search-save.test.js test/youtube.test.js`
- Confirm rich `--save` stdout is `next: atris experiments keep <slug>`
- Confirm sidecar/journal keep-rule text is unchanged
- Confirm thin/ephemeral/`--json`/help still print no keep next-step
- No live YouTube process, paid x-search, or paid YouTube search

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f77b757a-0f3b-4627-88de-55c783ca6307?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f77b757a-0f3b-4627-88de-55c783ca6307&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

