### PR TITLE
Print pasteable next-step after youtube digest

### DIFF
--- a/commands/youtube.js
+++ b/commands/youtube.js
@@ -1004,6 +1004,7 @@ function runYoutubeDigest(args = [], deps = {}) {
   const briefs = collectVideoBriefs({ cwd, now, days: options.days });
   if (!briefs.length) {
     output(`no video briefs in the last ${options.days} days`);
+    printWatchSearchNext(output);
     return 0;
   }
 
@@ -1031,6 +1032,7 @@ function runYoutubeDigest(args = [], deps = {}) {
   fs.writeFileSync(path.join(cwd, relDigest), `${header}\n\n${text}\n`);
   appendDigestJournal({ cwd, date, relDigest });
   output(`digest filed: ${relDigest} (${briefs.length} briefs)`);
+  printWatchTickNext(output);
   return 0;
 }
 

--- a/test/youtube-digest.test.js
+++ b/test/youtube-digest.test.js
@@ -151,6 +151,10 @@ test('digest writes the output file with sources listed', async () => {
   assert.match(prompts[0], /title: in window/);
   assert.match(prompts[0], /Ship local notes first/);
   assert.match(printed.text(), /digest filed: atris\/wiki\/briefs\/digest-2026-08-15\.md \(2 briefs\)/);
+  assert.deepEqual(
+    printed.text().split('\n').filter((line) => line.startsWith('next:')),
+    ['next: atris youtube watch tick'],
+  );
 
   const filed = fs.readFileSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'digest-2026-08-15.md'), 'utf8');
   assert.equal(filed.split('\n').slice(0, 3).join('\n'), [
@@ -215,6 +219,11 @@ test('empty window is a no-op', async () => {
   assert.equal(status, 0);
   assert.equal(ran, 0);
   assert.match(printed.text(), /no video briefs in the last 7 days/);
+  assert.deepEqual(
+    printed.text().split('\n').filter((line) => line.startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
+  assert.equal(printed.text().includes('next: atris youtube watch tick'), false);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', `digest-${TODAY}.md`)), false);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'logs')), false);
 });
@@ -229,4 +238,52 @@ test('digest help lists the new usage', async () => {
   });
   assert.equal(status, 0);
   assert.match(printed.text(), /atris youtube digest \[--days N\]/);
+  assert.equal(printed.text().includes('next:'), false);
+});
+
+test('digest engine failure prints no next-step', async () => {
+  const cwd = tempCwd();
+  writeBrief(cwd, 'youtube-in.md', {
+    date: TODAY,
+    source: 'https://www.youtube.com/watch?v=in11111',
+    title: 'in window',
+  });
+  const failed = collect();
+  const failStatus = await youtubeCommand(['digest'], {
+    cwd,
+    now: NOW,
+    output: failed.output,
+    runner: () => {
+      throw new Error('digest engine failed');
+    },
+  });
+  assert.equal(failStatus, 1);
+  assert.match(failed.text(), /digest engine failed/);
+  assert.equal(failed.text().includes('next:'), false);
+  assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', `digest-${TODAY}.md`)), false);
+
+  const empty = collect();
+  const emptyStatus = await youtubeCommand(['digest'], {
+    cwd,
+    now: NOW,
+    output: empty.output,
+    runner: () => '',
+  });
+  assert.equal(emptyStatus, 1);
+  assert.match(empty.text(), /digest engine returned no text/);
+  assert.equal(empty.text().includes('next:'), false);
+  assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', `digest-${TODAY}.md`)), false);
+});
+
+test('digest parse error prints no next-step', async () => {
+  const printed = collect();
+  const status = await youtubeCommand(['digest', '--days', 'nope'], {
+    output: printed.output,
+    runner: () => {
+      throw new Error('engine should not run for parse errors');
+    },
+  });
+  assert.equal(status, 2);
+  assert.match(printed.text(), /--days must be a positive integer/);
+  assert.equal(printed.text().includes('next:'), false);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A successful youtube digest used to stop after `digest filed:`. After a week of briefs, the rail dead-ended with no pasteable next line.

This change prints one next-step after the two live outcomes:

- After `digest filed: …`, print `next: atris youtube watch tick` (same constant as watch add/list).
- After `no video briefs in the last N days`, print `next: atris youtube search " "` (same placeholder as empty watch tick with channels).

Engine failure, empty engine text, help, and parse errors stay quiet. `--json` is not a digest flag and is not invented here. Notes, teach, watch, search, and x-search are unchanged except reuse of the existing next-string helpers.

## Tests

Hermetic. No network. No Atris credits. No real Claude/digest engine.

`node --test test/youtube-digest.test.js`

1. Successful digest stdout includes `digest filed:` and `next: atris youtube watch tick`.
2. Zero briefs includes `no video briefs` and `next: atris youtube search " "`, no watch-tick line.
3. Engine failure prints no next line.

Do not merge. One PR onto master.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d69cebcf-fb80-4156-b112-c296940f6ec1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d69cebcf-fb80-4156-b112-c296940f6ec1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

