### PR TITLE
Print search next-step after youtube unsave

### DIFF
--- a/commands/youtube.js
+++ b/commands/youtube.js
@@ -823,6 +823,9 @@ function runYoutubeUnsave(args = [], deps = {}) {
     const status = unsaveYoutubeNotes(target, deps);
     if (status !== 0) code = status;
   }
+  if (code === 0 && parsed.json !== true && deps.json !== true) {
+    printWatchSearchNext(output);
+  }
   return code;
 }
 

--- a/test/engine-ask.test.js
+++ b/test/engine-ask.test.js
@@ -342,11 +342,13 @@ test('silent fake engines fail or time out honestly and leave no process behind'
     const timedOut = await runAskProcess({
       bin: process.execPath,
       args: ['-e', silentScript],
-    }, { cwd: root, timeoutMs: 100 });
+    }, { cwd: root, timeoutMs: 1000 });
     assert.equal(timedOut.ok, false);
     assert.equal(timedOut.reason, 'timeout');
     assert.equal(timedOut.stdout, '');
     assert.equal(timedOut.stderr, '');
+    await waitUntil(() => fs.existsSync(pidFile), 2000)
+      .catch(() => assert.fail('silent engine must write its pid before timeout'));
     const pid = Number(fs.readFileSync(pidFile, 'utf8'));
     await wait(100);
     assert.equal(processIsAlive(pid), false);

--- a/test/youtube.test.js
+++ b/test/youtube.test.js
@@ -618,6 +618,10 @@ test('youtube unsave removes filed brief apply and notes pack', async () => {
 
   assert.equal(status, 0);
   assert.match(output.join('\n'), /removed atris\/wiki\/briefs\/youtube-gone01\.md and atris\/wiki\/briefs\/youtube-gone01\.apply\.md and atris\/experiments\/notes-gone01/);
+  assert.deepEqual(
+    output.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-gone01.md')), false);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'wiki', 'briefs', 'youtube-gone01.apply.md')), false);
   assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'notes-gone01')), false);
@@ -646,6 +650,10 @@ test('youtube unsave removes leftover packs when brief and apply are already gon
 
   assert.equal(status, 0);
   assert.match(output.join('\n'), /removed atris\/experiments\/notes-gone03 and atris\/experiments\/teach-gone03-s2/);
+  assert.deepEqual(
+    output.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
   assert.equal(fs.existsSync(notesPack), false);
   assert.equal(fs.existsSync(teachPack), false);
   assert.equal(fs.existsSync(path.join(otherPack, 'stay.txt')), true);
@@ -664,7 +672,67 @@ test('youtube notes --unsave and a missing id stay quiet', async () => {
 
   assert.equal(status, 0);
   assert.match(output.join('\n'), /already gone: atris\/wiki\/briefs\/youtube-gone02\.md and atris\/wiki\/briefs\/youtube-gone02\.apply\.md/);
+  assert.deepEqual(
+    output.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
   assert.equal(unsaveYoutubeNotes('gone02', { cwd, output: () => {} }), 0);
+});
+
+test('youtube unsave without a target prints usage and no next line', async () => {
+  const output = [];
+  const status = await youtubeCommand(['unsave'], {
+    output: (line) => output.push(line),
+    runner: () => {
+      throw new Error('unsave must not run notes');
+    },
+  });
+
+  assert.equal(status, 2);
+  assert.match(output.join('\n'), /usage: atris youtube unsave <url-or-id>/);
+  assert.equal(output.join('\n').includes('next:'), false);
+
+  const notesOut = [];
+  const notesStatus = await youtubeCommand(['notes', '--unsave'], {
+    output: (line) => notesOut.push(line),
+    runner: () => {
+      throw new Error('unsave must not run notes');
+    },
+  });
+  assert.equal(notesStatus, 2);
+  assert.match(notesOut.join('\n'), /usage: atris youtube unsave <url-or-id>/);
+  assert.equal(notesOut.join('\n').includes('next:'), false);
+});
+
+test('youtube unsave --json and multi-target print the search next-step once or not at all', async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-yt-unsave-json-'));
+  const jsonOut = [];
+  const jsonStatus = await youtubeCommand(['unsave', '--json', 'gone04'], {
+    cwd,
+    output: (line) => jsonOut.push(line),
+    runner: () => {
+      throw new Error('unsave must not run notes');
+    },
+  });
+  assert.equal(jsonStatus, 0);
+  assert.match(jsonOut.join('\n'), /already gone: atris\/wiki\/briefs\/youtube-gone04\.md/);
+  assert.equal(jsonOut.join('\n').includes('next:'), false);
+
+  const multiOut = [];
+  const multiStatus = await youtubeCommand(['unsave', 'gone05', 'gone06'], {
+    cwd,
+    output: (line) => multiOut.push(line),
+    runner: () => {
+      throw new Error('unsave must not run notes');
+    },
+  });
+  assert.equal(multiStatus, 0);
+  assert.match(multiOut.join('\n'), /already gone: atris\/wiki\/briefs\/youtube-gone05\.md/);
+  assert.match(multiOut.join('\n'), /already gone: atris\/wiki\/briefs\/youtube-gone06\.md/);
+  assert.deepEqual(
+    multiOut.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
 });
 
 test('youtube help says notes stay ephemeral unless --save', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Unsave used to print `removed …` or `already gone: …` and stop, so the next move was not pasteable.

After a successful unsave that removed files, or an already-gone unsave, the command now prints one line:

`next: atris youtube search " "`

Same placeholder as empty digest and an empty watch tick with channels. Usage or a missing target (exit 2) stays quiet. `--json` stays quiet. Multi-target prints that line once at the end.

Also hardens the silent-engine ask test so a loaded CI runner cannot time out before the fake engine writes its pid file.

## Test plan

- `node --test test/youtube.test.js`
- `node --test test/engine-ask.test.js`
- Removing real files includes `removed` and the search next-line
- Already gone includes `already gone` and the same next-line
- Usage / missing id prints no next-line
- `--json` skips the next-line; two targets print it once
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94d925de-27f6-43e6-874c-5b93dccf109a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94d925de-27f6-43e6-874c-5b93dccf109a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

