### PR TITLE
Print youtube search next-step after x-search unsave

### DIFF
--- a/commands/x-search.js
+++ b/commands/x-search.js
@@ -221,7 +221,9 @@ function parseUnsaveArgs(argv = []) {
   const options = {
     mode: 'unsave',
     help: false,
+    json: false,
     source: null,
+    sources: [],
   };
 
   if (args.length === 0 || ['help', '--help', '-h'].includes(args[0])) {
@@ -236,19 +238,20 @@ function parseUnsaveArgs(argv = []) {
     const arg = args[i];
     if (arg === '--help' || arg === '-h' || arg === 'help') {
       options.help = true;
+    } else if (arg === '--json') {
+      options.json = true;
     } else if (arg === '--unsave') {
       continue;
     } else if (arg.startsWith('-')) {
       throw new Error(`Unknown option: ${arg}`);
-    } else if (!options.source) {
-      options.source = arg;
     } else {
-      throw new Error(`Unexpected argument: ${arg}`);
+      options.sources.push(arg);
+      if (!options.source) options.source = arg;
     }
   }
 
   if (options.help) return options;
-  if (!options.source) throw new Error('usage: atris x-search unsave <query-or-source>');
+  if (!options.sources.length) throw new Error('usage: atris x-search unsave <query-or-source>');
   return options;
 }
 
@@ -530,6 +533,30 @@ function unsaveXSearch(target, deps = {}) {
   return 0;
 }
 
+function unsaveTargets(options) {
+  if (Array.isArray(options?.sources) && options.sources.length) return options.sources;
+  const single = options?.source || options?.query;
+  return single ? [single] : [];
+}
+
+function runXSearchUnsave(options, deps = {}) {
+  const output = deps.output || ((line = '') => console.log(line));
+  const targets = unsaveTargets(options);
+  if (!targets.length) {
+    output('usage: atris x-search unsave <query-or-source>');
+    return 2;
+  }
+  let code = 0;
+  for (const target of targets) {
+    const status = unsaveXSearch(target, deps);
+    if (status !== 0) code = status;
+  }
+  if (code === 0 && options.json !== true && deps.json !== true) {
+    printEmptyYoutubeSearchNext(output);
+  }
+  return code;
+}
+
 function saveRichXSearch({ cwd, source, text, now } = {}) {
   const lesson = xSearchLessonFromText(text);
   if (isThinTeachLesson(lesson)) {
@@ -620,7 +647,7 @@ async function xSearchCommand(argv = process.argv.slice(3), deps = {}) {
   }
 
   if (options.mode === 'unsave' || options.unsave) {
-    return unsaveXSearch(options.source || options.query, deps);
+    return runXSearchUnsave(options, deps);
   }
 
   let status = 0;

--- a/test/x-search-save.test.js
+++ b/test/x-search-save.test.js
@@ -310,6 +310,10 @@ test('x-search unsave after rich --save removes brief apply and pack', async () 
   assert.equal(status, 0);
   assert.equal(apiCalls, 0);
   assert.match(out.text(), /removed atris\/wiki\/briefs\/x-search-mcp-agents\.md and atris\/wiki\/briefs\/x-search-mcp-agents\.apply\.md and atris\/experiments\/x-search-mcp-agents/);
+  assert.deepEqual(
+    out.lines.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
   assert.equal(fs.existsSync(path.join(cwd, xSearchBriefRel('MCP agents'))), false);
   assert.equal(fs.existsSync(path.join(cwd, xSearchApplyRel('MCP agents'))), false);
   assert.equal(fs.existsSync(path.join(cwd, xSearchExperimentRel('MCP agents'))), false);
@@ -339,6 +343,10 @@ test('x-search unsave removes leftover pack when brief and apply are already gon
   assert.equal(status, 0);
   assert.equal(apiCalls, 0);
   assert.match(out.text(), /removed atris\/experiments\/x-search-mcp-agents/);
+  assert.deepEqual(
+    out.lines.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
   assert.equal(fs.existsSync(packDir), false);
   assert.equal(fs.existsSync(path.join(otherDir, 'stay.txt')), true);
 });
@@ -359,6 +367,10 @@ test('x-search unsave of a missing source stays quiet', async () => {
   assert.equal(status, 0);
   assert.equal(apiCalls, 0);
   assert.match(out.text(), /already gone: atris\/wiki\/briefs\/x-search-gone-query\.md and atris\/wiki\/briefs\/x-search-gone-query\.apply\.md/);
+  assert.deepEqual(
+    out.lines.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
   assert.equal(unsaveXSearch('gone query', { cwd, output: () => {} }), 0);
 });
 
@@ -394,6 +406,10 @@ test('x-search person rich --save then unsave removes the minted pack', async ()
   assert.equal(status, 0);
   assert.equal(apiCalls, 0);
   assert.match(out.text(), /removed atris\/wiki\/briefs\/x-search-leah-bonvissuto\.md and atris\/wiki\/briefs\/x-search-leah-bonvissuto\.apply\.md and atris\/experiments\/x-search-leah-bonvissuto/);
+  assert.deepEqual(
+    out.lines.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
   assert.equal(fs.existsSync(path.join(cwd, xSearchBriefRel('Leah Bonvissuto'))), false);
   assert.equal(fs.existsSync(path.join(cwd, xSearchApplyRel('Leah Bonvissuto'))), false);
   assert.equal(fs.existsSync(path.join(cwd, xSearchExperimentRel('Leah Bonvissuto'))), false);

--- a/test/x-search.test.js
+++ b/test/x-search.test.js
@@ -11,7 +11,9 @@ const {
   buildPersonPayload,
   xSearchHasResults,
   xSearchApplyRel,
+  xSearchBriefRel,
   xSearchExperimentSlug,
+  xSearchExperimentRel,
   xSearchCommand,
 } = require('../commands/x-search');
 const { TEACH_THIN_REFUSE } = require('../commands/youtube');
@@ -81,11 +83,18 @@ test('parseXSearchArgs accepts unsave subcommand and --unsave', () => {
   const sub = parseXSearchArgs(['unsave', 'MCP agents']);
   assert.equal(sub.mode, 'unsave');
   assert.equal(sub.source, 'MCP agents');
+  assert.deepEqual(sub.sources, ['MCP agents']);
+  assert.equal(sub.json, false);
   const flag = parseXSearchArgs(['MCP agents', '--unsave']);
   assert.equal(flag.mode, 'search');
   assert.equal(flag.query, 'MCP agents');
   assert.equal(flag.unsave, true);
+  const json = parseXSearchArgs(['unsave', '--json', 'MCP agents', 'other query']);
+  assert.equal(json.mode, 'unsave');
+  assert.equal(json.json, true);
+  assert.deepEqual(json.sources, ['MCP agents', 'other query']);
   assert.throws(() => parseXSearchArgs(['unsave']), /usage: atris x-search unsave/);
+  assert.throws(() => parseXSearchArgs(['unsave', '--json']), /usage: atris x-search unsave/);
   assert.throws(() => parseXSearchArgs(['--unsave']), /usage: atris x-search unsave/);
 });
 
@@ -794,4 +803,132 @@ test('502 with refunded credits surfaces them and does not invent a refund call'
   assert.doesNotMatch(text, /next: atris youtube search/);
   assert.equal(output.filter((line) => line === 'next: atris youtube search " "').length, 0);
   assertNoSaveFiles(cwd, 'agents');
+});
+
+function seedSavedXSearch(cwd, source) {
+  const briefRel = xSearchBriefRel(source);
+  const applyRel = xSearchApplyRel(source);
+  const packRel = xSearchExperimentRel(source);
+  fs.mkdirSync(path.join(cwd, 'atris', 'wiki', 'briefs'), { recursive: true });
+  fs.mkdirSync(path.join(cwd, packRel), { recursive: true });
+  fs.writeFileSync(path.join(cwd, briefRel), 'brief\n');
+  fs.writeFileSync(path.join(cwd, applyRel), 'apply\n');
+  fs.writeFileSync(path.join(cwd, packRel, 'measure.py'), 'print(0)\n');
+  return { briefRel, applyRel, packRel };
+}
+
+test('x-search unsave that removes files prints one youtube search next-step', async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-x-search-unsave-'));
+  seedSavedXSearch(cwd, 'MCP agents');
+  const output = [];
+  let apiCalls = 0;
+  const status = await xSearchCommand(['unsave', 'MCP agents'], {
+    cwd,
+    output: (line) => output.push(line),
+    apiRequestJson: async () => {
+      apiCalls += 1;
+      throw new Error('unsave must not call x-search');
+    },
+  });
+
+  assert.equal(status, 0);
+  assert.equal(apiCalls, 0);
+  assert.match(output.join('\n'), /removed atris\/wiki\/briefs\/x-search-mcp-agents\.md and atris\/wiki\/briefs\/x-search-mcp-agents\.apply\.md and atris\/experiments\/x-search-mcp-agents/);
+  assert.deepEqual(
+    output.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
+  assert.equal(fs.existsSync(path.join(cwd, xSearchBriefRel('MCP agents'))), false);
+  assert.equal(fs.existsSync(path.join(cwd, xSearchApplyRel('MCP agents'))), false);
+  assert.equal(fs.existsSync(path.join(cwd, xSearchExperimentRel('MCP agents'))), false);
+});
+
+test('x-search unsave of a missing source prints already gone and one youtube search next-step', async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-x-search-unsave-gone-'));
+  const output = [];
+  let apiCalls = 0;
+  const status = await xSearchCommand(['unsave', 'gone query'], {
+    cwd,
+    output: (line) => output.push(line),
+    apiRequestJson: async () => {
+      apiCalls += 1;
+      throw new Error('unsave must not call x-search');
+    },
+  });
+
+  assert.equal(status, 0);
+  assert.equal(apiCalls, 0);
+  assert.match(output.join('\n'), /already gone: atris\/wiki\/briefs\/x-search-gone-query\.md and atris\/wiki\/briefs\/x-search-gone-query\.apply\.md/);
+  assert.deepEqual(
+    output.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
+});
+
+test('x-search unsave without a target prints usage and no next line', async () => {
+  const output = [];
+  const status = await xSearchCommand(['unsave'], {
+    output: (line) => output.push(line),
+    apiRequestJson: async () => {
+      throw new Error('unsave must not call x-search');
+    },
+  });
+
+  assert.equal(status, 2);
+  assert.match(output.join('\n'), /usage: atris x-search unsave <query-or-source>/);
+  assert.equal(output.join('\n').includes('next:'), false);
+
+  const flagOut = [];
+  const flagStatus = await xSearchCommand(['--unsave'], {
+    output: (line) => flagOut.push(line),
+    apiRequestJson: async () => {
+      throw new Error('unsave must not call x-search');
+    },
+  });
+  assert.equal(flagStatus, 2);
+  assert.match(flagOut.join('\n'), /usage: atris x-search unsave <query-or-source>/);
+  assert.equal(flagOut.join('\n').includes('next:'), false);
+});
+
+test('x-search unsave --json and multi-target print the search next-step once or not at all', async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-x-search-unsave-json-'));
+  const jsonOut = [];
+  const jsonStatus = await xSearchCommand(['unsave', '--json', 'gone query'], {
+    cwd,
+    output: (line) => jsonOut.push(line),
+    apiRequestJson: async () => {
+      throw new Error('unsave must not call x-search');
+    },
+  });
+  assert.equal(jsonStatus, 0);
+  assert.match(jsonOut.join('\n'), /already gone: atris\/wiki\/briefs\/x-search-gone-query\.md/);
+  assert.equal(jsonOut.join('\n').includes('next:'), false);
+
+  const flagJsonOut = [];
+  const flagJsonStatus = await xSearchCommand(['gone query', '--unsave', '--json'], {
+    cwd,
+    output: (line) => flagJsonOut.push(line),
+    apiRequestJson: async () => {
+      throw new Error('unsave must not call x-search');
+    },
+  });
+  assert.equal(flagJsonStatus, 0);
+  assert.match(flagJsonOut.join('\n'), /already gone: atris\/wiki\/briefs\/x-search-gone-query\.md/);
+  assert.equal(flagJsonOut.join('\n').includes('next:'), false);
+
+  const multiOut = [];
+  const multiStatus = await xSearchCommand(['unsave', 'gone one', 'gone two'], {
+    cwd,
+    output: (line) => multiOut.push(line),
+    apiRequestJson: async () => {
+      throw new Error('unsave must not call x-search');
+    },
+  });
+  assert.equal(multiStatus, 0);
+  assert.match(multiOut.join('\n'), /already gone: atris\/wiki\/briefs\/x-search-gone-one\.md/);
+  assert.match(multiOut.join('\n'), /already gone: atris\/wiki\/briefs\/x-search-gone-two\.md/);
+  assert.deepEqual(
+    multiOut.filter((line) => String(line).startsWith('next:')),
+    ['next: atris youtube search " "'],
+  );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After `atris x-search unsave` removes a saved pull, or reports already gone, print one pasteable next step so the X rail does not dead-end.

```
next: atris youtube search " "
```

This matches youtube unsave. Usage and missing target stay quiet (exit 2). `--json` skips the line. Multi-target prints it once at the end.

Hermetic only. No paid X calls. Youtube commands are unchanged.

Verify: `node --test test/x-search.test.js`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b82b2053-0cbc-434f-a79d-e37ba12aee75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b82b2053-0cbc-434f-a79d-e37ba12aee75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

