### PR TITLE
Mint a failing apply after a rich learn log

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -121,7 +121,7 @@ rg "isAtrisCliRepo|refuse outside|--here|benchCommand" commands/bench.js test/do
 rg "whoCommand|parseScopeFlag|--global|filterProcessesToWorkspace" commands/who.js lib/cli-scope.js test/dogfood-pass2-t1-t5.test.js  # who defaults to workspace scope; --global for machine
 rg "founderCommand|--global|singleRepo|defaultScanRoot|isFreshWorkspace" commands/founder.js test/dogfood-pass2-t1-t5.test.js test/founder.test.js  # founder defaults to this workspace after a room exists; --global scans siblings; empty folders first-talk and write nothing
 rg "teachRoot|atris/teach|only reads" commands/teach.js test/dogfood-pass2-t1-t5.test.js  # teach reads ./atris/teach only
-rg "showLearnHelp|learnAtris|learn help|learnLogSchemaLines|title→key|detail→insight" commands/learn.js test/commands.test.js test/dogfood-papercuts.test.js # Project learnings + schema on help/validation + title/detail aliases
+rg "showLearnHelp|learnAtris|learn help|learnLogSchemaLines|title→key|detail→insight|mintRichLearn|saveRichLearn|learnExperimentSlug|proveSavedLearnerBaseline" commands/learn.js commands/youtube.js test/commands.test.js test/dogfood-papercuts.test.js test/learn-save.test.js # Project learnings + schema on help/validation + title/detail aliases. Rich `learn log` (number-with-units or named mechanism, same bar as youtube notes/teach) mints `atris/experiments/learn-<key>/` through `fileTeachExperiment` and one apply sidecar, then `proveSavedLearnerBaseline` prints `score: 0` only when that Apply starts failing. Thin log stays jsonl only.
 rg "showSoulHelp|async function soul|soul help" commands/soul.js test/commands.test.js # Soul/persona command + workspace-free help
 rg "workspace-free help smoke|showSearchHelp|showLearnHelp|showSoulHelp|showHelpShort|showHelpAll|help --all|help --json|already won|later|spaceship|recap|review|stop" bin/atris.js commands/learn.js commands/soul.js test/commands.test.js test/golden-path-help.test.js test/dogfood-papercuts.test.js test/dogfood-p0-safety.test.js  # Help surfaces: short first-minute doors, --all opens the same first-minute sentence then later/do/spaceship/autopilot/mission/recap/review/stop plus the long catalog, --json; default help has no em dash and no claim/ready/proof; --all has no box banner or MAP/journal lecture at the top
 rg "resolveFunctionalOwner|explicit_member_owner|remap_reason|engine_owner_resolved" lib/functional-owner.js commands/mission.js test/dogfood-papercuts.test.js test/mission-status.test.js  # Keep existing member owners; document remap_reason when engines remap
@@ -393,6 +393,7 @@ rg "outbound artifact gate|raw-html-in-plain-body|render-proof-missing|coach-sur
 - `atris/experiments/digest-<date>/` - minted by rich `atris youtube digest` through the same `fileTeachExperiment` helper (`commands/youtube.js:1034` `saveRichDigest`, slug at `commands/youtube.js:1002`); same keep-0-to-1 rule, apply sidecar `digest-<date>.apply.md`, thin digest writes no pack.
 - `atris/experiments/watch-<videoid>/` - minted by the first rich brief on `atris youtube watch tick` through the same `fileTeachExperiment` helper (`commands/youtube.js:1094` `saveRichWatch`, pick at `commands/youtube.js:1085` `firstRichWatchLesson`, slug at `commands/youtube.js:1047`); same keep-0-to-1 rule, apply sidecar `watch-<id>.apply.md`, all-thin watch tick writes no pack.
 - `atris/experiments/x-search-<slug>/` - minted by rich `atris x-search --save` through the same `fileTeachExperiment` helper (`commands/youtube.js:2655`, called from `commands/x-search.js:521` `saveRichXSearch`, slug at `commands/x-search.js:419`); same keep-0-to-1 rule, apply sidecar `x-search-<slug>.apply.md`, thin `--save` writes no pack. Default x-search without `--save` writes no pack (`commands/x-search.js:645`). `atris x-search unsave <query-or-source>` (`commands/x-search.js:498`) deletes this pack with the brief and apply sidecar; leftover pack-only still removes the pack.
+- `atris/experiments/learn-<key>/` - minted by rich `atris learn log` through the same `fileTeachExperiment` helper (`commands/learn.js` `saveRichLearn`, slug `learnExperimentSlug`); same keep-0-to-1 rule, apply sidecar `learn-<key>.apply.md`, thin log writes no pack.
 - **Value:** Makes self-improvement loops and scoreable benchmark runs first-class Atris CLI concepts instead of repo-local convention
 
 **Search:** `rg "experimentsCommand|experimentsKeep|experimentsRevert|printKeepRevertNext|printRevertKeepNext|printKeepWatchTickNext|runMeasureJson|runResetScript|experimentsRun|experimentsCompare|experimentsReplay|buildBenchmarkArtifact|ensureExperimentsFramework|experimentsDaily|experimentsQueue|sessionstart-plant|teach-thin-save|fileTeachExperiment|ensureTeachApply|teachExperimentSlug|notesExperimentSlug|digestExperimentSlug|watchExperimentSlug|saveRichNotes|saveRichDigest|ensureDigestApply|saveRichWatch|ensureWatchApply|xSearchExperimentSlug|saveRichXSearch|unsaveXSearch" commands/experiments.js commands/init.js lib/experiments/daily.js commands/autoland.js commands/youtube.js commands/x-search.js atris/experiments/sessionstart-plant atris/experiments/teach-thin-save`
@@ -1437,12 +1438,13 @@ rg "printRoster|registryPayload|canPersistEngineRegistry|speakFirstMinute|--glob
 **Purpose:** Store and inspect reusable project patterns, pitfalls, preferences, architecture notes, and tool lessons.
 
 - **Entry point:** `bin/atris.js:1574-1577` routes to `commands/learn.js`
-- **Handler:** `commands/learn.js:367-411` (`learnAtris`)
-- **Help:** `commands/learn.js:350-364` (`showLearnHelp`) and `commands/learn.js:368-371` short-circuit help before workspace checks
-- **Regression:** `test/commands.test.js:3731-3745` covers `learn --help`, `learn -h`, and `learn help` without temp workspace state
-- **Value:** Agents can inspect and add compounding memory without conflating it with journal search or Atris lessons.
+- **Handler:** `commands/learn.js` (`learnAtris`)
+- **Help:** `showLearnHelp` short-circuits help before workspace checks
+- **Rich log mint:** `commands/learn.js` `mintRichLearn` / `saveRichLearn` / `ensureLearnApply`. A rich `atris learn log` insight (number-with-units or named mechanism) mints `atris/experiments/learn-<key>/` plus `atris/wiki/briefs/learn-<key>.apply.md`, prints `next: atris experiments keep learn-<key>`, then `proveSavedLearnerBaseline` prints `score: 0` only when that sidecar starts failing. Thin log stays jsonl only.
+- **Regression:** `test/commands.test.js` covers `learn --help`; `test/learn-save.test.js` covers rich mint + failing baseline and thin jsonl-only; `test/dogfood-papercuts.test.js` covers title/detail aliases
+- **Value:** Agents can inspect and add compounding memory without conflating it with journal search or Atris lessons. A rich YouTube/X lesson captured through learn becomes one claimable Apply.
 
-**Search:** `rg "showLearnHelp|learnAtris|learn help" commands/learn.js test/commands.test.js`
+**Search:** `rg "showLearnHelp|learnAtris|learn help|mintRichLearn|saveRichLearn" commands/learn.js test/learn-save.test.js test/commands.test.js`
 
 ### Feature: Soul (`atris soul`)
 

--- a/atris/skills/youtube/SKILL.md
+++ b/atris/skills/youtube/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: youtube
 description: "YouTube discovery and learning. Get watch permalinks with atris youtube search QUERY (free, local ytsearch/yt-dlp). On 429 use printed rows if any; else the CLI retries once, then cached rows if printed, else STOP. Never run --paid after a 429. --paid only when the user explicitly asked to buy permalinks (5 credits). After a URL is picked, atris youtube notes URL (free, ephemeral unless --save). atris youtube process only to store knowledge (5 credits). Never paste tokens. Never /auth/cli. Mint with atris login --agent from a stored login. Never summarize a video from model memory. Triggers on: youtube search, find videos, paid youtube search, any youtube.com or youtu.be link, youtube, video, watch this, notes on this."
-version: 2.18.4
+version: 2.18.5
 tags:
   - youtube
   - research
@@ -44,6 +44,10 @@ search QUERY (free)
     |                 owed prints unpaid check; successful unlock prints next section command
     |                 bare teach resumes owed, or prints a start command if nothing is owed
     |
+   persist a rich lesson? --> learn log '{"type":"pattern","key":"...","insight":"..."}'
+                           --> rich: one pack-named apply + failing measure.py (score 0), then next: experiments keep
+                           --> thin: jsonl only
+
    write one Apply (claimable) before process
     |
    store knowledge? --> process URL (5 credits)

--- a/commands/learn.js
+++ b/commands/learn.js
@@ -12,6 +12,16 @@ const {
   getStats,
   exportMarkdown,
 } = require('../lib/learnings');
+const applyGate = require('../lib/apply-gate');
+const {
+  fileTeachExperiment,
+  extractTeachNumbers,
+  extractTeachMechanisms,
+  isThinTeachLesson,
+  proveSavedLearnerBaseline,
+} = require('./youtube');
+
+const KEEP_RULE = 'keep only if measure.py moves 0→1. scores 1 only when the fixture contains the check tokens.';
 
 function showRecent(limit = 20) {
   const learnings = loadLearnings()
@@ -239,24 +249,101 @@ function printLearnLogSchema(stream = console.error) {
   for (const line of learnLogSchemaLines()) stream(`  ${line}`);
 }
 
+function learnExperimentSlug(key) {
+  return `learn-${applyGate.applySlug(key)}`;
+}
+
+function learnExperimentRel(key) {
+  return `atris/experiments/${learnExperimentSlug(key)}`;
+}
+
+function learnApplyRel(key) {
+  return applyGate.applySidecarRel('learn', applyGate.applySlug(key));
+}
+
+function learnLessonFromText(text) {
+  const body = String(text || '');
+  return {
+    numbers: extractTeachNumbers(body),
+    mechanisms: extractTeachMechanisms(body),
+  };
+}
+
+function saveRichLearn({ cwd, key, insight } = {}) {
+  const lesson = learnLessonFromText(insight);
+  if (isThinTeachLesson(lesson)) {
+    return { thin: true, packRel: null, lesson };
+  }
+  if (cwd) fs.mkdirSync(path.join(cwd, 'atris', 'wiki'), { recursive: true });
+  const packRel = fileTeachExperiment({
+    cwd,
+    lesson,
+    slug: key ? learnExperimentSlug(key) : null,
+    applyRel: key ? learnApplyRel(key) : null,
+  });
+  return { thin: false, packRel, lesson };
+}
+
+function ensureLearnApply({ cwd, key, packRel, now, output } = {}) {
+  const pack = packRel || (key ? learnExperimentRel(key) : null);
+  const slug = pack ? path.basename(pack) : null;
+  return applyGate.ensureApply({
+    cwd,
+    source: key ? `learn:${key}` : 'learn',
+    rel: key ? learnApplyRel(key) : null,
+    now,
+    output,
+    incompleteMessage: slug
+      ? `next: atris experiments keep ${slug}`
+      : applyGate.ephemeralApplyMessage('learning'),
+    required: false,
+    change: pack ? `apply ${pack}` : undefined,
+    receipt: pack ? KEEP_RULE : undefined,
+    journalLine: pack ? `- [claimable] apply: ${pack}. ${KEEP_RULE}` : undefined,
+  });
+}
+
+function mintRichLearn({ cwd, key, insight, now, output } = {}) {
+  const print = typeof output === 'function' ? output : (line = '') => console.log(line);
+  const saved = saveRichLearn({ cwd, key, insight });
+  if (saved.thin) return 0;
+  ensureLearnApply({
+    cwd,
+    key,
+    packRel: saved.packRel,
+    now,
+    output: print,
+  });
+  return proveSavedLearnerBaseline({
+    cwd,
+    applyRel: key ? learnApplyRel(key) : null,
+    lesson: saved.lesson,
+    output: print,
+  });
+}
+
 /**
  * Non-interactive log: `atris learn log '{"type":"pattern","key":"...","insight":"...","confidence":8,"source":"observed"}'`
  * For agents and scripts, no prompts, no quality gate.
  * Aliases: title→key, detail→insight.
  */
-function logDirect(jsonStr) {
+function logDirect(jsonStr, deps = {}) {
+  const error = typeof deps.error === 'function' ? deps.error : (line = '') => console.error(line);
+  const print = typeof deps.output === 'function' ? deps.output : (line = '') => console.log(line);
+  const exit = typeof deps.exit === 'function' ? deps.exit : (code) => process.exit(code);
+  const cwd = deps.cwd || process.cwd();
   if (!jsonStr) {
-    console.error('  ✗ Usage: atris learn log \'<json>\'');
-    printLearnLogSchema();
-    process.exit(1);
+    error('  ✗ Usage: atris learn log \'<json>\'');
+    printLearnLogSchema(error);
+    return exit(1);
   }
   let data;
   try {
     data = JSON.parse(jsonStr);
   } catch (err) {
-    console.error(`  ✗ Invalid JSON: ${err.message}`);
-    printLearnLogSchema();
-    process.exit(1);
+    error(`  ✗ Invalid JSON: ${err.message}`);
+    printLearnLogSchema(error);
+    return exit(1);
   }
   try {
     const entry = addLearning({
@@ -267,11 +354,20 @@ function logDirect(jsonStr) {
       source: data.source || 'observed',
       files: data.files || [],
     });
-    console.log(`  ✓ [${entry.confidence}/10] ${entry.type}/${entry.key}`);
+    print(`  ✓ [${entry.confidence}/10] ${entry.type}/${entry.key}`);
+    const baseline = mintRichLearn({
+      cwd,
+      key: entry.key,
+      insight: entry.insight,
+      now: deps.now,
+      output: print,
+    });
+    if (baseline !== 0) return exit(baseline);
+    return 0;
   } catch (err) {
-    console.error(`  ✗ ${err.message}`);
-    printLearnLogSchema();
-    process.exit(1);
+    error(`  ✗ ${err.message}`);
+    printLearnLogSchema(error);
+    return exit(1);
   }
 }
 
@@ -376,7 +472,7 @@ function showLearnHelp() {
   console.log('  Commands:');
   console.log('    (none)     Show recent learnings');
   console.log('    add        Add a learning interactively');
-  console.log('    log <json> Add programmatically (for agents)');
+  console.log('    log <json> Add programmatically (for agents). A rich insight (number or named mechanism) mints one apply plus a failing measure.py.');
   console.log('    search <q> Search learnings by keyword');
   console.log('    harvest    Extract learnings from journal Notes');
   console.log('    prune      Check for stale/contradictory entries');
@@ -437,5 +533,13 @@ function learnAtris(subcommand, ...args) {
 }
 
 learnAtris.getLearningCount = getLearningCount;
+learnAtris.learnExperimentSlug = learnExperimentSlug;
+learnAtris.learnExperimentRel = learnExperimentRel;
+learnAtris.learnApplyRel = learnApplyRel;
+learnAtris.learnLessonFromText = learnLessonFromText;
+learnAtris.saveRichLearn = saveRichLearn;
+learnAtris.ensureLearnApply = ensureLearnApply;
+learnAtris.mintRichLearn = mintRichLearn;
+learnAtris.logDirect = logDirect;
 
 module.exports = learnAtris;

--- a/test/learn-save.test.js
+++ b/test/learn-save.test.js
@@ -1,0 +1,255 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  extractTeachNumbers,
+  extractTeachMechanisms,
+  isThinTeachLesson,
+  LEARNER_SCORE_ZERO,
+} = require('../commands/youtube');
+const learnAtris = require('../commands/learn');
+const {
+  learnExperimentSlug,
+  learnApplyRel,
+  learnExperimentRel,
+  saveRichLearn,
+  mintRichLearn,
+  logDirect,
+} = learnAtris;
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const VALIDATE_PY = path.join(REPO_ROOT, 'atris', 'experiments', 'validate.py');
+const CLI_PATH = path.join(REPO_ROOT, 'bin', 'atris.js');
+
+function findPython() {
+  for (const candidate of ['python3', 'python']) {
+    const result = spawnSync(candidate, ['--version'], { encoding: 'utf8' });
+    if (!result.error && result.status === 0) return candidate;
+  }
+  return null;
+}
+
+const pythonCmd = findPython();
+
+const RICH_INSIGHT = '37signals has 80 people and uses the omakase model';
+const THIN_INSIGHT = 'check MAP.md before grep';
+const RICH_KEY = 'attention window';
+
+function collect() {
+  const lines = [];
+  return {
+    lines,
+    output: (line = '') => lines.push(String(line)),
+    text: () => lines.join('\n'),
+  };
+}
+
+function escapeRe(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function learnWorkspace() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'atris-learn-save-'));
+  fs.mkdirSync(path.join(cwd, 'atris'), { recursive: true });
+  return cwd;
+}
+
+function runCliLearnLog(cwd, payload) {
+  return spawnSync(process.execPath, [CLI_PATH, 'learn', 'log', JSON.stringify(payload)], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+    },
+  });
+}
+
+function runExperimentsKeep(cwd, slug) {
+  return spawnSync(process.execPath, [CLI_PATH, 'experiments', 'keep', slug], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: {
+      ...process.env,
+      ATRIS_SKIP_UPDATE_CHECK: '1',
+      ...(pythonCmd ? { ATRIS_EXPERIMENTS_PYTHON: pythonCmd } : {}),
+    },
+  });
+}
+
+function assertLearnApplyClaimable(cwd, { key, tokens = [], date = '2026-09-08' } = {}) {
+  const packRel = learnExperimentRel(key);
+  const applyRel = learnApplyRel(key);
+  const sidecar = fs.readFileSync(path.join(cwd, applyRel), 'utf8');
+  assert.match(sidecar, new RegExp(escapeRe(packRel)));
+  assert.match(sidecar, /keep only if measure\.py moves 0→1/);
+  assert.match(sidecar, /scores 1 only when the fixture contains the check tokens/);
+  for (const token of tokens) {
+    assert.doesNotMatch(sidecar, new RegExp(escapeRe(token), 'i'));
+  }
+  const journal = fs.readFileSync(path.join(cwd, 'atris', 'logs', date.slice(0, 4), `${date}.md`), 'utf8');
+  assert.match(journal, /\[claimable\] apply: /);
+  assert.match(journal, new RegExp(escapeRe(packRel)));
+  assert.match(journal, /keep only if measure\.py moves 0→1/);
+  return { packRel, applyRel, sidecar, journal };
+}
+
+test('learnExperimentSlug prefixes the key slug', () => {
+  assert.equal(learnExperimentSlug('attention window'), 'learn-attention-window');
+  assert.equal(learnExperimentSlug('omakase model'), 'learn-omakase-model');
+});
+
+test('thin learn log writes jsonl only', () => {
+  const numbers = extractTeachNumbers(THIN_INSIGHT);
+  const mechanisms = extractTeachMechanisms(THIN_INSIGHT);
+  assert.deepEqual(numbers, []);
+  assert.deepEqual(mechanisms, []);
+  assert.equal(isThinTeachLesson({ numbers, mechanisms }), true);
+
+  const cwd = learnWorkspace();
+  const saved = saveRichLearn({ cwd, key: 'map-first', insight: THIN_INSIGHT });
+  assert.equal(saved.thin, true);
+  assert.equal(saved.packRel, null);
+  assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments')), false);
+  assert.equal(fs.existsSync(path.join(cwd, learnApplyRel('map-first'))), false);
+});
+
+test('rich learn mint writes a failing apply and prints score 0', () => {
+  assert.ok(pythonCmd, 'python3 is required to score the minted pack');
+  const cwd = learnWorkspace();
+  const out = collect();
+  const status = mintRichLearn({
+    cwd,
+    key: RICH_KEY,
+    insight: RICH_INSIGHT,
+    now: '2026-09-08',
+    output: out.output,
+  });
+
+  assert.equal(status, 0);
+  assert.equal(out.lines.filter((line) => line === LEARNER_SCORE_ZERO).length, 1);
+  assert.match(out.text(), /next: atris experiments keep learn-attention-window/);
+  assert.doesNotMatch(out.text(), /next: atris youtube/);
+
+  const packDir = path.join(cwd, 'atris', 'experiments', 'learn-attention-window');
+  for (const name of ['program.md', 'measure.py', 'loop.py', 'reset.py', 'results.tsv']) {
+    assert.equal(fs.existsSync(path.join(packDir, name)), true, name);
+  }
+  const program = fs.readFileSync(path.join(packDir, 'program.md'), 'utf8');
+  assert.ok(program.length < 1200);
+  assert.match(program, /omakase model/);
+  const measureSrc = fs.readFileSync(path.join(packDir, 'measure.py'), 'utf8');
+  assert.match(measureSrc, /omakase model/);
+
+  const validated = spawnSync(pythonCmd, [VALIDATE_PY, packDir], { encoding: 'utf8' });
+  assert.equal(validated.status, 0, validated.stderr || validated.stdout);
+  assert.match(validated.stdout, /PASS/);
+
+  function scoreFixture(text) {
+    const fixture = path.join(cwd, 'fixture.md');
+    fs.writeFileSync(fixture, text);
+    const measured = spawnSync(pythonCmd, [path.join(packDir, 'measure.py')], {
+      cwd: packDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ATRIS_REPO_ROOT: cwd,
+        ATRIS_TEACH_MEASURE_FIXTURE: fixture,
+      },
+    });
+    assert.equal(measured.status, 0, measured.stderr || measured.stdout);
+    return JSON.parse(measured.stdout.trim().split('\n').pop());
+  }
+
+  const miss = scoreFixture('feelings and vibes and a chat about nothing');
+  assert.equal(miss.score, 0);
+  const hit = scoreFixture('keep the omakase model as the default stack');
+  assert.equal(hit.score, 1);
+
+  const claim = assertLearnApplyClaimable(cwd, {
+    key: RICH_KEY,
+    tokens: ['omakase model', 'what is the omakase model?'],
+  });
+  const stub = spawnSync(pythonCmd, [path.join(packDir, 'measure.py')], {
+    cwd: packDir,
+    encoding: 'utf8',
+    env: { ...process.env, ATRIS_REPO_ROOT: cwd },
+  });
+  assert.equal(stub.status, 0, stub.stderr || stub.stdout);
+  const stubPayload = JSON.parse(stub.stdout.trim().split('\n').pop());
+  assert.equal(stubPayload.score, 0);
+  assert.doesNotMatch(claim.sidecar, /omakase model/i);
+
+  const keep = runExperimentsKeep(cwd, 'learn-attention-window');
+  assert.equal(keep.status, 1, keep.stderr || keep.stdout);
+  assert.match(keep.stderr + keep.stdout, /revert|score 0|keep only if/i);
+});
+
+test('rich learn log through the live cli mints the pack', () => {
+  const cwd = learnWorkspace();
+  const result = runCliLearnLog(cwd, {
+    type: 'pattern',
+    key: RICH_KEY,
+    insight: RICH_INSIGHT,
+    confidence: 8,
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /attention-window|attention window/);
+  assert.match(result.stdout, /score: 0/);
+  assert.match(result.stdout, /next: atris experiments keep learn-attention-window/);
+  assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments', 'learn-attention-window', 'measure.py')), true);
+  assert.equal(fs.existsSync(path.join(cwd, learnApplyRel(RICH_KEY))), true);
+  const jsonl = fs.readFileSync(path.join(cwd, 'atris', 'learnings.jsonl'), 'utf8');
+  assert.match(jsonl, /omakase model/);
+});
+
+test('thin learn log through the live cli stays jsonl only', () => {
+  const cwd = learnWorkspace();
+  const result = runCliLearnLog(cwd, {
+    type: 'pattern',
+    title: 'map-first',
+    detail: THIN_INSIGHT,
+    confidence: 8,
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /map-first/);
+  assert.doesNotMatch(result.stdout + result.stderr, /score: 0/);
+  assert.doesNotMatch(result.stdout + result.stderr, /next: atris experiments keep/);
+  assert.equal(fs.existsSync(path.join(cwd, 'atris', 'experiments')), false);
+  assert.equal(fs.existsSync(path.join(cwd, learnApplyRel('map-first'))), false);
+});
+
+test('learn log without a key still refuses invented success', () => {
+  const cwd = learnWorkspace();
+  const origCwd = process.cwd();
+  const out = collect();
+  const err = collect();
+  let exitCode = 0;
+  process.chdir(cwd);
+  try {
+    logDirect(JSON.stringify({
+      type: 'pattern',
+      insight: RICH_INSIGHT,
+    }), {
+      cwd,
+      output: out.output,
+      error: err.output,
+      exit: (code) => {
+        exitCode = code;
+        return code;
+      },
+    });
+  } finally {
+    process.chdir(origCwd);
+  }
+  assert.notEqual(exitCode, 0);
+  assert.match(err.text(), /Schema:/);
+  assert.doesNotMatch(out.text(), /score: 0/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A rich `atris learn log` used to write jsonl and stop. That was the first remaining in-bar learner hole: a rich YouTube/X lesson captured through learn never minted a failing `measure.py` or one claimable Apply.

This PR closes that hole.

After a successful rich log (number-with-units or named mechanism, same bar as youtube notes/teach):

- mint `atris/experiments/learn-<key>/` through the existing teach pack helper
- write one apply sidecar that omits the check tokens so baseline stays 0
- print `next: atris experiments keep learn-<key>`
- prove the Apply starts failing and print `score: 0`

Thin logs stay jsonl only. No youtube-search next-step. No paid youtube process or x-search calls.

## Verify

```bash
node --test test/learn-save.test.js test/learnings.test.js test/dogfood-papercuts.test.js
```

Expected: rich log mints the pack and apply, `measure.py` scores 0 on the sidecar and 1 only when the fixture contains the check tokens, thin log writes no pack, title/detail aliases still work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa6e7c26-5753-4754-9f4c-5c55c0d64892?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa6e7c26-5753-4754-9f4c-5c55c0d64892&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

