### PR TITLE
Use a leftover scoped token for billed YouTube pulls, do not remint

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -6,7 +6,7 @@
 
 ## Quick Reference Index
 
-- Login token isolation: `utils/auth.js:355` refuses scoped tokens in the login field; `loadCredentials(apiRequestJson)` repairs legacy files through refresh for authenticated callers while synchronous local reads stay offline. `commands/auth.js:88` stores minted keys in `agent_token` with scope/expiry metadata, and billed commands reuse only valid scoped keys. Regression: `test/auth-login-storage.test.js`, `test/auth-agent-token.test.js`, `test/billed-command-auth.test.js`.
+- Login token isolation: `utils/auth.js:355` refuses scoped tokens in the login field; `loadCredentials(apiRequestJson)` repairs legacy files through refresh for authenticated callers while synchronous local reads stay offline. `commands/auth.js:88` `isAgentAccessToken` / `scopedTokenCandidate` / `canMintFromLogin` treat a leftover login-field `agent_access` key as a billed candidate when the scope matches, and refuse remint when there is no real session JWT. `persistMintedAgentToken` will not write a scoped key back into `token`. Regression: `test/auth-login-storage.test.js`, `test/auth-agent-token.test.js`, `test/billed-command-auth.test.js`.
 
 - Member alive dispatcher lookup: `lib/member-alive.js:64` prefers workspace scripts, then the packaged `scripts/member-operate.mjs`; `test/member-alive.test.js` verifies installed dispatch, workspace cwd, and override precedence.
 - Member alive execution results: `scripts/member-operate.mjs:38` reads multiline JSON and preserves explicit failures despite zero process exit. Explicit `--shared-checkout` passes through `commands/member.js` and `lib/member-alive.js`; developer isolation remains the default. Regression: `test/member-alive.test.js`.

--- a/commands/auth.js
+++ b/commands/auth.js
@@ -85,7 +85,33 @@ function extractAgentTokenMeta(data, requested, token) {
   return { scopes, dailyCreditCap, expiresAt };
 }
 
+function isAgentAccessToken(token) {
+  return decodeJwtClaims(token)?.type === 'agent_access';
+}
+
+function scopedTokenCandidate(credentials = {}) {
+  if (credentials.agent_token) return credentials.agent_token;
+  if (
+    credentials.source === 'env'
+    || credentials.source === 'agent_token_file'
+    || isAgentAccessToken(credentials.token)
+  ) {
+    return firstNonEmptyString(credentials.token);
+  }
+  return null;
+}
+
+function canMintFromLogin(credentials = {}) {
+  const login = firstNonEmptyString(credentials.token);
+  const refresh = firstNonEmptyString(credentials.refresh_token);
+  if (isAgentAccessToken(login) && !refresh) return false;
+  return Boolean(login || refresh);
+}
+
 function persistMintedAgentToken(credentials, token, extras = {}) {
+  if (isAgentAccessToken(credentials.token)) {
+    throw new Error('Refusing to save a scoped agent token as the login token; keep it under agent_token');
+  }
   const next = {
     ...credentials,
     refresh_token: extras.refresh_token || credentials.refresh_token || null,
@@ -141,7 +167,7 @@ async function mintScopedAgentToken(requested = {}, deps = {}) {
   const credentials = await load(api) || {};
   const accessToken = firstNonEmptyString(credentials.token);
   const refreshToken = firstNonEmptyString(credentials.refresh_token);
-  if (!accessToken && !refreshToken) {
+  if (!canMintFromLogin(credentials)) {
     return { ok: false, code: 'not_logged_in', error: NO_STORED_JWT_MESSAGE };
   }
 
@@ -149,7 +175,7 @@ async function mintScopedAgentToken(requested = {}, deps = {}) {
     scopes,
     daily_credit_cap: dailyCreditCap,
   };
-  let authToken = accessToken || refreshToken;
+  let authToken = isAgentAccessToken(accessToken) ? refreshToken : (accessToken || refreshToken);
   let result = await postAgentToken(api, authToken, body);
   if (!result.ok && result.status === 401 && refreshToken && authToken !== refreshToken) {
     authToken = refreshToken;
@@ -199,7 +225,7 @@ async function ensureBilledCommandAuth(scope, deps = {}) {
   const ensured = !deps.forceMint && deps.ensureValidCredentials
     ? await deps.ensureValidCredentials(api) : null;
   const credentials = ensured?.credentials || await load(api) || {};
-  const candidate = credentials.agent_token || ((credentials.source === 'env' || credentials.source === 'agent_token_file') ? credentials.token : null);
+  const candidate = scopedTokenCandidate(credentials);
   const claims = decodeJwtClaims(candidate);
   const scopes = claims?.scopes || credentials.agent_token_scopes || [];
   const expiry = claims?.exp ? claims.exp * 1000 : Date.parse(credentials.agent_token_expires_at);
@@ -207,7 +233,7 @@ async function ensureBilledCommandAuth(scope, deps = {}) {
     return { ok: true, token: candidate, minted: false, credentials };
   }
 
-  if (!firstNonEmptyString(credentials.token, credentials.refresh_token)) {
+  if (!canMintFromLogin(credentials)) {
     return { ok: false, error: NO_STORED_JWT_MESSAGE };
   }
 

--- a/test/auth-login-storage.test.js
+++ b/test/auth-login-storage.test.js
@@ -30,6 +30,17 @@ test('saveCredentials rejects agent_access before changing any login file', t =>
   assert.equal(fs.readFileSync(file, 'utf8'), before);
 });
 
+test('persistMintedAgentToken refuses a scoped login token without writing', t => {
+  const { file } = sandbox(t);
+  fs.writeFileSync(file, JSON.stringify({ token: agent }));
+  const before = fs.readFileSync(file, 'utf8');
+  assert.throws(
+    () => persistMintedAgentToken({ token: agent }, jwt({ type: 'agent_access', scopes: ['x-search'], exp })),
+    /Refusing to save a scoped agent token as the login token/,
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), before);
+});
+
 test('persistMintedAgentToken preserves session and stores scoped metadata', t => {
   const { read } = sandbox(t);
   auth.saveCredentials('session', 'refresh', 'owner@example.com', 'owner', 'google');
@@ -92,6 +103,44 @@ for (const state of ['valid', 'expired', 'wrong-scope', 'missing']) {
     assert.equal(result.token, state === 'valid' ? token : 'new-agent');
   });
 }
+
+test('billed auth uses a login-field scoped token when the scope matches', async () => {
+  let minted = 0;
+  const result = await ensureBilledCommandAuth('youtube', {
+    loadCredentials: () => ({ token: agent }),
+    mintScopedAgentToken: async () => {
+      minted += 1;
+      return { ok: true, token: 'new-agent' };
+    },
+    apiRequestJson: async () => {
+      throw new Error('scoped login must not remint');
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.minted, false);
+  assert.equal(result.token, agent);
+  assert.equal(minted, 0);
+});
+
+test('billed auth does not remint from a login-field scoped token for another scope', async () => {
+  let minted = 0;
+  const result = await ensureBilledCommandAuth('x-search', {
+    loadCredentials: () => ({ token: agent }),
+    persistMintedAgentToken: () => {
+      throw new Error('should not persist');
+    },
+    mintScopedAgentToken: async () => {
+      minted += 1;
+      return { ok: true, token: 'new-agent' };
+    },
+    apiRequestJson: async () => {
+      throw new Error('scoped login must not remint');
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'not signed in. run atris login first.');
+  assert.equal(minted, 0);
+});
 
 test('authenticated loader repairs before validating the restored session', async t => {
   const { file, read } = sandbox(t);

--- a/test/billed-command-auth.test.js
+++ b/test/billed-command-auth.test.js
@@ -11,6 +11,10 @@ const { spawn, spawnSync } = require('node:child_process');
 const { ensureBilledCommandAuth } = require('../commands/auth');
 const { xSearchApplyRel } = require('../commands/x-search');
 
+const jwt = (claims) => `e30.${Buffer.from(JSON.stringify(claims)).toString('base64url')}.signature`;
+const agentExp = Math.floor(Date.now() / 1000) + 3600;
+const youtubeAgent = jwt({ type: 'agent_access', scopes: ['youtube'], exp: agentExp });
+
 const repoRoot = path.resolve(__dirname, '..');
 const cliPath = path.join(repoRoot, 'bin', 'atris.js');
 const SECRET = 'minted-billed-agent-token-secret';
@@ -470,6 +474,92 @@ test('atris youtube process mints a youtube token from the stored JWT and retrie
     assert.equal(stored.token, 'stored-user-jwt');
     assert.equal(stored.agent_token, SECRET);
     assert.equal(stored.refresh_token, 'stored-refresh-jwt');
+  } finally {
+    await closeServer(mock.server);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('atris youtube process uses a login-field scoped token and does not remint', async () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  writeCredentials(home, { token: youtubeAgent, provider: 'atris' });
+
+  const applyDir = path.join(dir, 'atris', 'wiki', 'briefs');
+  fs.mkdirSync(applyDir, { recursive: true });
+  fs.writeFileSync(path.join(applyDir, 'youtube-abc123.apply.md'), [
+    'source: https://youtu.be/abc123',
+    'change: commands/youtube.js',
+    'receipt: node --test test/billed-command-auth.test.js',
+    '',
+  ].join('\n'));
+
+  const mock = await startHttpMock((request) => {
+    if (request.url === '/api/auth/agent-token') {
+      return { status: 500, body: { error: 'scoped login must not remint' } };
+    }
+    if (request.url === '/api/agent/process_youtube') {
+      assert.equal(request.authorization, `Bearer ${youtubeAgent}`);
+      return {
+        status: 200,
+        body: {
+          status: 'success',
+          message: 'ok',
+          video_analysis: 'scoped login youtube worked',
+          credits_used: 5,
+          credits_remaining: 40,
+        },
+      };
+    }
+    return { status: 404, body: { error: `unexpected ${request.url}` } };
+  });
+
+  try {
+    const res = await runCliAsync(['youtube', 'process', 'https://youtu.be/abc123'], {
+      cwd: dir,
+      env: {
+        HOME: home,
+        ATRIS_API_URL: `http://127.0.0.1:${mock.port}/api`,
+      },
+    });
+    assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`);
+    assert.equal(mock.requests.some((req) => req.url === '/api/auth/agent-token'), false);
+    const processCall = mock.requests.find((req) => req.url === '/api/agent/process_youtube');
+    assert.ok(processCall, 'expected youtube process');
+    assert.equal(processCall.authorization, `Bearer ${youtubeAgent}`);
+    assert.match(res.stdout, /scoped login youtube worked/);
+    assert.doesNotMatch(`${res.stdout}\n${res.stderr}`, /Refusing to save a scoped agent token/);
+    assert.equal(readCredentials(home).token, youtubeAgent);
+    assert.equal(readCredentials(home).agent_token, undefined);
+  } finally {
+    await closeServer(mock.server);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('atris x-search with a youtube-only scoped login token stays off remint and the paid pull', async () => {
+  const dir = makeTempDir();
+  const home = path.join(dir, 'home');
+  writeCredentials(home, { token: youtubeAgent, provider: 'atris' });
+
+  const mock = await startHttpMock((request) => {
+    return { status: 500, body: { error: `unexpected ${request.url}` } };
+  });
+
+  try {
+    const res = await runCliAsync(['x-search', 'MCP agents'], {
+      cwd: dir,
+      env: {
+        HOME: home,
+        ATRIS_API_URL: `http://127.0.0.1:${mock.port}/api`,
+      },
+    });
+    assert.equal(res.status, 1, `${res.stdout}\n${res.stderr}`);
+    const text = `${res.stdout}\n${res.stderr}`;
+    assert.match(text, /not signed in\. run atris login first\./);
+    assert.doesNotMatch(text, /Refusing to save a scoped agent token/);
+    assert.equal(mock.requests.length, 0);
+    assert.equal(readCredentials(home).token, youtubeAgent);
   } finally {
     await closeServer(mock.server);
     fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A leftover YouTube-scoped agent token sitting in the login field was treated as a user JWT. Billed process and x-search then tried to remint, hit persist, and hid the real failure.

This change uses that leftover token when the scope matches. A wrong-scope leftover token prints the login sentence and does not remint or call the paid pull. Persist still refuses to write a scoped key back into the login field.

Verify:
`node --test test/auth-login-storage.test.js test/billed-command-auth.test.js test/auth-agent-token.test.js`

No live credits. Mocked network only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5b254cf-134b-496a-9389-c881b8df0590?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5b254cf-134b-496a-9389-c881b8df0590&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

