### PR TITLE
Fix OpenCode asks and refresh SWE-2 guidance

### DIFF
--- a/atris/skills/design/SKILL.md
+++ b/atris/skills/design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design
 description: Frontend aesthetics policy. Use when building UI, components, landing pages, dashboards, or any frontend work. Prevents generic ai-generated look.
-version: 3.2.16
+version: 3.2.17
 allowed-tools: Read, Write, Edit, Bash, Glob
 tags:
   - design
@@ -135,6 +135,8 @@ Every entry: id, rule, detector, status. A detector is a regex/command a gate ca
 | D30 | a floating rounded composer inherits the page canvas; never paint a full-width contrast band behind it unless that band is intentional chrome | judgment | active |
 | D31 | developer-only overlays stay off the product surface by default; any temporary visible launcher must have an immediate dismiss control | judgment | active |
 | D32 | before changing repeated UI copy, verify the operator's exact executable and surface; matching labels do not prove the installed app, dev app, header, and composer share one live path | judgment | active |
+
+| D33 | engine settings show only the selected engine’s effective model and supported controls; preserve saved choices missing from the option list instead of displaying another engine | `node scripts/test-engine-settings.mjs` in project-obelisk | graduated (engine settings regression) |
 
 Measured recipes live in the mimic studies: `~/arena/mimic-beautiful-ui/LESSONS.md` (18 AI-interface components with exact tokens) and its `remix.css` :root block (the portable Atris token sheet, coffee + paper themes). Start there before designing an agent surface.
 

--- a/atris/skills/design/SKILL.md
+++ b/atris/skills/design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design
 description: Frontend aesthetics policy. Use when building UI, components, landing pages, dashboards, or any frontend work. Prevents generic ai-generated look.
-version: 3.2.17
+version: 3.2.18
 allowed-tools: Read, Write, Edit, Bash, Glob
 tags:
   - design
@@ -136,7 +136,7 @@ Every entry: id, rule, detector, status. A detector is a regex/command a gate ca
 | D31 | developer-only overlays stay off the product surface by default; any temporary visible launcher must have an immediate dismiss control | judgment | active |
 | D32 | before changing repeated UI copy, verify the operator's exact executable and surface; matching labels do not prove the installed app, dev app, header, and composer share one live path | judgment | active |
 
-| D33 | engine settings show only the selected engine’s effective model and supported controls; preserve saved choices missing from the option list instead of displaying another engine | `node scripts/test-engine-settings.mjs` in project-obelisk | graduated (engine settings regression) |
+| D34 | engine settings show only the selected engine’s effective model and supported controls; preserve saved choices missing from the option list instead of displaying another engine | `node scripts/test-engine-settings.mjs` in project-obelisk | graduated (engine settings regression) |
 
 Measured recipes live in the mimic studies: `~/arena/mimic-beautiful-ui/LESSONS.md` (18 AI-interface components with exact tokens) and its `remix.css` :root block (the portable Atris token sheet, coffee + paper themes). Start there before designing an agent surface.
 

--- a/atris/skills/engines/SKILL.md
+++ b/atris/skills/engines/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: engines
 description: "Dispatch work to an installed terminal agent or named Atris engine profile. Supports Atris Fast, Claude, Codex, Cursor, Fable, Composer, Haiku, Devin, Grok, Antigravity (agy), and opencode. Triggers on: use codex, use cursor, use devin, use grok, use agy, use antigravity, use gemini, gemini session, use fable, use claude, use opencode, use atris, engine, dispatch to, worker agent, second opinion build."
-version: 1.5.1
+version: 1.5.2
 tags:
   - engines
   - claude
@@ -68,7 +68,7 @@ Raw spawns are not the default because they skip Atris receipts, watch, and coac
 | Fable | `atris engine fable "<question>"` | Canonical read-only FABLE ask with guards, live log, receipt, and health tracking. Scale `--timeout` to the work when needed. |
 | Composer | `atris run "<objective>" --engine composer` | Fast navigator/executor profile routed through the installed `ax` binary. |
 | Haiku | `claude -p "<prompt>" --model claude-haiku-4-5` | Fast validation and bounded read-only checks. |
-| Devin | `devin -p --permission-mode dangerous -- "<prompt>"` (run from the target repo) | Default permission mode is read-only for writes — build work NEEDS `--permission-mode dangerous`, so only run it in an isolated worktree. Also `devin cloud` for sessions that outlive this machine. Supports `--model swe-1.7` |
+| Devin | `devin -p --permission-mode dangerous -- "<prompt>"` (run from the target repo) | Default permission mode is read-only for writes — build work NEEDS `--permission-mode dangerous`, so only run it in an isolated worktree. Also `devin cloud` for sessions that outlive this machine. Supports `--model swe-2-max`; `devin models list` verifies availability and price. |
 | Grok | `grok --always-approve -p "<prompt>"` (run from the target repo) | Headless single-turn via `-p`; default model grok-4.6. Very fast on lookups (~5-10s, reads MAP first). Great for quick second opinions; use `--best-of-n <N>` for tricky bounded builds. Uses grok.com login |
 | Antigravity | `agy --mode accept-edits --add-dir "$PWD" -p "<prompt>"` (run from the target repo) | `agy` executor profile; also answers to "gemini". **`--add-dir` is mandatory for writes** — without it agy edits its own scratch folder (`~/.gemini/antigravity-cli/scratch/`) and the project never changes, which looks like a silent failure (verified live 2026-08-28). Use `--mode plan --sandbox` for read-only review, `--model <id>` to pin a model, and `--dangerously-skip-permissions` if a build still stalls on an approval prompt. |
 | opencode | `opencode run "<prompt>"` (read-only ask: `opencode run --agent plan "<prompt>"`) | Headless print mode; exits when done. Pin a model with `-m provider/model`. Build work needs `--auto` to auto-approve permissions (dangerous: run in an isolated worktree). Verified live 2026-08-21, ~7s per plan-mode lookup. |
@@ -96,7 +96,7 @@ Each engine CLI can pin a specific model. Current best picks:
 | Engine | Flag | Best models today |
 |--------|------|-------------------|
 | Claude / Fable | `--model opus` | `opus` currently resolves to Opus 5; use the explicit Opus 4.8 identifier only for reproducibility |
-| Devin | `--model swe-1.7` | `swe-1.7` (free right now: use it as the volume executor for parallel bounded slices), `swe-1.7-lightning` for speed |
+| Devin | `--model swe-2-max` | `swe-2-max`, `swe-2-high`, `swe-2-medium` verified Free in the live CLI on 2026-09-10. Use Max for Keshav’s team; recheck with `devin models list` before unattended work. |
 | Cursor | `--model cursor-grok-4.6-xhigh` | `cursor-grok-4.6-xhigh` for second-opinion builds, `cursor-grok-4.6-high-fast` for quick pinned asks (answered in ~12s live 2026-08-12), `composer-2.5` for fast edits; parameterized Claude via `'claude-opus-4-8[effort=high]'`; `--list-models` shows the full menu |
 | Composer | `--engine composer` | `composer 2.5` through the Atris profile |
 | Haiku | `--model claude-haiku-4-5` | `haiku` for fast validation |

--- a/lib/daily-log.js
+++ b/lib/daily-log.js
@@ -79,10 +79,7 @@ function noteTitle(content) {
 
 module.exports = {
   todayLogName,
-  logStamp,
   compactLogText,
-  logFieldRows,
-  appendDailyEntry,
   memberSlug,
   appendMemberDailyEntry,
   appendMasterDailyEntry,

--- a/lib/engine-ask.js
+++ b/lib/engine-ask.js
@@ -283,7 +283,7 @@ function buildReadOnlyEngineInvocation(engineName, prompt, modelName = '', {
   if (engine === 'opencode') {
     // `run` with a message is headless print mode; the built-in plan agent
     // keeps the ask read-only (verified live 2026-08-21, ~7s per lookup).
-    return { engine, bin: profile.bin, args: ['--agent', 'plan', ...(model ? ['-m', model] : []), request] };
+    return { engine, bin: profile.bin, args: ['run', '--agent', 'plan', ...(model ? ['-m', model] : []), request] };
   }
   throw new Error(`engine ask has no read-only command for ${engine}`);
 }

--- a/test/engine-ask.test.js
+++ b/test/engine-ask.test.js
@@ -272,8 +272,8 @@ test('model-capable engines receive exact model flags without weakening read-onl
   assert.deepEqual(grok.args.slice(6, 8), ['--model', 'grok-composer-2.5-fast']);
 
   const opencode = buildReadOnlyEngineInvocation('opencode', 'inspect the router', 'opencode/big-pickle');
-  assert.deepEqual(opencode.args.slice(0, 2), ['--agent', 'plan']);
-  assert.deepEqual(opencode.args.slice(2, 4), ['-m', 'opencode/big-pickle']);
+  assert.deepEqual(opencode.args.slice(0, 3), ['run', '--agent', 'plan'], 'OpenCode must enter headless run mode; otherwise the prompt is interpreted as a project path');
+  assert.deepEqual(opencode.args.slice(3, 5), ['-m', 'opencode/big-pickle']);
 
   for (const engine of ['atris-fast', 'claude', 'codex', 'cursor', 'fable', 'composer', 'haiku', 'devin', 'grok', 'agy', 'opencode']) {
     const invocation = buildReadOnlyEngineInvocation(engine, 'read only');


### PR DESCRIPTION
`atris engine opencode` omitted the required `run` subcommand, causing OpenCode to interpret the entire read-only prompt as a project path and fail with ENAMETOOLONG. Add `run` while preserving plan mode and explicit model selection.

Validation: all 18 engine-ask tests and all 3 repository-hygiene tests pass. Live default OpenCode and pinned `opencode/big-pickle` asks both returned ENGINE_OK after the local repair. A concurrent local run exposed the existing process-tree timeout test's timing sensitivity; the sequential rerun passed.

The full CI run exposed three unused daily-log exports already present on the base branch. Remove only those exports, preserving the functions, to satisfy the existing orphan-export gate. This also records verified SWE-2 Max guidance and the operator's engine-settings clarity lesson in the canonical skills.
